### PR TITLE
Add a .travis.yml to automate testing 'quickstart'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - "3.4"
+install:
+  - "pip install ."
+  - "make"
+script: 
+  - "python -m voc tests/example.py org.pybee"
+  - "java -XX:-UseSplitVerifier -classpath python.jar:. org.pybee.example"


### PR DESCRIPTION
Given future changes to the quickstart doco, this will have to be updated, but it currently reflects reality. 

Tested to work in my current fork of master: https://travis-ci.org/glasnt/voc/builds/80040395

To get pybee and Travis-CI talking to each other, it requires signing in, and just a few button clicks: http://docs.travis-ci.com/user/getting-started/