### PR TITLE
correct relative folders

### DIFF
--- a/docs/tutorials/tutorial-0.rst
+++ b/docs/tutorials/tutorial-0.rst
@@ -55,7 +55,7 @@ This classfile can run on any Java 6 (or higher) VM. To run the project, type:
 
 .. code-block:: bash
 
-    $ java -classpath ../voc/dist/python-java.jar:. python.example.__init__
+    $ java -classpath ../dist/python-java.jar:. python.example.__init__
     Hello, World
 
 Congratulations! You've just run your first Python program under Java using


### PR DESCRIPTION
starting in tutorial0 directory:

   "This will produce an ``__init__.class`` in the ``python/example`` namespace.
    This classfile can run on any Java 6 (or higher) VM. To run the project, type:

      .. code-block:: bash

          $ java -classpath ../voc/dist/python-java.jar:. python.example.__init__
          Hello, World

   Congratulations! You've just run your first Python program under Java using
   VOC! Now you're ready to get a little more adventurous."

the /voc doesn't work.  The command line should read:

`$ java -classpath ../dist/python-java.jar:. python.example.__init__`