### PR TITLE
Move to using a common namespace for all Python packages.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,12 +55,12 @@ Quickstart
 Using Python 3.4, install `voc`, then run the example script::
 
     $ pip install voc
-    $ python -m voc tests/example.py org.pybee
+    $ python -m voc tests/example.py
     Creating class 'example'...
     Writing example.class...
     Done.
 
-This will produce an `example.class`, in the org.pybee namespace, that you can
+This will produce an `example.class`, in the `python` namespace, that you can
 run on any Java 1.7+ VM.
 
 Next step - you need to compile the Python support libraries:
@@ -70,7 +70,7 @@ Next step - you need to compile the Python support libraries:
 This will compile `python.jar`. You will need to make sure that the python.jar
 support file is in your classpath::
 
-    $ java -XX:-UseSplitVerifier -classpath python.jar:. org.pybee.example
+    $ java -XX:-UseSplitVerifier -classpath python.jar:. python.example
     Hello, World
 
 The ``-CC:-UseSplitVerifier`` argument is necessary to turn off stack map

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -49,7 +49,7 @@ class JavanNormalizationTests(unittest.TestCase):
             Caused by: org.python.exceptions.IndexError: list index out of range
                 at org.python.types.List.__getitem__(List.java:100)
                 at org.python.types.List.__getitem__(List.java:85)
-                at org.pybee.test.<clinit>(test.py:2)
+                at python.test.<clinit>(test.py:2)
             """,
             """
             ### EXCEPTION ###
@@ -65,7 +65,7 @@ class JavanNormalizationTests(unittest.TestCase):
             Caused by: org.python.exceptions.IndexError: list index out of range
                 at org.python.types.List.__getitem__(List.java:100)
                 at org.python.types.List.__getitem__(List.java:85)
-                at org.pybee.test.<clinit>(test.py:2)
+                at python.test.<clinit>(test.py:2)
             """,
             """
             Hello, world.
@@ -80,7 +80,7 @@ class JavanNormalizationTests(unittest.TestCase):
             Exception in thread "main" org.python.exceptions.IndexError: list index out of range
                 at org.python.types.List.__getitem__(List.java:100)
                 at org.python.types.List.__getitem__(List.java:85)
-                at org.pybee.test.main(test.py:3)
+                at python.test.main(test.py:3)
             """,
             """
             ### EXCEPTION ###
@@ -95,7 +95,7 @@ class JavanNormalizationTests(unittest.TestCase):
             Exception in thread "main" org.python.exceptions.IndexError: list index out of range
                 at org.python.types.List.__getitem__(List.java:100)
                 at org.python.types.List.__getitem__(List.java:85)
-                at org.pybee.test.main(test.py:3)
+                at python.test.main(test.py:3)
             """,
             """
             Hello, world.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -42,7 +42,7 @@ def adjust(text):
 def runAsJava(main_code, **extra):
     """Run a block of Python code as a Java program."""
 
-    transpiler = Transpiler('org.pybee')
+    transpiler = Transpiler()
     with capture_output():
         transpiler.transpile_string("test.py", main_code)
 
@@ -52,7 +52,7 @@ def runAsJava(main_code, **extra):
     transpiler.write(os.path.dirname(__file__), verbosity=0)
 
     proc = subprocess.Popen(
-        ["java", "-classpath", "../python.jar:.", "-XX:-UseSplitVerifier", "org.pybee.test"],
+        ["java", "-classpath", "../python.jar:.", "-XX:-UseSplitVerifier", "python.test"],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,

--- a/voc/__main__.py
+++ b/voc/__main__.py
@@ -3,13 +3,18 @@ from .transpiler import transpile
 
 
 def main():
-    if len(sys.argv) != 3:
-        print("Usage: voc <path to .py file> <namespace>")
+    if len(sys.argv) not in (2, 3):
+        print("Usage: voc <path to .py file> [<output dir>]")
         print()
-        print('  e.g.: voc tests/example.py org.pybee')
+        print('  e.g.: voc tests/example.py out')
         sys.exit(1)
 
-    transpile(sys.argv[1], sys.argv[2])
+    if len(sys.argv) == 2:
+        outdir = None
+    else:
+        outdir = sys.argv[2]
+
+    transpile(sys.argv[1], outdir=outdir)
 
 if __name__ == "__main__":
     main()

--- a/voc/transpiler.py
+++ b/voc/transpiler.py
@@ -6,17 +6,17 @@ import py_compile
 from .python.modules import Module
 
 
-def transpile(filename, namespace, outdir=None):
+def transpile(filename, outdir=None):
     print("Compiling %s ..." % filename)
     py_compile.compile(filename)
 
-    transpiler = Transpiler(namespace)
+    transpiler = Transpiler()
     transpiler.transpile(filename)
     transpiler.write(outdir)
 
 
 class Transpiler:
-    def __init__(self, namespace):
+    def __init__(self, namespace="python"):
         self.namespace = namespace
         self.classfiles = []
 


### PR DESCRIPTION
This is necessary so that __import__ has a standard place to look.