### PR TITLE
Explicitly use python3 instead of python

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -117,7 +117,7 @@ def runAsPython(test_dir, main_code, extra_code=None, run_in_function=False, arg
         args = []
 
     proc = subprocess.Popen(
-        ["python", "test.py"] + args,
+        ["python3", "test.py"] + args,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -117,7 +117,7 @@ def runAsPython(test_dir, main_code, extra_code=None, run_in_function=False, arg
         args = []
 
     proc = subprocess.Popen(
-        ["python3", "test.py"] + args,
+        [sys.executable, "test.py"] + args,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,


### PR DESCRIPTION
Some str tests were failing (e.g. str_add_bool) even though python3 and Java
were producing identical error messages. The problem was that the command
invocation was using "python" which ran python2 on my OSX machine.