### PR TITLE
Introduce Range.RangeIterator to improve range behaviour

### DIFF
--- a/python/common/org/python/types/Range.java
+++ b/python/common/org/python/types/Range.java
@@ -1,7 +1,6 @@
 package org.python.types;
 
-public class Range extends org.python.types.Object implements org.python.Iterable {
-    private long index;
+public class Range extends org.python.types.Object {
     private long start;
     private long stop;
     private long step;
@@ -39,13 +38,10 @@ public class Range extends org.python.types.Object implements org.python.Iterabl
             throw new org.python.exceptions.ValueError("range() arg 3 must not be zero");
         }
         this.__dict__.put("step", step);
-
-        index = this.start;
-        // value = __dict__;
     }
 
     @org.python.Method(
-            __doc__ = "Implement iter(self)."
+            __doc__ = "Implement repr(self)."
     )
     public org.python.Object __repr__() {
         if (this.step == 1) {
@@ -66,22 +62,7 @@ public class Range extends org.python.types.Object implements org.python.Iterabl
             __doc__ = "Implement iter(self)."
     )
     public org.python.Iterable __iter__() {
-        return this;
-    }
-
-    @org.python.Method(
-            __doc__ = "Implement iter(self)."
-    )
-    public org.python.Object __next__() {
-        if (this.step > 0 && this.index >= this.stop) {
-            throw new org.python.exceptions.StopIteration();
-        } else if (this.step < 0 && this.index <= this.stop) {
-            throw new org.python.exceptions.StopIteration();
-        }
-
-        org.python.Object result = new org.python.types.Int(this.index);
-        this.index += this.step;
-        return result;
+        return new RangeIterator(start, stop, step);
     }
 
     @org.python.Method(
@@ -206,5 +187,74 @@ public class Range extends org.python.types.Object implements org.python.Iterabl
     )
     public org.python.Object __le__(org.python.Object other) {
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
+    }
+
+    public class RangeIterator extends org.python.types.Object implements org.python.Iterable {
+
+        public static final java.lang.String PYTHON_TYPE_NAME = "range_iterator";
+
+        private long index;
+
+        private long start;
+        private long stop;
+        private long step;
+
+        public RangeIterator(long start, long stop, long step) {
+            super();
+            this.start = start;
+            this.stop = stop;
+            this.step = step;
+            index = this.start;
+        }
+
+        @org.python.Method(
+                __doc__ = ""
+        )
+        public org.python.Object __iadd__(org.python.Object other) {
+            throw new org.python.exceptions.TypeError("unsupported operand type(s) for +=: 'range_iterator' and '" + other.typeName() + "'");
+        }
+
+        @org.python.Method(
+                 __doc__ = "Implement iter(self)."
+        )
+        public org.python.Iterable __iter__() {
+            return this;
+        }
+
+        @org.python.Method(
+                __doc__ = "Implement next(self)."
+        )
+        public org.python.Object __next__() {
+            if (this.step > 0 && this.index >= this.stop) {
+                throw new org.python.exceptions.StopIteration();
+            } else if (this.step < 0 && this.index <= this.stop) {
+                throw new org.python.exceptions.StopIteration();
+            }
+
+            org.python.Object result = new org.python.types.Int(this.index);
+            this.index += this.step;
+            return result;
+        }
+
+        @org.python.Method(
+                __doc__ = ""
+        )
+        public org.python.Object __invert__() {
+            throw new org.python.exceptions.TypeError("bad operand type for unary ~: 'range'");
+        }
+
+        @org.python.Method(
+                __doc__ = ""
+        )
+        public org.python.Object __neg__() {
+            throw new org.python.exceptions.TypeError("bad operand type for unary -: 'range'");
+        }
+
+        @org.python.Method(
+                __doc__ = ""
+        )
+        public org.python.Object __pos__() {
+            throw new org.python.exceptions.TypeError("bad operand type for unary +: 'range'");
+        }
     }
 }

--- a/tests/datatypes/test_range.py
+++ b/tests/datatypes/test_range.py
@@ -64,6 +64,22 @@ class RangeTests(TranspileTestCase):
             print(len(range(0, 5, -1)))
         """)
 
+    def test_multiple_iterators(self):
+        self.assertCodeExecution("""
+            r = range(0, 10)
+            print(list(r))
+            print(list(r))
+        """)
+
+    def test_iterator_iterator(self):
+        self.assertCodeExecution("""
+            r = range(0, 10)
+            i = iter(r)
+            print(next(i))
+            print(next(iter(i)))
+            print(r)
+        """)
+
 
 class UnaryRangeOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'range'


### PR DESCRIPTION
Currently, the ``Range`` class in VOC is an iterator itself. In CPython it is not, but ``Range.__iter__()`` returns a ``<range_iterator object at 0x…>``, which is. The main difference in behaviour can be seen for example by:

CPython:
```
>>> r = range(8)
>>> list(r)
[0, 1, 2, 3, 4, 5, 6, 7]
>>> list(r)
[0, 1, 2, 3, 4, 5, 6, 7]
```

VOC (before this PR):
```
>>> r = range(8)
>>> list(r)
[0, 1, 2, 3, 4, 5, 6, 7]
>>> list(r)
[]
```