### PR TITLE
Implement unary invert for String

### DIFF
--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -334,6 +334,13 @@ public class Str extends org.python.types.Object {
     @org.python.Method(
         __doc__=""
     )
+    public org.python.Object __invert__() {
+        throw new org.python.exceptions.TypeError("bad operand type for unary ~: 'str'");
+    }
+
+    @org.python.Method(
+        __doc__=""
+    )
     public org.python.Object __bool__() {
         return new org.python.types.Bool(this.value.length() > 0);
     }

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -20,7 +20,6 @@ class UnaryStrOperationTests(UnaryOperationTestCase, TranspileTestCase):
     values = ['""', '"This is a string"']
 
     not_implemented = [
-        'test_unary_invert',
     ]
 
 


### PR DESCRIPTION
And this completes a milestone for me! VOC unary operators for String types are over. :grinning: :dancer: 