### PR TITLE
add fallback for module import, to allow wrongly classified modules to be imported

### DIFF
--- a/python/common/org/python/ImportLib.java
+++ b/python/common/org/python/ImportLib.java
@@ -45,7 +45,16 @@ public class ImportLib {
                     if (native_import) {
                         python_module = importNativeModule(mod_name);
                     } else {
-                        python_module = importPythonModule(mod_name);
+                        try {
+                            // try to import unknown native module as python..
+                            python_module = importPythonModule(mod_name);
+                        } catch (java.lang.ClassNotFoundException e) {
+                            // .. but try again to import as native module
+                            // if is not found, otherwise some modules like
+                            // generated resource modules can not be imported
+                            python_module = importNativeModule(mod_name);
+                        }
+
                     }
                 } catch (java.lang.ClassNotFoundException e) {
                     throw new org.python.exceptions.ImportError("No module named '" + python_name + "'");


### PR DESCRIPTION
If a module is wrongly classified as being a not a native module, there is currently no way to import the module. Add a fallback for the importer to try for both,  native and python modules.

Use case: When developing for android and using the resource compiler to generate the `R.java` source file the (native) module will be available as submodule of the (python) app module.
This code only works with this change:

```
import android.app.Activity
import android.os.Bundle

from android.util import Log 
from python.myapp.app import R
import java.lang.System 

class MyApp(extends=android.app.Activity):
    def onCreate(self, state: android.os.Bundle) -> void:
        Log.i("VOC", "starting up voc app")
        super().onCreate(state)
        self.setContentView(R.layout.activity_main)
        text_view = self.findViewById(R.id.textView)
        text_view.setText("Hey from python!")
```