### PR TITLE
Add important information to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,6 +89,11 @@ Documentation
 
 Documentation for VOC can be found on `Read The Docs`_.
 
+Supported Python Versions
+-------------------------
+
+VOC requires Python 3.x
+
 Why "VOC"?
 ----------
 

--- a/README.rst
+++ b/README.rst
@@ -52,9 +52,16 @@ and development effort.
 Quickstart
 ----------
 
-Install `voc`, then run the example script::
+Install `voc`::
 
     $ pip install voc
+
+If pip complains about "no matching distribution found" while trying to collect `voc` (or other similar errors), it's possible to install `voc` like this::
+
+    $ pip install git+https://github.com/pybee/voc.git
+
+Once installed, run the example script::
+
     $ python -m voc tests/example.py org.pyee
     Creating class 'example'...
     Writing example.class...


### PR DESCRIPTION
This pull request adds to the README file some important information:
 * an alternative way to install VOC via pip (as discussed in issue #2 )
 * Python 3.x is required to run VOC (otherwise [some lambda functions raise errors](https://github.com/pybee/voc/blob/master/voc/java/klass.py#L92), due to `print` being a statement in Python 2.x)