### PR TITLE
Minor fixes for Testdaemon

### DIFF
--- a/build-java.xml
+++ b/build-java.xml
@@ -47,9 +47,9 @@
 
     <jar jarfile="${dist}/Python-Java-testdaemon-${python-version}-b${release}.jar" basedir="${build}/java-testdaemon"/>
 
-    <symlink
-        link="${dist}/python-java-testdaemon.jar"
-        resource="${dist}/Python-Java-testdaemon-${python-version}-b${release}.jar"
+    <copy
+        tofile="${dist}/python-java-testdaemon.jar"
+        file="${dist}/Python-Java-testdaemon-${python-version}-b${release}.jar"
         overwrite="true" />
   </target>
 

--- a/python/common/python/platform/__init__.java
+++ b/python/common/python/platform/__init__.java
@@ -19,7 +19,7 @@ public class __init__ extends org.python.types.Module {
         }
 
         try {
-            platform_class = java.lang.Thread.currentThread().getContextClassLoader().loadClass(platform_class_name);
+            platform_class = java.lang.Class.forName(platform_class_name);
             impl = (python.Platform) platform_class.getConstructor().newInstance();
         } catch (ClassNotFoundException e) {
             throw new org.python.exceptions.RuntimeError("Unable to find platform '" + platform_class_name + "'");


### PR DESCRIPTION
- Roll `python.platform.__init__` back to using `Class.forName()`, as it only ever loads classes from within the package, which is inside the runtime jar.
- Switch the ant symlink task for the testdaemon jar to copy for Windows compatibility.