### PR TITLE
Error msg too verbose

### DIFF
--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -269,7 +269,7 @@ public class Str extends org.python.types.Object {
                 }
             }
         } catch (ClassCastException e) {
-            throw new org.python.exceptions.TypeError("string indices must be integers, not " + index.typeName());
+            throw new org.python.exceptions.TypeError("string indices must be integers");
         }
     }
 

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -183,7 +183,6 @@ class BinaryStrOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_subscr_bytearray',
         'test_subscr_class',
         'test_subscr_complex',
-        'test_subscr_dict',
         'test_subscr_frozenset',
         'test_subscr_slice',
 

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -181,18 +181,11 @@ class BinaryStrOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_rshift_slice',
 
         'test_subscr_bytearray',
-        'test_subscr_bytes',
         'test_subscr_class',
         'test_subscr_complex',
         'test_subscr_dict',
-        'test_subscr_float',
         'test_subscr_frozenset',
         'test_subscr_slice',
-        'test_subscr_list',
-        'test_subscr_None',
-        'test_subscr_NotImplemented',
-        'test_subscr_range',
-        'test_subscr_set',
         'test_subscr_str',
         'test_subscr_tuple',
 

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -186,8 +186,6 @@ class BinaryStrOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_subscr_dict',
         'test_subscr_frozenset',
         'test_subscr_slice',
-        'test_subscr_str',
-        'test_subscr_tuple',
 
         'test_subtract_bytearray',
         'test_subtract_class',


### PR DESCRIPTION
The python error is ONLY "string indices must be integers"
no need for ', not " + index.typeName()'


Also deleted all unexpected successes that were a result of this fix.