### PR TITLE
Update python version requirement to 3.5+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
-  - "3.4.2"
-  - "3.4.4"
+  - "3.5.2"
 install:
   - "pip install ."
   - "ant java"

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 import sys
 
-if sys.version_info[:2] != (3, 4):
-    raise SystemExit("VOC requires Python 3.4+")
+if sys.version_info[:2] != (3, 5):
+    raise SystemExit("VOC requires Python 3.5+")
 
 import io
 import re


### PR DESCRIPTION
As mentioned in the issue #270, I think that the python version requirement should be updated to 3.5+ instead of 3.4+. This is a minor fix, but please do correct me if I am wrong.