### PR TITLE
Handle special floats in str.__float__ and float.__repr__

### DIFF
--- a/python/common/org/python/types/Float.java
+++ b/python/common/org/python/types/Float.java
@@ -502,4 +502,12 @@ public class Float extends org.python.types.Object {
     public org.python.Object __round__(org.python.Object ndigits) {
         throw new org.python.exceptions.NotImplementedError("float.__round__() has not been implemented.");
     }
+
+
+    @org.python.Method(
+        __doc__ = ""
+    )
+    public org.python.Object __invert__() {
+        throw new org.python.exceptions.TypeError("bad operand type for unary ~: 'float'");
+    }
 }

--- a/python/common/org/python/types/Float.java
+++ b/python/common/org/python/types/Float.java
@@ -48,7 +48,20 @@ public class Float extends org.python.types.Object {
         __doc__ = ""
     )
     public org.python.types.Str __repr__() {
-        return new org.python.types.Str(java.lang.Double.toString(this.value));
+        double value = this.value;
+        String result;
+        if (Double.isNaN(value)) {
+            result = "nan";
+        } else if (Double.isInfinite(value)) {
+            if (value > 0) {
+                result = "inf";
+            } else {
+                result = "-inf";
+            }
+        } else {
+            result = java.lang.Double.toString(this.value);
+        }
+        return new org.python.types.Str(result);
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -77,15 +77,27 @@ public class Str extends org.python.types.Object {
         __doc__ = ""
     )
     public org.python.types.Float __float__() {
+        double result;
         try {
-            return new org.python.types.Float(Double.parseDouble(this.value));
+            result = Double.parseDouble(this.value);
         } catch (NumberFormatException e) {
-            String value = this.value;
-            if (value.length() > 0) {
-                value = "'" + value + "'";
+            String trimmed = this.value.trim();
+            if (trimmed == "inf") {
+                result = Double.POSITIVE_INFINITY;
+            } else if (trimmed == "-inf") {
+                result = Double.NEGATIVE_INFINITY;
+            } else if (trimmed == "nan") {
+                result = Double.NaN;
+            } else {
+                String value = this.value;
+                if (value.length() > 0) {
+                    value = "'" + value + "'";
+                }
+                throw new org.python.exceptions.ValueError(
+                    "could not convert string to float: " + value);
             }
-            throw new org.python.exceptions.ValueError("could not convert string to float: " + value);
         }
+        return new org.python.types.Float(result);
     }
 
     @org.python.Method(

--- a/tests/datatypes/test_float.py
+++ b/tests/datatypes/test_float.py
@@ -18,7 +18,6 @@ class FloatTests(TranspileTestCase):
             print('Done.')
             """)
 
-    @expectedFailure
     def test_repr(self):
         self.assertCodeExecution("""
             x = 0.35
@@ -27,11 +26,30 @@ class FloatTests(TranspileTestCase):
             print(x)
             x = 0.0035
             print(x)
-            x = 0.00035
-            print(x)
             x = 0.000035
             print(x)
             x = 0.0000035
+            print(x)
+
+            x = 0.0
+            print(x)
+            x = float('-0.0')
+            print(x)
+            x = float('nan')
+            print(x)
+            x = float('inf')
+            print(x)
+            x = float('-inf')
+            print(x)
+            """)
+
+    @expectedFailure
+    def test_repr_failure(self):
+        # Merge these cases into test_repr when they pass
+        self.assertCodeExecution("""
+            x = -0.0
+            print(x)
+            x = 0.00035
             print(x)
             """)
 

--- a/tests/datatypes/test_float.py
+++ b/tests/datatypes/test_float.py
@@ -39,10 +39,6 @@ class FloatTests(TranspileTestCase):
 class UnaryFloatOperationTests(UnaryOperationTestCase, TranspileTestCase):
     values = ['1.2345', '0.0', '-2.345']
 
-    not_implemented = [
-        'test_unary_invert',
-    ]
-
 
 class BinaryFloatOperationTests(BinaryOperationTestCase, TranspileTestCase):
     values = ['1.2345', '0.0', '-2.345']


### PR DESCRIPTION
While working on `float.__repr__`, I saw CPython has some code to handle special floats (`nan`, `inf`, `-inf`). This adds enough support that these can be tested.

And I'm adding a commit for `float.__invert__`, too.