### PR TITLE
Implement float.hex()

### DIFF
--- a/python/common/org/python/types/Float.java
+++ b/python/common/org/python/types/Float.java
@@ -523,4 +523,59 @@ public class Float extends org.python.types.Object {
     public org.python.Object __invert__() {
         throw new org.python.exceptions.TypeError("bad operand type for unary ~: 'float'");
     }
+
+
+    @org.python.Method(
+        __doc__ = ""
+    )
+    public org.python.types.Str hex() {
+        String result;
+        if (Double.isNaN(this.value)) {
+            result = "nan";
+        } else if (Double.isInfinite(this.value)) {
+            if (this.value > 0) {
+                result = "inf";
+            } else {
+                result = "-inf";
+            }
+        } else {
+            long bits = Double.doubleToLongBits(this.value);
+            StringBuilder buffer = new StringBuilder();
+            boolean sign = (bits >> 63) != 0;
+            long exponent = (bits >> 52) & 0x7ffL;
+            long mantissa = bits & 0x000fffffffffffffL;
+            if (sign) {
+                buffer.append("-");
+            }
+            buffer.append("0x");
+            String hexMantissa = Long.toHexString(mantissa);
+            if (exponent == 0) {
+                buffer.append("0.");
+            } else {
+                buffer.append("1.");
+            }
+            if (exponent == 0 && mantissa == 0) {
+                // for some reason the matissa is not padded in this case
+                buffer.append(hexMantissa);
+                buffer.append("p+0");
+            } else {
+                buffer.append("0000000000000".substring(hexMantissa.length()));
+                buffer.append(hexMantissa);
+                if (exponent == 0) {
+                    exponent = -1022;
+                } else {
+                    exponent -= 1023;
+                }
+                if (exponent >= 0) {
+                    buffer.append("p+");
+                    buffer.append(Long.toString(exponent));
+                } else {
+                    buffer.append("p-");
+                    buffer.append(Long.toString(-exponent));
+                }
+            }
+            result = buffer.toString();
+        }
+        return new org.python.types.Str(result);
+    }
 }

--- a/tests/datatypes/test_float.py
+++ b/tests/datatypes/test_float.py
@@ -53,6 +53,17 @@ class FloatTests(TranspileTestCase):
             print(x)
             """)
 
+    def test_hex(self):
+        numbers = [0e0, -0e0, 10000152587890625e-16, -566e85,
+                   -87336362425182547697e-280, 4.9406564584124654e-324,
+                   'nan', 'inf', '-inf']
+        template = """
+            x = float('{}')
+            print(x.hex())
+            """
+        code = '\n'.join(template.format(number) for number in numbers)
+        self.assertCodeExecution(code)
+
 
 class UnaryFloatOperationTests(UnaryOperationTestCase, TranspileTestCase):
     values = ['1.2345', '0.0', '-2.345']

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -237,7 +237,7 @@ JAVA_FLOAT = re.compile('(\d+)E(-)?(\d+)')
 # PYTHON_EXCEPTION = re.compile('Traceback \(most recent call last\):\n(  File ".*", line \d+, in .*\n)(    .*\n  File "(?P<file>.*)", line (?P<line>\d+), in .*\n)+(?P<exception>.*): (?P<message>.*\n)')
 PYTHON_EXCEPTION = re.compile('Traceback \(most recent call last\):\r?\n(  File "(?P<file>.*)", line (?P<line>\d+), in .*\r?\n    .*\r?\n)+(?P<exception>.*?): (?P<message>.*\r?\n)')
 PYTHON_STACK = re.compile('  File "(?P<file>.*)", line (?P<line>\d+), in .*\r?\n    .*\r?\n')
-PYTHON_FLOAT = re.compile('(\d+)e(-)?0?(\d+)')
+PYTHON_FLOAT = re.compile('(\d+)e(-?)0?(\d+)')
 
 MEMORY_REFERENCE = re.compile('0x[\dabcdef]{4,8}')
 


### PR DESCRIPTION
I need a bit more insight into what's going on in float-land before I implement `float.__repr__`. So, I implemented `float hex()` to tell what the bits are.