### PR TITLE
Fix incorrect tuple.__lt__ implementation

### DIFF
--- a/python/common/org/python/types/Tuple.java
+++ b/python/common/org/python/types/Tuple.java
@@ -103,20 +103,23 @@ public class Tuple extends org.python.types.Object {
             int otherSize = otherTuple.value.size();
             int count = Math.min(size, otherSize);
 
-            boolean cmp = false;
             for (int i = 0; i < count; i++) {
                 org.python.types.Bool b =
                     (org.python.types.Bool) this.value.get(i).__lt__(otherTuple.value.get(i));
-
-                cmp = cmp & b.value;
+                org.python.types.Bool b2 =
+                    (org.python.types.Bool) otherTuple.value.get(i).__lt__(this.value.get(i));
+                if (b.value) {
+                    return new org.python.types.Bool(true);
+                } else if (b2.value) {
+                    return new org.python.types.Bool(false);
+                }
             }
 
-            if (cmp) {
-                return new org.python.types.Bool(cmp);
+            if (size == otherSize) {
+                return new org.python.types.Bool(false);
+            } else {
+                return new org.python.types.Bool(size < otherSize);
             }
-
-            // At this point the lists are different sizes or every comparison is true.
-            return new org.python.types.Bool(size < otherSize);
 
         } else {
             throw new org.python.exceptions.TypeError(

--- a/tests/datatypes/test_tuple.py
+++ b/tests/datatypes/test_tuple.py
@@ -115,7 +115,6 @@ class BinaryTupleOperationTests(BinaryOperationTestCase, TranspileTestCase):
 
         'test_lt_class',
         'test_lt_frozenset',
-        'test_lt_tuple',
 
         'test_modulo_class',
         'test_modulo_complex',

--- a/tests/datatypes/test_tuple.py
+++ b/tests/datatypes/test_tuple.py
@@ -64,6 +64,18 @@ class TupleTests(TranspileTestCase):
             print(x[-10])
             """)
 
+    def test_lt(self):
+        self.assertCodeExecution("""
+            pairs = [
+                (1, 2, 3), (3, 2, 1),
+                (1, 2, 1), (1, 2, 4),
+                (1, 2, 3, 4), (1, 2, 3, 0)
+            ]
+            for p1 in pairs:
+                for p2 in pairs:
+                    print(p1, "<", p2, ":", p1 < p2)
+            """, run_in_function=False)
+
 
 class UnaryTupleOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'tuple'


### PR DESCRIPTION
The current implementation of ``Tuple.__lt__`` is sadly plain wrong. I added a number of testcases and a working implementation. The implementation makes twice as many ``__lt__`` calls to the tuple members, but I don't see a clever way around that right now.