### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,8 +32,8 @@ with `the first tutorial`_.
 
 If you'd like to contribute to VOC development, we have a `guide for first time contributors`_.
 
-.. _Getting Started guide: http://voc.readthedocs.org/en/latest/intro/getting-started.html
-.. _the first tutorial: http://voc.readthedocs.org/en/latest/tutorials/tutorial-0.html
+.. _Getting Started guide: https://voc.readthedocs.io/en/latest/intro/getting-started.html
+.. _the first tutorial: https://voc.readthedocs.io/en/latest/tutorials/tutorial-0.html
 
 .. _guide for first time contributors: https://github.com/pybee/voc/wiki/Your-first-VOC-contribution
 
@@ -82,7 +82,7 @@ If you experience problems with VOC, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
 .. _BeeWare suite: http://pybee.org
-.. _Read The Docs: http://voc.readthedocs.org
+.. _Read The Docs: https://voc.readthedocs.io
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
 .. _BeeWare Users Mailing list: https://groups.google.com/forum/#!forum/beeware-users
 .. _wiki: https://github.com/pybee/voc/wiki/Your-first-VOC-contribution

--- a/docs/intro/community.rst
+++ b/docs/intro/community.rst
@@ -23,7 +23,7 @@ If you experience problems with VOC, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
 .. _BeeWare suite: http://pybee.org
-.. _Read The Docs: http://voc.readthedocs.org
+.. _Read The Docs: https://voc.readthedocs.io
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
 .. _BeeWare Users Mailing list: https://groups.google.com/forum/#!forum/beeware-users
 .. _BeeWare Developers Mailing list: https://groups.google.com/forum/#!forum/beeware-developers


### PR DESCRIPTION
As per their email ‘Changes to project subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.