### PR TITLE
Implement the set.pop() function

### DIFF
--- a/python/common/org/python/types/Set.java
+++ b/python/common/org/python/types/Set.java
@@ -409,10 +409,19 @@ public class Set extends org.python.types.Object {
     }
 
     @org.python.Method(
-        __doc__ = ""
+            __doc__ = "",
+            args = {}
     )
-    public org.python.Object pop(org.python.Object other) {
-        throw new org.python.exceptions.NotImplementedError("pop() has not been implemented.");
+    public org.python.Object pop() {
+        if (this.value.size() == 0) {
+            throw new org.python.exceptions.KeyError(new org.python.types.Str("pop from an empty set"));
+        }
+
+        java.util.Iterator<org.python.Object> iterator = this.value.iterator();
+        org.python.Object popped = iterator.next();
+        iterator.remove();
+
+        return popped;
     }
 
     @org.python.Method(

--- a/tests/datatypes/test_set.py
+++ b/tests/datatypes/test_set.py
@@ -47,6 +47,28 @@ class SetTests(TranspileTestCase):
             print('c' in x)
             """)
 
+    def test_pop(self):
+        # Test empty set popping.
+        self.assertCodeExecution("""
+            x = set()
+            x.pop()
+        """)
+
+        # Test populated set popping.
+        self.assertCodeExecution("""
+            x = {'a'}
+            print(len(x) == 1)
+            x.pop()
+            print(len(x) == set())
+        """)
+
+        # Test popping returns from set.
+        self.assertCodeExecution("""
+            x = {'a', 'b', 'c', 'd', 'e'}
+            y = x.pop()
+            print(y in x)
+        """)
+
 
 class UnarySetOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'set'


### PR DESCRIPTION
Refs #38
This commit implements the `set.pop()` function which removes an
arbitrary element from a set.
(PR#229 Redux)

Signed-off-by: Thomas Cranny tkcranny@gmail.com