### PR TITLE
Fix some Testdaemon issues

### DIFF
--- a/python/testdaemon/python/testdaemon/TestDaemon.java
+++ b/python/testdaemon/python/testdaemon/TestDaemon.java
@@ -64,11 +64,6 @@ public class TestDaemon {
                 // first parameter can be null since method is static
                 // cast second parameter to Object to make it a varargs call
                 method.invoke(null, (Object) inputArgs);
-
-                // cleanup
-                Class<?> importlib = joinedClassLoader.loadClass("org.python.ImportLib");
-                Field importlib_modules = importlib.getDeclaredField("modules");
-                importlib_modules.set(null, new java.util.HashMap());
             } catch (ReflectiveOperationException e) {
                 // InvocationTargetException may contain an ExitException
                 if (e instanceof InvocationTargetException && e.getCause() != null
@@ -92,6 +87,15 @@ public class TestDaemon {
                 // NoSuchMethodError
                 e.printStackTrace();
             } finally {
+                // always cleanup the module cache in ImportLib
+                try {
+                    Class<?> importlib = joinedClassLoader.loadClass("org.python.ImportLib");
+                    Field importlib_modules = importlib.getDeclaredField("modules");
+                    importlib_modules.set(null, new java.util.HashMap());
+                } catch (ReflectiveOperationException e) {
+                    // ClassNotFound, NoSuchMethod, IllegalAccess Exceptions
+                }
+
                 System.out.println(".");
             }
 

--- a/python/testdaemon/python/testdaemon/TestDaemon.java
+++ b/python/testdaemon/python/testdaemon/TestDaemon.java
@@ -75,15 +75,20 @@ public class TestDaemon {
                         && e.getCause() instanceof ExitException) {
                     // System.exit() was invoked somewhere, and caught due to
                     // the custom SecurityManager
-                    System.out.println(".");
+                    // Do nothing, there should be no output
                 } else {
                     // ClassNotFound, NoSuchMethod, IllegalAccess Exceptions
                     e.printStackTrace();
                 }
             } catch (ExceptionInInitializerError e) {
-                // unwrap the Error to get the org.python.exceptions.* thing
-                System.err.print("Exception in thread \"main\" ");
-                e.printStackTrace();
+                if (e.getCause() != null && e.getCause() instanceof ExitException) {
+                    // System.exit() was invoked somewhere, and caught due to
+                    // the custom SecurityManager
+                    // Do nothing, there should be no output
+                } else {
+                    System.err.print("Exception in thread \"main\" ");
+                    e.printStackTrace();
+                }
             } catch (Throwable e) {
                 // NoSuchMethodError
                 e.printStackTrace();

--- a/python/testdaemon/python/testdaemon/TestDaemon.java
+++ b/python/testdaemon/python/testdaemon/TestDaemon.java
@@ -86,7 +86,6 @@ public class TestDaemon {
                     // the custom SecurityManager
                     // Do nothing, there should be no output
                 } else {
-                    System.err.print("Exception in thread \"main\" ");
                     e.printStackTrace();
                 }
             } catch (Throwable e) {


### PR DESCRIPTION
- Add the catch for ExitException from the init blocks anyway, in case the exit from static thing is fixed in the future
- Remove the `Exception in thread "main"` line since the regex has been modified to cater to Windows JVM, which doesn't print it
- Always cleanup ImportLib's module cache, even if an exception is caught, which might fix some general flakiness

I've run each commit separately on Travis and they've passed each time, so fingers crossed...