### PR TITLE
Corrected typo where command is -XX instead of -CC

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,7 @@ you would run::
     $ java -XX:-UseSplitVerifier -classpath dist/python-java.jar:. python.example
     Hello, World
 
-The ``-CC:-UseSplitVerifier`` argument is necessary to turn off stack map
+The ``-XX:-UseSplitVerifier`` argument is necessary to turn off stack map
 verification in Java 7. This could be addressed by computing stack maps
 for generated code.
 


### PR DESCRIPTION
While going through the ReadMe.rst I noticed that it used -XX in the command but in the description afterwards it used -CC. After testing on my machine and looking through the documentation or jvm options I did not see any reference to -CC as a set of options. 