### PR TITLE
Optimize constant pools a bit

### DIFF
--- a/voc/java/constants.py
+++ b/voc/java/constants.py
@@ -264,7 +264,7 @@ class Classref(Constant):
         return '<Class %s>' % self.name
 
     def __eq__(self, other):
-        return multieq(self, other, 'tag', 'name')
+        return isinstance(other, Classref) and other.tag == self.tag and other.name == self.name
 
     def __hash__(self):
         return multihash(self, 'tag', 'name')
@@ -322,7 +322,7 @@ class Fieldref(Constant):
         return '<Fieldref %s.%s (%s)>' % (self.class_name, self.name, self.descriptor)
 
     def __eq__(self, other):
-        return multieq(self, other, 'tag', 'klass', 'name_and_type')
+        return isinstance(other, Fieldref) and other.tag == self.tag and other.klass == self.klass and other.name_and_type == self.name_and_type
 
     def __hash__(self):
         return multihash(self, 'tag', 'klass', 'name_and_type')
@@ -394,7 +394,7 @@ class Methodref(Constant):
         return '<Methodref %s.%s %s>' % (self.class_name, self.name, self.name_and_type.descriptor)
 
     def __eq__(self, other):
-        return multieq(self, other, 'tag', 'klass', 'name_and_type')
+        return isinstance(other, Methodref) and other.tag == self.tag and other.klass == self.klass and other.name_and_type == self.name_and_type
 
     def __hash__(self):
         return multihash(self, 'tag', 'klass', 'name_and_type')
@@ -455,7 +455,7 @@ class InterfaceMethodref(Constant):
         return '<InterfaceMethodref %s.%s %s>' % (self.class_name, self.name, self.name_and_type.descriptor)
 
     def __eq__(self, other):
-        return multieq(self, other, 'tag', 'klass', 'name_and_type')
+        return isinstance(other, InterfaceMethodref) and other.tag == self.tag and other.klass == self.klass and other.name_and_type == self.name_and_type
 
     def __hash__(self):
         return multihash(self, 'tag', 'klass', 'name_and_type')
@@ -505,7 +505,7 @@ class String(Constant):
         return "<String '%s'>" % self.value
 
     def __eq__(self, other):
-        return multieq(self, other, 'tag', 'value')
+        return isinstance(other, String) and other.tag == self.tag and other.value == self.value
 
     def __hash__(self):
         return multihash(self, 'tag', 'value')
@@ -552,7 +552,7 @@ class Integer(Constant):
         return '<Integer %s>' % self.value
 
     def __eq__(self, other):
-        return multieq(self, other, 'tag', 'value')
+        return isinstance(other, Integer) and other.tag == self.tag and other.value == self.value
 
     def __hash__(self):
         return multihash(self, 'tag', 'value')
@@ -609,7 +609,7 @@ class Float(Constant):
         return '<Float %s>' % self.value
 
     def __eq__(self, other):
-        return multieq(self, other, 'tag', 'value')
+        return isinstance(other, Float) and other.tag == self.tag and other.value == self.value
 
     def __hash__(self):
         return multihash(self, 'tag', 'value')
@@ -665,7 +665,7 @@ class Long(Constant):
         return '<Long %s>' % self.value
 
     def __eq__(self, other):
-        return multieq(self, other, 'tag', 'value')
+        return isinstance(other, Long) and other.tag == self.tag and other.value == self.value
 
     def __hash__(self):
         return multihash(self, 'tag', 'value')
@@ -728,7 +728,7 @@ class Double(Constant):
         return '<Double %s>' % self.value
 
     def __eq__(self, other):
-        return multieq(self, other, 'tag', 'value')
+        return isinstance(other, Double) and other.tag == self.tag and other.value == self.value
 
     def __hash__(self):
         return multihash(self, 'tag', 'value')
@@ -779,7 +779,7 @@ class NameAndType(Constant):
         return '<NameAndType: name:%s descriptor:%s>' % (self.name, self.descriptor)
 
     def __eq__(self, other):
-        return multieq(self, other, 'tag', 'name', 'descriptor')
+        return isinstance(other, NameAndType) and other.tag == self.tag and other.name == self.name and other.descriptor == self.descriptor
 
     def __hash__(self):
         return multihash(self, 'tag', 'name', 'descriptor')
@@ -959,7 +959,7 @@ class Utf8(Constant):
         writer.write_bytes(self.bytes)
 
     def __eq__(self, other):
-        return multieq(self, other, 'tag', '_bytes')
+        return isinstance(other, Utf8) and other.tag == self.tag and other._bytes == self._bytes
 
     def __hash__(self):
         return multihash(self, 'tag', '_bytes')


### PR DESCRIPTION
Profiling the test suite indicates that we burn a lot of CPU time on this, likely due to the many calls to `type()` and `getattr()`. Changing to these hard-coded `__eq__` methods saves about 150 seconds on a single-threaded run of `tests.builtins` on my Mac.

I'd like feedback on whether this is worth doing; mainly, I don't know whether this set of constant types is closed or likely to see additions in the future that make the CPU-time-for-dev-time tradeoff worth it.