### PR TITLE
Implement TestDaemon - single JVM instance for tests

### DIFF
--- a/build-java.xml
+++ b/build-java.xml
@@ -20,6 +20,17 @@
     </javac>
   </target>
 
+  <target name="compile-testdaemon" description="Compile the testdaemon source">
+    <mkdir dir="${build}/java-testdaemon"/>
+    <javac
+        debug="true"
+        debuglevel="lines,vars,source"
+        includeantruntime="false"
+        destdir="${build}/java-testdaemon">
+      <src path="${src}/testdaemon" />
+    </javac>
+  </target>
+
   <target name="dist" depends="compile" description="Generate Oracle jar file">
     <mkdir dir="${dist}"/>
 
@@ -28,6 +39,17 @@
     <copy
         tofile="${dist}/python-java.jar"
         file="${dist}/Python-Java-${python-version}-b${release}.jar"
+        overwrite="true" />
+  </target>
+
+  <target name="dist-testdaemon" depends="compile-testdaemon" description="Generate testdaemon jar file">
+    <mkdir dir="${dist}"/>
+
+    <jar jarfile="${dist}/Python-Java-testdaemon-${python-version}-b${release}.jar" basedir="${build}/java-testdaemon"/>
+
+    <symlink
+        link="${dist}/python-java-testdaemon.jar"
+        resource="${dist}/Python-Java-testdaemon-${python-version}-b${release}.jar"
         overwrite="true" />
   </target>
 

--- a/build.xml
+++ b/build.xml
@@ -11,6 +11,7 @@
 
   <target name="java">
     <ant antfile="build-java.xml" target="dist"/>
+    <ant antfile="build-java.xml" target="dist-testdaemon"/>
   </target>
 
   <target name="android">

--- a/python/common/org/python/ImportLib.java
+++ b/python/common/org/python/ImportLib.java
@@ -79,7 +79,7 @@ public class ImportLib {
                 if (!name.equals("*")) {
                     try {
                         if (native_import) {
-                            java.lang.Class java_class = java.lang.Class.forName(java_name.toString().replace("/", ".") + name);
+                            java.lang.Class java_class = java.lang.Thread.currentThread().getContextClassLoader().loadClass(java_name.toString().replace("/", ".") + name);
                             parent_module.__setattr__(name, org.python.java.Type.pythonType(java_class));
                         } else {
                             python_module = importPythonModule(java_name.toString() + name);
@@ -106,7 +106,7 @@ public class ImportLib {
             throws java.lang.ClassNotFoundException {
         org.python.types.Module python_module;
         try {
-            java.lang.Class java_class = java.lang.Class.forName(java_name.replace("/", "."));
+            java.lang.Class java_class = java.lang.Thread.currentThread().getContextClassLoader().loadClass(java_name.replace("/", "."));
             python_module = null;
         } catch (java.lang.ClassNotFoundException e) {
             python_module = new org.python.java.Module(java_name.replace("/", "."));
@@ -136,7 +136,7 @@ public class ImportLib {
             throws java.lang.ClassNotFoundException {
         org.python.types.Module python_module;
         try {
-            java.lang.Class java_class = java.lang.Class.forName(java_name.replace("/", ".") + ".__init__");
+            java.lang.Class java_class = java.lang.Thread.currentThread().getContextClassLoader().loadClass(java_name.replace("/", ".") + ".__init__");
             java.lang.reflect.Constructor constructor = java_class.getConstructor();
             python_module = (org.python.types.Module) constructor.newInstance();
             modules.put(java_name, python_module);

--- a/python/common/org/python/java/Module.java
+++ b/python/common/org/python/java/Module.java
@@ -27,7 +27,7 @@ public class Module extends org.python.types.Module {
         value = cls.attrs.get(name);
         if (value == null) {
             try {
-                java.lang.Class java_class = java.lang.Class.forName(java_namespace + "." + name);
+                java.lang.Class java_class = java.lang.Thread.currentThread().getContextClassLoader().loadClass(java_namespace + "." + name);
                 value = new org.python.java.Type(org.python.types.Type.Origin.JAVA, java_class);
                 cls.attrs.put(name, value);
             } catch (java.lang.ClassNotFoundException e) {

--- a/python/common/org/python/java/Type.java
+++ b/python/common/org/python/java/Type.java
@@ -190,7 +190,7 @@ public class Type extends org.python.types.Type {
                         // Field does not exist.
                         try {
                             // org.Python.debug("Look for inner class ", this.klass.getName() + "$" + name);
-                            java.lang.Class inner_klass = java.lang.Class.forName(this.klass.getName() + "$" + name);
+                            java.lang.Class inner_klass = java.lang.Thread.currentThread().getContextClassLoader().loadClass(this.klass.getName() + "$" + name);
                             value = new org.python.java.Type(org.python.types.Type.Origin.JAVA, inner_klass);
                         } catch (java.lang.ClassNotFoundException ce) {
                             // org.Python.debug("Inner class not found", ce);

--- a/python/common/org/python/types/Type.java
+++ b/python/common/org/python/types/Type.java
@@ -52,7 +52,7 @@ public class Type extends org.python.types.Object implements org.python.Callable
 
     public static org.python.types.Type pythonType(java.lang.String java_class_name) {
         try {
-            return pythonType(java.lang.Class.forName(java_class_name.replace("/", ".")));
+            return pythonType(java.lang.Thread.currentThread().getContextClassLoader().loadClass(java_class_name.replace("/", ".")));
         } catch (ClassNotFoundException e) {
             throw new org.python.exceptions.RuntimeError("Unknown Class " + java_class_name);
         }

--- a/python/common/python/platform/__init__.java
+++ b/python/common/python/platform/__init__.java
@@ -19,7 +19,7 @@ public class __init__ extends org.python.types.Module {
         }
 
         try {
-            platform_class = Class.forName(platform_class_name);
+            platform_class = java.lang.Thread.currentThread().getContextClassLoader().loadClass(platform_class_name);
             impl = (python.Platform) platform_class.getConstructor().newInstance();
         } catch (ClassNotFoundException e) {
             throw new org.python.exceptions.RuntimeError("Unable to find platform '" + platform_class_name + "'");

--- a/python/testdaemon/python/testdaemon/JoinClassLoader.java
+++ b/python/testdaemon/python/testdaemon/JoinClassLoader.java
@@ -1,0 +1,82 @@
+package python.testdaemon;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.security.SecureClassLoader;
+import java.util.Enumeration;
+import java.util.Vector;
+
+// http://www.source-code.biz/snippets/java/12.htm
+/**
+* A class loader that combines multiple class loaders into one.<br>
+* The classes loaded by this class loader are associated with this class loader,
+* i.e. Class.getClassLoader() points to this class loader.
+* <p>
+* Author Christian d'Heureuse, Inventec Informatik AG, Zurich, Switzerland, www.source-code.biz<br>
+* License: LGPL, http://www.gnu.org/licenses/lgpl.html<br>
+* Please contact the author if you need another license.
+*/
+public class JoinClassLoader extends ClassLoader {
+
+private ClassLoader[] delegateClassLoaders;
+
+public JoinClassLoader (ClassLoader parent, ClassLoader... delegateClassLoaders) {
+   super (parent);
+   this.delegateClassLoaders = delegateClassLoaders; }
+
+protected Class<?> findClass (String name) throws ClassNotFoundException {
+   // It would be easier to call the loadClass() methods of the delegateClassLoaders
+   // here, but we have to load the class from the byte code ourselves, because we
+   // need it to be associated with our class loader.
+   String path = name.replace('.', '/') + ".class";
+   URL url = findResource(path);
+   if (url == null) {
+      throw new ClassNotFoundException (name); }
+   ByteBuffer byteCode;
+   try {
+      byteCode = loadResource(url); }
+    catch (IOException e) {
+      throw new ClassNotFoundException (name, e); }
+   return defineClass(name, byteCode, null); }
+
+private ByteBuffer loadResource (URL url) throws IOException {
+   InputStream stream = null;
+   try {
+      stream = url.openStream();
+      int initialBufferCapacity = Math.min(0x40000, stream.available() + 1);
+      if (initialBufferCapacity <= 2)
+         initialBufferCapacity = 0x10000;
+       else
+         initialBufferCapacity = Math.max(initialBufferCapacity, 0x200);
+      ByteBuffer buf = ByteBuffer.allocate(initialBufferCapacity);
+      while (true) {
+         if (!buf.hasRemaining()) {
+            ByteBuffer newBuf = ByteBuffer.allocate(2*buf.capacity());
+            buf.flip();
+            newBuf.put (buf);
+            buf = newBuf; }
+         int len = stream.read(buf.array(), buf.position(), buf.remaining());
+         if (len <= 0) break;
+         buf.position (buf.position()+len); }
+      buf.flip();
+      return buf; }
+    finally {
+      if (stream != null) stream.close(); }}
+
+protected URL findResource (String name) {
+   for (ClassLoader delegate : delegateClassLoaders) {
+      URL resource = delegate.getResource(name);
+      if (resource != null) return resource; }
+   return null; }
+
+protected Enumeration<URL> findResources (String name) throws IOException {
+   Vector<URL> vector = new Vector<URL>();
+   for (ClassLoader delegate : delegateClassLoaders) {
+      Enumeration<URL> enumeration = delegate.getResources(name);
+      while (enumeration.hasMoreElements()) {
+         vector.add (enumeration.nextElement()); }}
+   return vector.elements(); }
+
+} // end class JoinClassLoader

--- a/python/testdaemon/python/testdaemon/JoinClassLoader.java
+++ b/python/testdaemon/python/testdaemon/JoinClassLoader.java
@@ -10,73 +10,86 @@ import java.util.Vector;
 
 // http://www.source-code.biz/snippets/java/12.htm
 /**
-* A class loader that combines multiple class loaders into one.<br>
-* The classes loaded by this class loader are associated with this class loader,
-* i.e. Class.getClassLoader() points to this class loader.
-* <p>
-* Author Christian d'Heureuse, Inventec Informatik AG, Zurich, Switzerland, www.source-code.biz<br>
-* License: LGPL, http://www.gnu.org/licenses/lgpl.html<br>
-* Please contact the author if you need another license.
-*/
+ * A class loader that combines multiple class loaders into one.<br>
+ * The classes loaded by this class loader are associated with this class loader,
+ * i.e. Class.getClassLoader() points to this class loader.
+ * <p>
+ * Author Christian d'Heureuse, Inventec Informatik AG, Zurich, Switzerland, www.source-code.biz<br>
+ * License: LGPL, http://www.gnu.org/licenses/lgpl.html<br>
+ * Please contact the author if you need another license.
+ */
 public class JoinClassLoader extends ClassLoader {
 
-private ClassLoader[] delegateClassLoaders;
+    private ClassLoader[] delegateClassLoaders;
 
-public JoinClassLoader (ClassLoader parent, ClassLoader... delegateClassLoaders) {
-   super (parent);
-   this.delegateClassLoaders = delegateClassLoaders; }
+    public JoinClassLoader(ClassLoader parent, ClassLoader...delegateClassLoaders) {
+        super(parent);
+        this.delegateClassLoaders = delegateClassLoaders;
+    }
 
-protected Class<?> findClass (String name) throws ClassNotFoundException {
-   // It would be easier to call the loadClass() methods of the delegateClassLoaders
-   // here, but we have to load the class from the byte code ourselves, because we
-   // need it to be associated with our class loader.
-   String path = name.replace('.', '/') + ".class";
-   URL url = findResource(path);
-   if (url == null) {
-      throw new ClassNotFoundException (name); }
-   ByteBuffer byteCode;
-   try {
-      byteCode = loadResource(url); }
-    catch (IOException e) {
-      throw new ClassNotFoundException (name, e); }
-   return defineClass(name, byteCode, null); }
+    protected Class <?> findClass(String name) throws ClassNotFoundException {
+        // It would be easier to call the loadClass() methods of the delegateClassLoaders
+        // here, but we have to load the class from the byte code ourselves, because we
+        // need it to be associated with our class loader.
+        String path = name.replace('.', '/') + ".class";
+        URL url = findResource(path);
+        if (url == null) {
+            throw new ClassNotFoundException(name);
+        }
+        ByteBuffer byteCode;
+        try {
+            byteCode = loadResource(url);
+        } catch (IOException e) {
+            throw new ClassNotFoundException(name, e);
+        }
+        return defineClass(name, byteCode, null);
+    }
 
-private ByteBuffer loadResource (URL url) throws IOException {
-   InputStream stream = null;
-   try {
-      stream = url.openStream();
-      int initialBufferCapacity = Math.min(0x40000, stream.available() + 1);
-      if (initialBufferCapacity <= 2)
-         initialBufferCapacity = 0x10000;
-       else
-         initialBufferCapacity = Math.max(initialBufferCapacity, 0x200);
-      ByteBuffer buf = ByteBuffer.allocate(initialBufferCapacity);
-      while (true) {
-         if (!buf.hasRemaining()) {
-            ByteBuffer newBuf = ByteBuffer.allocate(2*buf.capacity());
+    private ByteBuffer loadResource(URL url) throws IOException {
+        InputStream stream = null;
+        try {
+            stream = url.openStream();
+            int initialBufferCapacity = Math.min(0x40000, stream.available() + 1);
+            if (initialBufferCapacity <= 2)
+                initialBufferCapacity = 0x10000;
+            else
+                initialBufferCapacity = Math.max(initialBufferCapacity, 0x200);
+            ByteBuffer buf = ByteBuffer.allocate(initialBufferCapacity);
+            while (true) {
+                if (!buf.hasRemaining()) {
+                    ByteBuffer newBuf = ByteBuffer.allocate(2 * buf.capacity());
+                    buf.flip();
+                    newBuf.put(buf);
+                    buf = newBuf;
+                }
+                int len = stream.read(buf.array(), buf.position(), buf.remaining());
+                if (len <= 0) break;
+                buf.position(buf.position() + len);
+            }
             buf.flip();
-            newBuf.put (buf);
-            buf = newBuf; }
-         int len = stream.read(buf.array(), buf.position(), buf.remaining());
-         if (len <= 0) break;
-         buf.position (buf.position()+len); }
-      buf.flip();
-      return buf; }
-    finally {
-      if (stream != null) stream.close(); }}
+            return buf;
+        } finally {
+            if (stream != null) stream.close();
+        }
+    }
 
-protected URL findResource (String name) {
-   for (ClassLoader delegate : delegateClassLoaders) {
-      URL resource = delegate.getResource(name);
-      if (resource != null) return resource; }
-   return null; }
+    protected URL findResource(String name) {
+        for (ClassLoader delegate : delegateClassLoaders) {
+            URL resource = delegate.getResource(name);
+            if (resource != null) return resource;
+        }
+        return null;
+    }
 
-protected Enumeration<URL> findResources (String name) throws IOException {
-   Vector<URL> vector = new Vector<URL>();
-   for (ClassLoader delegate : delegateClassLoaders) {
-      Enumeration<URL> enumeration = delegate.getResources(name);
-      while (enumeration.hasMoreElements()) {
-         vector.add (enumeration.nextElement()); }}
-   return vector.elements(); }
+    protected Enumeration <URL> findResources(String name) throws IOException {
+        Vector <URL> vector = new Vector <URL> ();
+        for (ClassLoader delegate : delegateClassLoaders) {
+            Enumeration <URL> enumeration = delegate.getResources(name);
+            while (enumeration.hasMoreElements()) {
+                vector.add(enumeration.nextElement());
+            }
+        }
+        return vector.elements();
+    }
 
-} // end class JoinClassLoader
+}

--- a/python/testdaemon/python/testdaemon/TestDaemon.java
+++ b/python/testdaemon/python/testdaemon/TestDaemon.java
@@ -1,0 +1,68 @@
+
+package python.testdaemon;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.net.MalformedURLException;
+import java.util.Arrays;
+import java.util.Scanner;
+
+public class TestDaemon {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        String input = "";
+
+        URL url;
+        try {
+            // need the trailing slash so that the ClassLoader knows it's a
+            // directory instead of a jar file
+            url = new URL("file:" + System.getProperty("user.dir") + "/temp/");
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+            return;
+        }
+        URL[] urls = new URL[] { url };
+
+        input = sc.nextLine();
+
+        while (!input.equals("exit")) {
+            // separate out the params
+            String[] parts = input.split(" ");
+            String className = parts[0];
+            String[] inputArgs = Arrays.copyOfRange(parts, 1, parts.length);
+
+            // get a fresh ClassLoader so that we pick up the latest class files
+            ClassLoader newClassLoader = new URLClassLoader(urls);
+
+            try {
+                // don't leave this as Class type as that's raw and compiler
+                // is required to generate a warning. add generic type <?>.
+                Class<?> klass = newClassLoader.loadClass(className);
+
+                // retrieve the standard main(String[] args)
+                Method method = klass.getMethod("main", String[].class);
+
+                // first parameter can be null since method is static
+                // cast second parameter to Object to make it a varargs call
+                method.invoke(null, (Object) inputArgs);
+            } catch (ReflectiveOperationException e) {
+                // ClassNotFound, NoSuchMethod, IllegalAccess Exceptions
+                e.printStackTrace();
+            } catch (ExceptionInInitializerError e) {
+                // unwrap the Error to get the org.python.exceptions.* thing
+                System.err.print("Exception in thread \"main\" ");
+                e.printStackTrace();
+            } catch (Throwable e) {
+                // NoSuchMethodError
+                e.printStackTrace();
+            } finally {
+                System.out.println(".");
+            }
+
+            input = sc.nextLine();
+        }
+
+    }
+}

--- a/python/testdaemon/python/testdaemon/TestDaemon.java
+++ b/python/testdaemon/python/testdaemon/TestDaemon.java
@@ -1,4 +1,3 @@
-
 package python.testdaemon;
 
 import java.io.File;
@@ -14,16 +13,22 @@ public class TestDaemon {
         Scanner sc = new Scanner(System.in);
         String input = "";
 
-        URL url;
+        URL voc;
+        URL runtime1;
+        URL runtime2;
         try {
+            // load the voc jar here so that they can see the runtime classes
+            voc = new URL("file:" + System.getProperty("user.dir") + "/../dist/python-java.jar");
             // need the trailing slash so that the ClassLoader knows it's a
             // directory instead of a jar file
-            url = new URL("file:" + System.getProperty("user.dir") + "/temp/");
+            runtime1 = new URL("file:" + System.getProperty("user.dir") + "/temp/");
+            runtime2 = new URL("file:" + System.getProperty("user.dir") + "/java/");
         } catch (MalformedURLException e) {
             e.printStackTrace();
             return;
         }
-        URL[] urls = new URL[] { url };
+        ClassLoader vocClassLoader = new URLClassLoader(new URL[] { voc });
+        URL[] runtimeURLs = new URL[] { runtime1, runtime2 };
 
         input = sc.nextLine();
 
@@ -34,12 +39,12 @@ public class TestDaemon {
             String[] inputArgs = Arrays.copyOfRange(parts, 1, parts.length);
 
             // get a fresh ClassLoader so that we pick up the latest class files
-            ClassLoader newClassLoader = new URLClassLoader(urls);
+            ClassLoader runtimeClassLoader = new URLClassLoader(runtimeURLs);
 
             try {
                 // don't leave this as Class type as that's raw and compiler
                 // is required to generate a warning. add generic type <?>.
-                Class<?> klass = newClassLoader.loadClass(className);
+                Class<?> klass = runtimeClassLoader.loadClass(className);
 
                 // retrieve the standard main(String[] args)
                 Method method = klass.getMethod("main", String[].class);

--- a/python/testdaemon/python/testdaemon/TestDaemon.java
+++ b/python/testdaemon/python/testdaemon/TestDaemon.java
@@ -47,6 +47,8 @@ public class TestDaemon {
                 vocClassLoader,
                 runtimeClassLoader);
 
+            Thread.currentThread().setContextClassLoader(joinedClassLoader);
+
             try {
                 // don't leave this as Class type as that's raw and compiler
                 // is required to generate a warning. add generic type <?>.

--- a/python/testdaemon/python/testdaemon/TestDaemon.java
+++ b/python/testdaemon/python/testdaemon/TestDaemon.java
@@ -1,6 +1,7 @@
 package python.testdaemon;
 
 import java.io.File;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -57,6 +58,11 @@ public class TestDaemon {
                 // first parameter can be null since method is static
                 // cast second parameter to Object to make it a varargs call
                 method.invoke(null, (Object) inputArgs);
+
+                // cleanup
+                Class<?> importlib = joinedClassLoader.loadClass("org.python.ImportLib");
+                Field importlib_modules = importlib.getDeclaredField("modules");
+                importlib_modules.set(null, new java.util.HashMap());
             } catch (ReflectiveOperationException e) {
                 // ClassNotFound, NoSuchMethod, IllegalAccess Exceptions
                 e.printStackTrace();

--- a/python/testdaemon/python/testdaemon/TestDaemon.java
+++ b/python/testdaemon/python/testdaemon/TestDaemon.java
@@ -41,10 +41,15 @@ public class TestDaemon {
             // get a fresh ClassLoader so that we pick up the latest class files
             ClassLoader runtimeClassLoader = new URLClassLoader(runtimeURLs);
 
+            ClassLoader joinedClassLoader = new JoinClassLoader(
+                TestDaemon.class.getClassLoader(),
+                vocClassLoader,
+                runtimeClassLoader);
+
             try {
                 // don't leave this as Class type as that's raw and compiler
                 // is required to generate a warning. add generic type <?>.
-                Class<?> klass = runtimeClassLoader.loadClass(className);
+                Class<?> klass = joinedClassLoader.loadClass(className);
 
                 // retrieve the standard main(String[] args)
                 Method method = klass.getMethod("main", String[].class);

--- a/tests/stdlib/test_sys.py
+++ b/tests/stdlib/test_sys.py
@@ -1,4 +1,5 @@
 from unittest import expectedFailure
+from unittest import skip
 
 from ..utils import TranspileTestCase
 
@@ -359,6 +360,7 @@ class SysModuleTests(TranspileTestCase):
             print('Done.')
             """)
 
+    @skip
     def test_exit(self):
         # From inside main
         self.assertCodeExecution("""

--- a/tests/stdlib/test_sys.py
+++ b/tests/stdlib/test_sys.py
@@ -1,5 +1,4 @@
 from unittest import expectedFailure
-from unittest import skip
 
 from ..utils import TranspileTestCase
 
@@ -360,7 +359,6 @@ class SysModuleTests(TranspileTestCase):
             print('Done.')
             """)
 
-    @skip
     def test_exit(self):
         # From inside main
         self.assertCodeExecution("""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -76,10 +76,68 @@ class JavaNormalizationTests(unittest.TestCase):
             """
         )
 
+    def test_exception_in_clinit_after_output_windows(self):
+        self.assertNormalized(
+            """
+            Hello, world.
+            java.lang.ExceptionInInitializerError
+            Caused by: org.python.exceptions.IndexError: list index out of range
+                at org.python.types.List.__getitem__(List.java:100)
+                at org.python.types.List.__getitem__(List.java:85)
+                at python.test.<clinit>(test.py:2)
+            """,
+            """
+            Hello, world.
+            ### EXCEPTION ###
+            IndexError: list index out of range
+                test.py:2
+            """
+        )
+
+    def test_exception_in_clinit_after_output_testdaemon(self):
+        self.assertNormalized(
+            """
+            False
+            True
+            Exception in thread "main" java.lang.ExceptionInInitializerError
+            \tat sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+            \tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+            \tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+            \tat java.lang.reflect.Method.invoke(Method.java:497)
+            \tat python.testdaemon.TestDaemon.main(TestDaemon.java:66)
+            Caused by: org.python.exceptions.KeyError: 'c'
+                at org.python.types.Dict.__getitem__(Dict.java:142)
+                at python.test.__init__.<clinit>(test.py:4)
+                ... 5 more
+            """,
+            """
+            False
+            True
+            ### EXCEPTION ###
+            KeyError: 'c'
+                test.py:4
+            """
+        )
+
     def test_exception_in_method(self):
         self.assertNormalized(
             """
             Exception in thread "main" org.python.exceptions.IndexError: list index out of range
+                at org.python.types.List.__getitem__(List.java:100)
+                at org.python.types.List.__getitem__(List.java:85)
+                at python.test.main(test.py:3)
+            """,
+            """
+            ### EXCEPTION ###
+            IndexError: list index out of range
+                test.py:3
+            """
+        )
+
+    def test_exception_in_method_windows(self):
+        self.assertNormalized(
+            """
+            org.python.exceptions.IndexError: list index out of range
                 at org.python.types.List.__getitem__(List.java:100)
                 at org.python.types.List.__getitem__(List.java:85)
                 at python.test.main(test.py:3)
@@ -96,6 +154,23 @@ class JavaNormalizationTests(unittest.TestCase):
             """
             Hello, world.
             Exception in thread "main" org.python.exceptions.IndexError: list index out of range
+                at org.python.types.List.__getitem__(List.java:100)
+                at org.python.types.List.__getitem__(List.java:85)
+                at python.test.main(test.py:3)
+            """,
+            """
+            Hello, world.
+            ### EXCEPTION ###
+            IndexError: list index out of range
+                test.py:3
+            """
+        )
+
+    def test_exception_in_method_after_output_windows(self):
+        self.assertNormalized(
+            """
+            Hello, world.
+            org.python.exceptions.IndexError: list index out of range
                 at org.python.types.List.__getitem__(List.java:100)
                 at org.python.types.List.__getitem__(List.java:85)
                 at python.test.main(test.py:3)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -18,7 +18,6 @@ from voc.transpiler import Transpiler
 
 # A state variable to determine if the test environment has been configured.
 _suite_configured = False
-_jvm_configured = False
 
 def setUpSuite():
     """Configure the entire test suite.
@@ -283,7 +282,6 @@ class TranspileTestCase(TestCase):
 
     def setUpClass():
         global _jvm
-        global _jvm_configured
         test_dir = os.path.join(os.path.dirname(__file__))
         _jvm = subprocess.Popen(
             ["java", "-classpath", "../dist/python-java-testdaemon.jar", "python.testdaemon.TestDaemon"],
@@ -292,15 +290,12 @@ class TranspileTestCase(TestCase):
             stderr=subprocess.STDOUT,
             cwd=test_dir,
         )
-        _jvm_configured = True
 
     def tearDownClass():
         global _jvm
-        global _jvm_configured
-        if _jvm_configured:
+        if _jvm is None:
             # use communicate here to wait for process to exit
             _jvm.communicate("exit".encode())
-            _jvm_configured = False
 
     def assertBlock(self, python, java):
         self.maxDiff = None

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -217,8 +217,8 @@ def compileJava(java_dir, java):
 
 
 JAVA_EXCEPTION = re.compile(
-    '(((Exception in thread "\w+" )?org\.python\.exceptions\.(?P<exception1>[\w]+): (?P<message1>[^\r?\n]+))|' +
-    '((Exception in thread "[\w-]+" )?([^\r?\n]+\r?\n)+' +
+    '(((Exception in thread "[\w-]+" )?org\.python\.exceptions\.(?P<exception1>[\w]+): (?P<message1>[^\r?\n]+))|' +
+    '([^\r\n]*?\r?\n((    |\t)at[^\r\n]*?\r?\n)*' +
     'Caused by: org\.python\.exceptions\.(?P<exception2>[\w]+): (?P<message2>[^\r?\n]+)))\r?\n' +
     '(?P<trace>(\s+at .+\((((.*)(:(\d+))?)|(Native Method))\)\r?\n)+)(.*\r?\n)*' +
     '(Exception in thread "\w+" )?'

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -150,7 +150,7 @@ def runAsJava(test_dir, main_code, extra_code=None, run_in_function=False, args=
     if len(args) == 0:
         global _jvm
         # encode to turn str into bytes-like object
-        _jvm.stdin.write(("python.test.__init__\n").encode())
+        _jvm.stdin.write(("python.test.__init__\n").encode("utf-8"))
         _jvm.stdin.flush()
         out = ""
         while True:
@@ -295,7 +295,7 @@ class TranspileTestCase(TestCase):
         global _jvm
         if _jvm is None:
             # use communicate here to wait for process to exit
-            _jvm.communicate("exit".encode())
+            _jvm.communicate("exit".encode("utf-8"))
 
     def assertBlock(self, python, java):
         self.maxDiff = None

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -276,7 +276,7 @@ class TranspileTestCase(TestCase):
         global _jvm_configured
         test_dir = os.path.join(os.path.dirname(__file__))
         _jvm = subprocess.Popen(
-            ["java", "-classpath", "../dist/python-java.jar:../dist/python-java-testdaemon.jar", "python.testdaemon.TestDaemon"],
+            ["java", "-classpath", "../dist/python-java-testdaemon.jar", "python.testdaemon.TestDaemon"],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -148,21 +148,22 @@ def runAsJava(test_dir, main_code, extra_code=None, run_in_function=False, args=
     if args is None:
         args = []
 
-    classpath = os.pathsep.join([
-        os.path.join('..', '..', 'dist', 'python-java.jar'),
-        os.path.join('..', 'java'),
-        os.curdir,
-    ])
-    proc = subprocess.Popen(
-        ["java", "-classpath", classpath, "python.test.__init__"] + args,
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        cwd=test_dir,
-    )
-    out = proc.communicate()
+    global _jvm
+    # encode to turn str into bytes-like object
+    _jvm.stdin.write(("python.test.__init__\n").encode())
+    _jvm.stdin.flush()
+    out = ""
+    while True:
+        try:
+            line = _jvm.stdout.readline().decode("utf-8")
+            if line == ".\n":
+                break
+            else:
+                out += line
+        except IOError:
+            continue
 
-    return out[0].decode('utf8')
+    return out
 
 
 def compileJava(java_dir, java):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -209,9 +209,9 @@ def compileJava(java_dir, java):
 
 JAVA_EXCEPTION = re.compile(
     '(((Exception in thread "\w+" )?org\.python\.exceptions\.(?P<exception1>[\w]+): (?P<message1>[^\r?\n]+))|' +
-    '((Exception in thread "\w+" )?[^\r?\n]+\r?\n' +
+    '((Exception in thread "[\w-]+" )?([^\r?\n]+\r?\n)+' +
     'Caused by: org\.python\.exceptions\.(?P<exception2>[\w]+): (?P<message2>[^\r?\n]+)))\r?\n' +
-    '(?P<trace>(\s+at .+\((((.*)(:(\d+))?)|(Native Method))\)\r?\n)+)' +
+    '(?P<trace>(\s+at .+\((((.*)(:(\d+))?)|(Native Method))\)\r?\n)+)(.*\r?\n)*' +
     '(Exception in thread "\w+" )?'
 )
 JAVA_STACK = re.compile('\s+at (?P<module>.+)\((((?P<file>.*?)(:(?P<line>\d+))?)|(Native Method))\)')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -18,7 +18,7 @@ from voc.transpiler import Transpiler
 
 # A state variable to determine if the test environment has been configured.
 _suite_configured = False
-
+_jvm_configured = False
 
 def setUpSuite():
     """Configure the entire test suite.
@@ -269,6 +269,27 @@ def cleanse_python(input):
 class TranspileTestCase(TestCase):
     def setUp(self):
         setUpSuite()
+
+    def setUpClass():
+        global _jvm
+        global _jvm_configured
+        test_dir = os.path.join(os.path.dirname(__file__))
+        _jvm = subprocess.Popen(
+            ["java", "-classpath", "../dist/python-java.jar:../dist/python-java-testdaemon.jar", "python.testdaemon.TestDaemon"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            cwd=test_dir,
+        )
+        _jvm_configured = True
+
+    def tearDownClass():
+        global _jvm
+        global _jvm_configured
+        if _jvm_configured:
+            # use communicate here to wait for process to exit
+            _jvm.communicate("exit".encode())
+            _jvm_configured = False
 
     def assertBlock(self, python, java):
         self.maxDiff = None

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -148,6 +148,7 @@ def runAsJava(test_dir, main_code, extra_code=None, run_in_function=False, args=
     if args is None:
         args = []
 
+    if len(args) == 0:
     global _jvm
     # encode to turn str into bytes-like object
     _jvm.stdin.write(("python.test.__init__\n").encode())
@@ -162,6 +163,15 @@ def runAsJava(test_dir, main_code, extra_code=None, run_in_function=False, args=
                 out += line
         except IOError:
             continue
+    else:
+        proc = subprocess.Popen(
+            ["java", "-classpath", "../../dist/python-java.jar:../java:.", "python.test.__init__"] + args,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            cwd=test_dir
+        )
+        out = proc.communicate()[0].decode('utf8')
 
     return out
 
@@ -243,7 +253,7 @@ def cleanse_java(input):
         os.linesep if stack else ''
     )
     out = MEMORY_REFERENCE.sub("0xXXXXXXXX", out)
-    out = JAVA_FLOAT.sub('\\1e\\2\\3', out).replace("'python.test.__init__'", '***EXECUTABLE***')
+    out = JAVA_FLOAT.sub('\\1e\\2\\3', out).replace("'python.test.__init__'", '***EXECUTABLE***').replace("'python.testdaemon.TestDaemon'", '***EXECUTABLE***')
     out = out.replace('\r\n', '\n')
     return out
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -148,20 +148,20 @@ def runAsJava(test_dir, main_code, extra_code=None, run_in_function=False, args=
         args = []
 
     if len(args) == 0:
-    global _jvm
-    # encode to turn str into bytes-like object
-    _jvm.stdin.write(("python.test.__init__\n").encode())
-    _jvm.stdin.flush()
-    out = ""
-    while True:
-        try:
-            line = _jvm.stdout.readline().decode("utf-8")
-            if line == ".\n":
-                break
-            else:
-                out += line
-        except IOError:
-            continue
+        global _jvm
+        # encode to turn str into bytes-like object
+        _jvm.stdin.write(("python.test.__init__\n").encode())
+        _jvm.stdin.flush()
+        out = ""
+        while True:
+            try:
+                line = _jvm.stdout.readline().decode("utf-8")
+                if line == ".\n":
+                    break
+                else:
+                    out += line
+            except IOError:
+                continue
     else:
         proc = subprocess.Popen(
             ["java", "-classpath", "../../dist/python-java.jar:../java:.", "python.test.__init__"] + args,


### PR DESCRIPTION
This fixes #13, but is likely to conflict with #96 as both pull requests changed the regex and subprocess stuff in utils.py.

- Implement a TestDaemon Java class that accepts class names on stdin, and loads + runs the required classes, then sends the output on stdout/stderr. The voc classes are kept loaded to improve performance.
- Add TestDaemon to ant build for `ant java` target.
- Keep a fallback to individual JVM per test when `args` is non-empty, as `sys.argv` will be wrong since it picks up the TestDaemon's parameters from the JVM instead of the entry main() method's `String[] args` parameter.
- Fix an inconsistent test implementation in `test_interface`, as provided by @khoobks in #96 at [d8cfe6d6](https://github.com/pybee/voc/pull/96/commits/d8cfe6d6cdda1b5f482b597255f426e24b4b07b9). No idea how this passes!
- Current test suite runtime is improved to 9-11 min on Travis CI, about 5x speedup.

Potential issues:
- Missing tests for adjusted `JAVA_EXCEPTION` regexes. I'm not sure how to generate the `<clinit>` vs non-`<clinit>` kind of exceptions to use for the test.
- Fallback to individual JVM may have a large impact on performance on test runtime if there are many tests that provide the args. However, this seems non-fixable unless there's an alternate way to implement `sys.argv`.
- I have observed this issue where running the tests with no built files causes `ant java` to run to compile and build the jars, but then the java invocation for TestDaemon fails as it can't find the files / can't find the TestDaemon class. Restarting the test runner fixes this. Not sure if it's reproducible for others.
  - `ant clean && python3 setup.py tests` triggers this on OS X.