### PR TITLE
Implement list.copy() and list.index() methods

### DIFF
--- a/python/common/org/python/types/List.java
+++ b/python/common/org/python/types/List.java
@@ -1,6 +1,7 @@
 package org.python.types;
 
 import org.Python;
+
 import java.util.Collections;
 import java.util.Comparator;
 
@@ -517,19 +518,40 @@ public class List extends org.python.types.Object {
         return org.python.types.NoneType.NONE;
     }
 
+    private int toPositiveIndex(int index) {
+        if (index < 0) {
+            return this.value.size() + index;
+        }
+        return index;
+    }
+
     @org.python.Method(
-        __doc__ = ""
+        __doc__ = "L.index(value, [start, [stop]]) -> integer -- return first index of value.\nRaises ValueError if the value is not present.",
+        args = {"item"},
+        default_args = {"start", "end"}
     )
     public org.python.Object index(org.python.Object item, org.python.Object start, org.python.Object end) {
         if (start != null && !(start instanceof org.python.types.Int)) {
             throw new org.python.exceptions.TypeError("list indices must be integers, not " + start.typeName());
         }
-
         if (end != null && !(end instanceof org.python.types.Int)) {
             throw new org.python.exceptions.TypeError("list indices must be integers, not " + end.typeName());
         }
 
-        throw new org.python.exceptions.NotImplementedError("list.index() has not been implemented.");
+        int iStart = 0, iEnd = this.value.size();
+        if (end != null) {
+            iEnd = toPositiveIndex(((Long) end.toJava()).intValue());
+        }
+        if (start != null) {
+            iStart = toPositiveIndex(((Long) start.toJava()).intValue());
+        }
+
+        for (int i = iStart; i < Math.min(iEnd, this.value.size()); i++) {
+            if (((org.python.types.Bool) this.value.get(i).__eq__(item)).value) {
+                return new org.python.types.Int(i);
+            }
+        }
+        throw new org.python.exceptions.ValueError(String.format("%d is not in list",  ((org.python.types.Int)item).value));
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/List.java
+++ b/python/common/org/python/types/List.java
@@ -489,10 +489,10 @@ public class List extends org.python.types.Object {
     }
 
     @org.python.Method(
-        __doc__ = ""
+        __doc__ = "L.copy() -> list -- a shallow copy of L"
     )
     public org.python.Object copy() {
-        throw new org.python.exceptions.NotImplementedError("list.copy() has not been implemented.");
+        return new org.python.types.List(new java.util.ArrayList<org.python.Object>(this.value));
     }
 
     @org.python.Method(

--- a/tests/datatypes/test_list.py
+++ b/tests/datatypes/test_list.py
@@ -269,6 +269,38 @@ class ListTests(TranspileTestCase):
             print(x)
             """)
 
+    def test_copy(self):
+        self.assertCodeExecution("""
+            x = [1, 2, 3]
+            y = x.copy()
+            print(y)
+            """)
+
+        self.assertCodeExecution("""
+            x = [1, 2, 3]
+            y = x.copy()
+            print(x == y)
+            """)
+
+        self.assertCodeExecution("""
+            x = [1, 2, 3]
+            y = x.copy()
+            print(x is not y)
+            """)
+
+        self.assertCodeExecution("""
+            x = [1, 2, 3]
+            y = x.copy()
+            y.append(4)
+            print(x == y)
+            """)
+
+        self.assertCodeExecution("""
+            x = [[1], 2, 3]
+            y = x.copy()
+            print(x[0] is y[0])
+            """)
+
 
 class UnaryListOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'list'

--- a/tests/datatypes/test_list.py
+++ b/tests/datatypes/test_list.py
@@ -301,6 +301,78 @@ class ListTests(TranspileTestCase):
             print(x[0] is y[0])
             """)
 
+    def test_index(self):
+        self.assertCodeExecution("""
+            x = [1, 2, 3]
+            print(x.index(1))
+            """)
+
+        self.assertCodeExecution("""
+            x = [1, 2, 1]
+            print(x.index(1, 1))
+            """)
+
+        self.assertCodeExecution("""
+            x = [1, 2, 3, 4]
+            print(x.index(4, 0, len(x)))
+            """)
+
+        self.assertCodeExecution("""
+            x = [1, 2, 3, 4]
+            print(x.index(2, 1, 2))
+            """)
+
+        self.assertCodeExecution("""
+            x = [1, 2, 3, 4]
+            print(x.index(2, 0, 10))
+            """)
+
+        self.assertCodeExecution("""
+            x = [1, 2, 1]
+            print(x.index(1, 0, -2))
+            """)
+
+        self.assertCodeExecution("""
+            x = [1, 2, 1]
+            print(x.index(1, -3, -2))
+            """)
+
+        # cases for 'ValueError: not in list'
+        self.assertCodeExecution("""
+            x = [1, 2, 3]
+            print(x.index(4))
+            """)
+
+        self.assertCodeExecution("""
+            x = [1, 2, 1]
+            print(x.index(2, 0, 1))
+            """)
+
+        self.assertCodeExecution("""
+            x = [1, 2, 3, 4]
+            print(x.index(4, 0, 3))
+            """)
+
+        self.assertCodeExecution("""
+            x = [1, 2, 1]
+            print(x.index(3, 0, 10))
+            """)
+
+        self.assertCodeExecution("""
+            x = [1, 2, 3, 4]
+            print(x.index(2, 10, 20))
+            """)
+
+        self.assertCodeExecution("""
+            x = [1, 2, 3, 4]
+            print(x.index(2, 10, 0))
+            """)
+
+        self.assertCodeExecution("""
+            x = []
+            print(x.index(1, 0, 10))
+            """)
+
 
 class UnaryListOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'list'


### PR DESCRIPTION
This implements the following `list` type methods:

- `copy()`
- `index()`

Does it look good? Please let me know if there's anything I can improve.