### PR TITLE
Exception return too verbose

### DIFF
--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -269,7 +269,7 @@ public class Str extends org.python.types.Object {
                 }
             }
         } catch (ClassCastException e) {
-            throw new org.python.exceptions.TypeError("string indices must be integers, not " + index.typeName());
+            throw new org.python.exceptions.TypeError("string indices must be integers");
         }
     }
 


### PR DESCRIPTION
Removed ", not " + index.typeError()
The error ONLY mentions "string indices must be integers"
