### PR TITLE
Bugfixes and methods added in the dict datatype

### DIFF
--- a/python/common/org/python/types/Dict.java
+++ b/python/common/org/python/types/Dict.java
@@ -354,10 +354,19 @@ public class Dict extends org.python.types.Object {
     }
 
     @org.python.Method(
-        __doc__ = ""
+        __doc__ = "",
+        default_args = {"other", "default_value"}
     )
-    public org.python.Object setdefault(org.python.Object other) {
-        throw new org.python.exceptions.NotImplementedError("dict.setdefault() has not been implemented.");
+    public org.python.Object setdefault(org.python.Object other, org.python.Object default_value) {
+        try {
+            return this.__getitem__(other);
+        } catch (org.python.exceptions.KeyError e){ // allow unhashable type error to be percolated up.
+            if (default_value == null) {
+                default_value = org.python.types.NoneType.NONE;
+            }
+            __setitem__(other, default_value);
+            return default_value;
+        }
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Dict.java
+++ b/python/common/org/python/types/Dict.java
@@ -339,8 +339,18 @@ public class Dict extends org.python.types.Object {
     @org.python.Method(
         __doc__ = ""
     )
-    public org.python.Object popitem(org.python.Object other) {
-        throw new org.python.exceptions.NotImplementedError("dict.popitem() has not been implemented.");
+    public org.python.Object popitem() {
+        if (this.value.size() == 0) {
+            throw new org.python.exceptions.KeyError(new org.python.types.Str("popitem(): dictionary is empty"));
+        }
+        java.util.Map.Entry<org.python.Object, org.python.Object> entry = this.value.entrySet().iterator().next();
+        org.python.Object key = entry.getKey();
+        org.python.Object value = this.value.remove(key);
+
+        java.util.List<org.python.Object> item_pair = new java.util.ArrayList<>();
+        item_pair.add(key);
+        item_pair.add(value);
+        return new org.python.types.Tuple(item_pair);
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Dict.java
+++ b/python/common/org/python/types/Dict.java
@@ -264,14 +264,26 @@ public class Dict extends org.python.types.Object {
         __doc__ = ""
     )
     public org.python.Object __contains__(org.python.Object item) {
-        return new org.python.types.Bool(this.value.get(item) != null);
+         // allow unhashable type error to be percolated up.
+        try{
+            __getitem__(item);
+            return new org.python.types.Bool(true);
+        } catch(org.python.exceptions.KeyError e) {
+            return new org.python.types.Bool(false);
+        }
     }
 
     @org.python.Method(
         __doc__ = ""
     )
     public org.python.Object __not_contains__(org.python.Object item) {
-        return new org.python.types.Bool(this.value.get(item) == null);
+         // allow unhashable type error to be percolated up.
+        try{
+            __getitem__(item);
+            return new org.python.types.Bool(false);
+        } catch(org.python.exceptions.KeyError e) {
+            return new org.python.types.Bool(true);
+        }
     }
 
     @org.python.Method(

--- a/tests/datatypes/test_dict.py
+++ b/tests/datatypes/test_dict.py
@@ -95,6 +95,10 @@ class DictTests(TranspileTestCase):
             print('a' in x)
             print(x['a'])
             print('c' in x)
+
+            # Test __contains__ throws unhashable exception
+            print([] in x)
+            print([] not in x)
         """)
 
     def test_builtin_non_2_tuples(self):

--- a/tests/datatypes/test_dict.py
+++ b/tests/datatypes/test_dict.py
@@ -127,6 +127,20 @@ class DictTests(TranspileTestCase):
             print(x.popitem()) # Check for exception
             """)
 
+    def test_method_setdefault(self):
+        self.assertCodeExecution("""
+            x = {42: 'Babel'}
+            print(x.setdefault(42)) # should return Babel
+
+            print(x.setdefault(1)) # should return None
+            print(x[1] == None) # should be True
+
+            print(x.setdefault('David', 'Gilmour')) # should return 'Gilmour'
+
+            # Check unhashable exceptions
+            x.setdefault([], 42)
+            """)
+
 
 class UnaryDictOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'dict'

--- a/tests/datatypes/test_dict.py
+++ b/tests/datatypes/test_dict.py
@@ -113,6 +113,20 @@ class DictTests(TranspileTestCase):
             x = dict([('a', 1), False, ('b', 2)])
             """)
 
+    def test_method_popitem(self):
+        self.assertCodeExecution("""
+            ITEMS = [(1, 2), (3, ("4", 5))]
+            x = dict(ITEMS)
+
+            popped_1 = x.popitem()
+            print(popped_1 in ITEMS)
+
+            popped_2 = x.popitem()
+            print(popped_2 in ITEMS and popped_2 != popped_1)
+
+            print(x.popitem()) # Check for exception
+            """)
+
 
 class UnaryDictOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'dict'


### PR DESCRIPTION
 - `__contains__` and `__not_contains__` hooks of a `dict` throw unhashable type Exceptions
 - added `popitem` method
 - added `setdefault` method