### PR TITLE
Add implementation for list.sort()

### DIFF
--- a/python/common/org/python/Object.java
+++ b/python/common/org/python/Object.java
@@ -1,7 +1,7 @@
 package org.python;
 
 
-public interface Object {
+public interface Object extends Comparable {
     /**
      * Return a Java object that is the underlying data representation
      * of this object (e.g., the java.util.Map behind a Python dict()).

--- a/python/common/org/python/types/List.java
+++ b/python/common/org/python/types/List.java
@@ -558,7 +558,7 @@ public class List extends org.python.types.Object {
         args = {},
         default_args = {"key", "reverse"}
     )
-    public org.python.Object sort(org.python.Object key, org.python.Object reverse) {
+    public org.python.Object sort(final org.python.Object key, org.python.Object reverse) {
         if (key == null && reverse == null) {
             Collections.sort(this.value);
         } else {

--- a/python/common/org/python/types/List.java
+++ b/python/common/org/python/types/List.java
@@ -1,6 +1,7 @@
 package org.python.types;
 
 import org.Python;
+import java.util.Collections;
 
 public class List extends org.python.types.Object {
     public java.util.List<org.python.Object> value;
@@ -552,10 +553,18 @@ public class List extends org.python.types.Object {
     }
 
     @org.python.Method(
-        __doc__ = ""
+        __doc__ = "L.sort(key=None, reverse=False) -> None -- stable sort *IN PLACE*"
     )
     public org.python.Object sort() {
-        throw new org.python.exceptions.NotImplementedError("list.sort() has not been implemented.");
+        return this.sort(org.python.types.NoneType.NONE, org.python.types.NoneType.NONE);
+    }
+
+    @org.python.Method(
+        __doc__ = "L.sort(key=None, reverse=False) -> None -- stable sort *IN PLACE*"
+    )
+    public org.python.Object sort(org.python.Object key, org.python.Object reverse) {
+        Collections.sort(this.value);
+        return org.python.types.NoneType.NONE;
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -410,7 +410,7 @@ public class Object implements org.python.Object {
         org.python.types.List names = new org.python.types.List(new java.util.ArrayList(this.__dict__.keySet()));
 
         names.extend(this.__dict__.get("__class__").__dir__());
-        names.sort();
+        names.sort(null, null);
 
         return names;
     }

--- a/tests/datatypes/test_list.py
+++ b/tests/datatypes/test_list.py
@@ -203,6 +203,34 @@ class ListTests(TranspileTestCase):
                 print(x)
             """)
 
+        self.assertCodeExecution("""
+            fixtures = [
+                [9, 4, 7],
+                ['beta', 'theta', 'alpha'],
+            ]
+            for x in fixtures:
+                x.sort(reverse=True)
+                print(x)
+            """)
+
+        self.assertCodeExecution("""
+            def second(s):
+                return s[1]
+
+            x = ['abc', 'bza', 'cda', 'daa']
+            x.sort(key=second)
+            print(x)
+            """)
+
+        self.assertCodeExecution("""
+            def second(s):
+                return s[1]
+
+            x = ['abc', 'bza', 'cda', 'daa']
+            x.sort(key=second, reverse=True)
+            print(x)
+            """)
+
 
 class UnaryListOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'list'

--- a/tests/datatypes/test_list.py
+++ b/tests/datatypes/test_list.py
@@ -192,6 +192,17 @@ class ListTests(TranspileTestCase):
             print(x.count(1))
             """)
 
+    def test_sort(self):
+        self.assertCodeExecution("""
+            fixtures = [
+                [9, 4, 7],
+                ['beta', 'theta', 'alpha'],
+            ]
+            for x in fixtures:
+                x.sort()
+                print(x)
+            """)
+
 
 class UnaryListOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'list'


### PR DESCRIPTION
So, this adds an initial implementation for `list.sort()`, paving the way to implement builtin's `sorted()`.

I _think_ once we have `sorted()` working fine we could start using it in other unit tests (I found hard trying to come with tests for set operations without a sorting function).

Does this look good?