### PR TITLE
Windows compatibility

### DIFF
--- a/build-java.xml
+++ b/build-java.xml
@@ -25,9 +25,9 @@
 
     <jar jarfile="${dist}/Python-Java-${python-version}-b${release}.jar" basedir="${build}/java"/>
 
-    <symlink
-        link="${dist}/python-java.jar"
-        resource="${dist}/Python-Java-${python-version}-b${release}.jar"
+    <copy
+        tofile="${dist}/python-java.jar"
+        file="${dist}/Python-Java-${python-version}-b${release}.jar"
         overwrite="true" />
   </target>
 

--- a/tests/stdlib/test_time.py
+++ b/tests/stdlib/test_time.py
@@ -1,3 +1,4 @@
+import os
 from unittest import expectedFailure
 
 from ..utils import TranspileTestCase
@@ -101,16 +102,20 @@ class TimeModuleTests(TranspileTestCase):
         # Since we can't know exactly what CPU time will be used,
         # and CPU time will vary between implementations,
         # this test validates that clock returns a float < 0.01s
+        sleepy_time = 1
+        diff_offset = sleepy_time if os.name == 'nt' else 0
+        # On Windows, time.clock includes the time spent in time.sleep
+        # however on Unix it does not.
         self.assertCodeExecution("""
             import time
             start = time.clock()
-            time.sleep(1)
+            time.sleep({sleepy_time})
             end = time.clock()
-            diff = end - start
+            diff = end - start - {diff_offset}
             print(type(diff))
             print(diff < 0.1)
             print('Done.')
-            """)
+            """.format(sleepy_time=sleepy_time, diff_offset=diff_offset))
 
     #######################################################
     # ctime

--- a/tests/structures/test_interface.py
+++ b/tests/structures/test_interface.py
@@ -23,7 +23,7 @@ class InterfaceTests(TranspileTestCase):
                     return MyStringAnalog(self.value[start:end])
 
                 def toString(self) -> java.lang.String:
-                    return self.value
+                    return len(self.value) * 'x'
 
             analog = MyStringAnalog("world")
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -30,7 +30,7 @@ def setUpSuite():
         return
 
     proc = subprocess.Popen(
-        ["ant", "java"],
+        "ant java",
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
@@ -190,8 +190,12 @@ def compileJava(java_dir, java):
 
             sources.append(class_file)
 
+    classpath = os.pathsep.join([
+        os.path.join('..', '..', 'dist', 'python-java.jar'),
+        os.curdir,
+    ])
     proc = subprocess.Popen(
-        ["javac", "-classpath", "../../dist/python-java.jar:."] + sources,
+        ["javac", "-classpath", classpath] + sources,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
@@ -207,7 +211,7 @@ JAVA_EXCEPTION = re.compile(
     '((Exception in thread "\w+" )?[^\r?\n]+\r?\n' +
     'Caused by: org\.python\.exceptions\.(?P<exception2>[\w]+): (?P<message2>[^\r?\n]+)))\r?\n' +
     '(?P<trace>(\s+at .+\((((.*)(:(\d+))?)|(Native Method))\)\r?\n)+)' +
-    '(Exception in thread "\w+" )'
+    '(Exception in thread "\w+" )?'
 )
 JAVA_STACK = re.compile('\s+at (?P<module>.+)\((((?P<file>.*?)(:(?P<line>\d+))?)|(Native Method))\)')
 JAVA_FLOAT = re.compile('(\d+)E(-)?(\d+)')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -34,6 +34,7 @@ def setUpSuite():
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
+        shell=True,
     )
 
     try:
@@ -147,8 +148,13 @@ def runAsJava(test_dir, main_code, extra_code=None, run_in_function=False, args=
     if args is None:
         args = []
 
+    classpath = os.pathsep.join([
+        os.path.join('..', '..', 'dist', 'python-java.jar'),
+        os.path.join('..', 'java'),
+        os.curdir,
+    ])
     proc = subprocess.Popen(
-        ["java", "-classpath", "../../dist/python-java.jar:../java:.", "python.test.__init__"] + args,
+        ["java", "-classpath", classpath, "python.test.__init__"] + args,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
@@ -197,17 +203,18 @@ def compileJava(java_dir, java):
 
 
 JAVA_EXCEPTION = re.compile(
-    '((Exception in thread "\w+" org\.python\.exceptions\.(?P<exception1>[\w]+): (?P<message1>[^\n]+))|' +
-    '(Exception in thread "\w+" [^\n]+\n' +
-    'Caused by: org\.python\.exceptions\.(?P<exception2>[\w]+): (?P<message2>[^\n]+)))\n' +
-    '(?P<trace>(\s+at .+\((((.*)(:(\d+))?)|(Native Method))\)\n)+)'
+    '(((Exception in thread "\w+" )?org\.python\.exceptions\.(?P<exception1>[\w]+): (?P<message1>[^\r?\n]+))|' +
+    '((Exception in thread "\w+" )?[^\r?\n]+\r?\n' +
+    'Caused by: org\.python\.exceptions\.(?P<exception2>[\w]+): (?P<message2>[^\r?\n]+)))\r?\n' +
+    '(?P<trace>(\s+at .+\((((.*)(:(\d+))?)|(Native Method))\)\r?\n)+)' +
+    '(Exception in thread "\w+" )'
 )
 JAVA_STACK = re.compile('\s+at (?P<module>.+)\((((?P<file>.*?)(:(?P<line>\d+))?)|(Native Method))\)')
 JAVA_FLOAT = re.compile('(\d+)E(-)?(\d+)')
 
 # PYTHON_EXCEPTION = re.compile('Traceback \(most recent call last\):\n(  File ".*", line \d+, in .*\n)(    .*\n  File "(?P<file>.*)", line (?P<line>\d+), in .*\n)+(?P<exception>.*): (?P<message>.*\n)')
-PYTHON_EXCEPTION = re.compile('Traceback \(most recent call last\):\n(  File "(?P<file>.*)", line (?P<line>\d+), in .*\n    .*\n)+(?P<exception>.*?): (?P<message>.*\n)')
-PYTHON_STACK = re.compile('  File "(?P<file>.*)", line (?P<line>\d+), in .*\n    .*\n')
+PYTHON_EXCEPTION = re.compile('Traceback \(most recent call last\):\r?\n(  File "(?P<file>.*)", line (?P<line>\d+), in .*\r?\n    .*\r?\n)+(?P<exception>.*?): (?P<message>.*\r?\n)')
+PYTHON_STACK = re.compile('  File "(?P<file>.*)", line (?P<line>\d+), in .*\r?\n    .*\r?\n')
 PYTHON_FLOAT = re.compile('(\d+)e(-)?0?(\d+)')
 
 MEMORY_REFERENCE = re.compile('0x[\dabcdef]{4,8}')
@@ -215,39 +222,44 @@ MEMORY_REFERENCE = re.compile('0x[\dabcdef]{4,8}')
 
 def cleanse_java(input):
     try:
-        out = JAVA_EXCEPTION.sub('### EXCEPTION ###\n\\g<exception2>: \\g<message2>\n\\g<trace>', input)
+        out = JAVA_EXCEPTION.sub('### EXCEPTION ###{linesep}\\g<exception2>: \\g<message2>{linesep}\\g<trace>'.format(linesep=os.linesep), input)
     except:
-        out = JAVA_EXCEPTION.sub('### EXCEPTION ###\n\\g<exception1>: \\g<message1>\n\\g<trace>', input)
+        out = JAVA_EXCEPTION.sub('### EXCEPTION ###{linesep}\\g<exception1>: \\g<message1>{linesep}\\g<trace>'.format(linesep=os.linesep), input)
+
     stack = JAVA_STACK.findall(out)
     out = JAVA_STACK.sub('', out)
     out = '%s%s%s' % (
         out,
-        '\n'.join([
+        os.linesep.join([
             "    %s:%s" % (s[3], s[5])
             for s in stack[::-1]
             if s[0].startswith('python.') and not s[0].endswith('.<init>')
         ]),
-        '\n' if stack else ''
+        os.linesep if stack else ''
     )
     out = MEMORY_REFERENCE.sub("0xXXXXXXXX", out)
-    return JAVA_FLOAT.sub('\\1e\\2\\3', out).replace("'python.test.__init__'", '***EXECUTABLE***')
+    out = JAVA_FLOAT.sub('\\1e\\2\\3', out).replace("'python.test.__init__'", '***EXECUTABLE***')
+    out = out.replace('\r\n', '\n')
+    return out
 
 
 def cleanse_python(input):
-    out = PYTHON_EXCEPTION.sub('### EXCEPTION ###\n\\g<exception>: \\g<message>', input)
+    out = PYTHON_EXCEPTION.sub('### EXCEPTION ###{linesep}\\g<exception>: \\g<message>'.format(linesep=os.linesep), input)
     stack = PYTHON_STACK.findall(input)
     out = '%s%s%s' % (
         out,
-        '\n'.join(
+        os.linesep.join(
             [
                 "    %s:%s" % (s[0], s[1])
                 for s in stack
             ]
         ),
-        '\n' if stack else ''
+        os.linesep if stack else ''
     )
     out = MEMORY_REFERENCE.sub("0xXXXXXXXX", out)
-    return PYTHON_FLOAT.sub('\\1e\\2\\3', out).replace("'test.py'", '***EXECUTABLE***')
+    out = PYTHON_FLOAT.sub('\\1e\\2\\3', out).replace("'test.py'", '***EXECUTABLE***')
+    out = out.replace('\r\n', '\n')
+    return out
 
 
 class TranspileTestCase(TestCase):


### PR DESCRIPTION
Second attempt at  changes to support running the unit tests on Windows.

- Symlinks not supported on Windows (via ant)
- Directory separators ('\' vs '/')
- Path separators (';' vs ':')
- Line endings ('\r\n' vs '\n')
- Slight variations in the format of exceptions
- Slight variations on how time.clock works in Windows

All unit tests were run with the following result

Ran 3131 tests in 2694.256s
OK (skipped=2, expected failures=1802)