### PR TITLE
Corrected Getting Started guide

### DIFF
--- a/docs/intro/getting-started.rst
+++ b/docs/intro/getting-started.rst
@@ -22,6 +22,7 @@ Then create a virtual environment and install VOC into it:
 
     $ virtualenv -p $(which python3) env
     $ . env/bin/activate
+    $ cd voc
     $ pip install -e .
 
 Building the support JAR file
@@ -31,10 +32,9 @@ Next, you need to build the Python support file:
 
 .. code-block:: bash
 
-    $ cd voc
     $ ant java
 
-This should create a `dist/python-java.jar` file. This JAR file is a support library
+This should create a ``dist/python-java.jar`` file. This JAR file is a support library
 that implements Python-like behavior and provides the Python standard library for
 the Java environment. This JAR file must be included on the classpath for any
 VOC-generated project.


### PR DESCRIPTION
Moved the `cd voc` part to its right location. I've always had the habit of creating my virtual environments right inside the project directory, and I realize I ended up doing that the last time. How I got the setup to work last time is still a mystery to me! 

In any case, we're now going to have parallel directories: `env`, `voc`, `tutorial-0`, `tutorial-1`, `tutorial-2`, etc.

I also added some minor formatting corrections. 