### PR TITLE
Wiki link on readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ VOC is part of the `BeeWare suite`_. You can talk to the community through:
 Contributing
 ------------
 
-To get started with contributing to VOC, head over to the `wiki`.
+To get started with contributing to VOC, head over to the `wiki`_.
 
 If you experience problems with VOC, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.

--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,8 @@ VOC is part of the `BeeWare suite`_. You can talk to the community through:
 Contributing
 ------------
 
+To get started with contributing to VOC, head over to the `wiki`.
+
 If you experience problems with VOC, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
@@ -79,6 +81,7 @@ want to contribute code, please `fork the code`_ and `submit a pull request`_.
 .. _Read The Docs: http://voc.readthedocs.org
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
 .. _BeeWare Users Mailing list: https://groups.google.com/forum/#!forum/beeware-users
+.. _wiki: https://github.com/pybee/voc/wiki/Your-first-VOC-contribution
 .. _BeeWare Developers Mailing list: https://groups.google.com/forum/#!forum/beeware-developers
 .. _log them on Github: https://github.com/pybee/voc/issues
 .. _fork the code: https://github.com/pybee/voc


### PR DESCRIPTION
Every time I have to struggle a lot to find the "contribution explanation" link on the wiki. It's buried two levels deep, and is neither in the README nor in Read The Docs. I'm adding it to README to make it easier for new people to figure out what to do.