### PR TITLE
Fix race condition between compile and testdaemon startup

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -277,10 +277,8 @@ def cleanse_python(input):
 
 
 class TranspileTestCase(TestCase):
-    def setUp(self):
-        setUpSuite()
-
     def setUpClass():
+        setUpSuite()
         global _jvm
         test_dir = os.path.join(os.path.dirname(__file__))
         _jvm = subprocess.Popen(


### PR DESCRIPTION
- As `setUpClass()` is runs before `setUp()`, ensure that the defined
`setUpSuite()` which runs `ant java` to build the jars is run before
testdaemon is started up.
- This was not an issue before the introduction of testdaemon because
only `setUp()` was defined.
- This should fix some spurious build pass/fail results due to the old
python-java.jar being used on testdaemon startup, before ant completes
the build.

:flushed: :sweat: :sweat_smile: 