### PR TITLE
Add implementation for str's index, find and count methods, fix list's and str's __getitem__

### DIFF
--- a/python/common/org/python/types/List.java
+++ b/python/common/org/python/types/List.java
@@ -280,14 +280,14 @@ public class List extends org.python.types.Object {
                 } else {
                     long start;
                     if (slice.start != null) {
-                        start = slice.start.value;
+                        start = Math.min(slice.start.value, this.value.size());
                     } else {
                         start = 0;
                     }
 
                     long stop;
                     if (slice.stop != null) {
-                        stop = slice.stop.value;
+                        stop = Math.min(slice.stop.value, this.value.size());
                     } else {
                         stop = this.value.size();
                     }

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -545,11 +545,32 @@ public class Str extends org.python.types.Object {
         throw new org.python.exceptions.NotImplementedError("format_map() has not been implemented.");
     }
 
+    private int toPositiveIndex(int index) {
+        if (index < 0) {
+            return this.value.length() + index;
+        }
+        return index;
+    }
+
     @org.python.Method(
-        __doc__ = ""
+        __doc__ = "S.index(sub[, start[, end]]) -> int\n\nLike S.find() but raise ValueError when the substring is not found.",
+        args = {"item"},
+        default_args = {"start", "end"}
     )
-    public org.python.Object index() {
-        throw new org.python.exceptions.NotImplementedError("index() has not been implemented.");
+    public org.python.Object index(org.python.Object item, org.python.Object start, org.python.Object end) {
+        int iStart = 0, iEnd = this.value.length();
+        if (start != null) {
+            iStart = toPositiveIndex(((Long) ((Int) start).value).intValue());
+        }
+        if (end != null) {
+            iEnd = toPositiveIndex(((Long) ((Int) end).value).intValue());
+            iEnd = Math.min(iEnd, this.value.length());
+        }
+        int foundAt = this.value.substring(iStart, iEnd).indexOf(((Str) item).value);
+        if (foundAt >= 0) {
+            return new Int(foundAt + iStart);
+        }
+        throw new org.python.exceptions.ValueError("substring not found");
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -207,14 +207,14 @@ public class Str extends org.python.types.Object {
                 else {
                     long start;
                     if (slice.start != null) {
-                        start = slice.start.value;
+                        start = Math.min(slice.start.value, this.value.length());
                     } else {
                         start = 0;
                     }
 
                     long stop;
                     if (slice.stop != null) {
-                        stop = slice.stop.value;
+                        stop = Math.min(slice.stop.value, this.value.length());
                     } else {
                         stop = this.value.length();
                     }

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -497,10 +497,20 @@ public class Str extends org.python.types.Object {
     }
 
     @org.python.Method(
-        __doc__ = ""
+        __doc__ = "",
+        args = {"item"},
+        default_args = {"sub", "end"}
     )
-    public org.python.Object count() {
-        throw new org.python.exceptions.NotImplementedError("count() has not been implemented.");
+    public org.python.Object count(org.python.Object sub, org.python.Object start, org.python.Object end) {
+        String sub_str = ((Str) sub).toString();
+        if (start == null) {
+            start = new Int(0);
+        }
+        if (end == null) {
+            end = new Int(this.value.length());
+        }
+        String original = this.__getitem__(new Slice(start, end)).toString();
+        return new Int((original.length() - original.replace(sub_str, "").length()) / sub_str.length());
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -536,10 +536,22 @@ public class Str extends org.python.types.Object {
     }
 
     @org.python.Method(
-        __doc__ = ""
+        __doc__ = "S.find(sub[, start[, end]]) -> int",
+        args = {"item"},
+        default_args = {"start", "end"}
     )
-    public org.python.Object find() {
-        throw new org.python.exceptions.NotImplementedError("find() has not been implemented.");
+    public org.python.Object find(org.python.Object item, org.python.Object start, org.python.Object end) {
+        if (start == null) {
+            start = new Int(0);
+        }
+        if (end == null) {
+            end = new Int(this.value.length());
+        }
+        int foundAt = this.__getitem__(new Slice(start, end)).toString().indexOf(item.toString());
+        if (foundAt >= 0) {
+            return new Int(foundAt + toPositiveIndex(((Int) start).value));
+        }
+        return new Int(foundAt);
     }
 
     @org.python.Method(
@@ -569,17 +581,12 @@ public class Str extends org.python.types.Object {
         default_args = {"start", "end"}
     )
     public org.python.Object index(org.python.Object item, org.python.Object start, org.python.Object end) {
-        if (start == null) {
-            start = new Int(0);
+        org.python.Object foundAt = this.find(item, start, end);
+        if (((Int)foundAt).value < 0) {
+            throw new org.python.exceptions.ValueError("substring not found");
+        } else {
+            return foundAt;
         }
-        if (end == null) {
-            end = new Int(this.value.length());
-        }
-        int foundAt = this.__getitem__(new Slice(start, end)).toString().indexOf(item.toString());
-        if (foundAt >= 0) {
-            return new Int(foundAt + toPositiveIndex(((Int) start).value));
-        }
-        throw new org.python.exceptions.ValueError("substring not found");
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -207,14 +207,14 @@ public class Str extends org.python.types.Object {
                 else {
                     long start;
                     if (slice.start != null) {
-                        start = Math.min(slice.start.value, this.value.length());
+                        start = toPositiveIndex(Math.min(slice.start.value, this.value.length()));
                     } else {
                         start = 0;
                     }
 
                     long stop;
                     if (slice.stop != null) {
-                        stop = Math.min(slice.stop.value, this.value.length());
+                        stop = toPositiveIndex(Math.min(slice.stop.value, this.value.length()));
                     } else {
                         stop = this.value.length();
                     }
@@ -510,6 +510,7 @@ public class Str extends org.python.types.Object {
             end = new Int(this.value.length());
         }
         String original = this.__getitem__(new Slice(start, end)).toString();
+
         return new Int((original.length() - original.replace(sub_str, "").length()) / sub_str.length());
     }
 
@@ -555,7 +556,7 @@ public class Str extends org.python.types.Object {
         throw new org.python.exceptions.NotImplementedError("format_map() has not been implemented.");
     }
 
-    private int toPositiveIndex(int index) {
+    private long toPositiveIndex(long index) {
         if (index < 0) {
             return this.value.length() + index;
         }
@@ -568,17 +569,15 @@ public class Str extends org.python.types.Object {
         default_args = {"start", "end"}
     )
     public org.python.Object index(org.python.Object item, org.python.Object start, org.python.Object end) {
-        int iStart = 0, iEnd = this.value.length();
-        if (start != null) {
-            iStart = toPositiveIndex(((Long) ((Int) start).value).intValue());
+        if (start == null) {
+            start = new Int(0);
         }
-        if (end != null) {
-            iEnd = toPositiveIndex(((Long) ((Int) end).value).intValue());
-            iEnd = Math.min(iEnd, this.value.length());
+        if (end == null) {
+            end = new Int(this.value.length());
         }
-        int foundAt = this.value.substring(iStart, iEnd).indexOf(((Str) item).value);
+        int foundAt = this.__getitem__(new Slice(start, end)).toString().indexOf(item.toString());
         if (foundAt >= 0) {
-            return new Int(foundAt + iStart);
+            return new Int(foundAt + toPositiveIndex(((Int) start).value));
         }
         throw new org.python.exceptions.ValueError("substring not found");
     }

--- a/tests/datatypes/test_list.py
+++ b/tests/datatypes/test_list.py
@@ -149,6 +149,18 @@ class ListTests(TranspileTestCase):
             print(x[1:4])
             """)
 
+        # Slice bound in both directions with end out of bounds
+        self.assertCodeExecution("""
+            x = [1, 2, 3, 4, 5]
+            print(x[1:6])
+            """)
+
+        # Slice bound in both directions with start out of bounds
+        self.assertCodeExecution("""
+            x = [1, 2, 3, 4, 5]
+            print(x[6:7])
+            """)
+
     def test_count(self):
         # Normal Count
         self.assertCodeExecution("""

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -1,3 +1,4 @@
+
 from .. utils import TranspileTestCase, UnaryOperationTestCase, BinaryOperationTestCase, InplaceOperationTestCase
 
 
@@ -74,6 +75,42 @@ class StrTests(TranspileTestCase):
                 # print(s.swap())
                 # print(s.title())
                 print(s.upper())
+            """)
+
+    def test_index(self):
+        self.assertCodeExecution("""
+            s = 'hello hell'
+            print(s.index('hell'))
+            """)
+
+        self.assertCodeExecution("""
+            s = 'hello hell'
+            print(s.index('world'))
+            """)
+
+        self.assertCodeExecution("""
+            s = 'hello hell'
+            print(s.index('hell', 1))
+            """)
+
+        self.assertCodeExecution("""
+            s = 'hello hell'
+            print(s.index('hell', 1, 3))
+            """)
+
+        self.assertCodeExecution("""
+            s = 'hello hell'
+            print(s.index('hell', 1, 100))
+            """)
+
+        self.assertCodeExecution("""
+            s = 'hello hell'
+            print(s.index('hell', 1, -1))
+            """)
+
+        self.assertCodeExecution("""
+            s = 'hello hell'
+            print(s.index('hell', -4))
             """)
 
 

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -20,51 +20,63 @@ class StrTests(TranspileTestCase):
     def test_getitem(self):
         # Simple positive index
         self.assertCodeExecution("""
-            x = [1, 2, 3, 4, 5]
+            x = "12345"
             print(x[2])
             """)
 
         # Simple negative index
         self.assertCodeExecution("""
-            x = [1, 2, 3, 4, 5]
+            x = "12345"
             print(x[-2])
             """)
 
         # Positive index out of range
         self.assertCodeExecution("""
-            x = [1, 2, 3, 4, 5]
+            x = "12345"
             print(x[10])
             """)
 
         # Negative index out of range
         self.assertCodeExecution("""
-            x = [1, 2, 3, 4, 5]
+            x = "12345"
             print(x[-10])
             """)
 
     def test_slice(self):
         # Full slice
         self.assertCodeExecution("""
-            x = [1, 2, 3, 4, 5]
+            x = "12345"
             print(x[:])
             """)
 
         # Left bound slice
         self.assertCodeExecution("""
-            x = [1, 2, 3, 4, 5]
+            x = "12345"
             print(x[1:])
             """)
 
         # Right bound slice
         self.assertCodeExecution("""
-            x = [1, 2, 3, 4, 5]
+            x = "12345"
             print(x[:4])
             """)
 
         # Slice bound in both directions
         self.assertCodeExecution("""
-            x = [1, 2, 3, 4, 5]
+            x = "12345"
             print(x[1:4])
+            """)
+
+        # Slice bound in both directions with end out of bounds
+        self.assertCodeExecution("""
+            x = "12345"
+            print(x[1:6])
+            """)
+
+        # Slice bound in both directions with start out of bounds
+        self.assertCodeExecution("""
+            x = "12345"
+            print(x[6:7])
             """)
 
     def test_case_changes(self):

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -161,6 +161,16 @@ class StrTests(TranspileTestCase):
             print(s.count('ll', 0, 100))
             """)
 
+        self.assertCodeExecution("""
+            s = 'hello hell'
+            print(s.count('hell', 1, -1))
+            """)
+
+        self.assertCodeExecution("""
+            s = 'hello hell'
+            print(s.count('hell', -4))
+            """)
+
 
 class UnaryStrOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'str'

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -113,6 +113,37 @@ class StrTests(TranspileTestCase):
             print(s.index('hell', -4))
             """)
 
+    def test_count(self):
+        self.assertCodeExecution("""
+            s = 'hello hell'
+            print(s.count('e'))
+            """)
+
+        self.assertCodeExecution("""
+            s = 'hello hell'
+            print(s.count('a'))
+            """)
+
+        self.assertCodeExecution("""
+            s = 'hello hell'
+            print(s.count('ll'))
+            """)
+
+        self.assertCodeExecution("""
+            s = 'hello hell'
+            print(s.count('ll', 3))
+            """)
+
+        self.assertCodeExecution("""
+            s = 'hello hell'
+            print(s.count('ll', 3, 4))
+            """)
+
+        self.assertCodeExecution("""
+            s = 'hello hell'
+            print(s.count('ll', 0, 4))
+            """)
+
 
 class UnaryStrOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'str'

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -171,6 +171,42 @@ class StrTests(TranspileTestCase):
             print(s.count('hell', -4))
             """)
 
+    def test_find(self):
+        self.assertCodeExecution("""
+            s = 'hello hell'
+            print(s.find('hell'))
+            """)
+
+        self.assertCodeExecution("""
+            s = 'hello hell'
+            print(s.find('world'))
+            """)
+
+        self.assertCodeExecution("""
+            s = 'hello hell'
+            print(s.find('hell', 1))
+            """)
+
+        self.assertCodeExecution("""
+            s = 'hello hell'
+            print(s.find('hell', 1, 3))
+            """)
+
+        self.assertCodeExecution("""
+            s = 'hello hell'
+            print(s.find('hell', 1, 100))
+            """)
+
+        self.assertCodeExecution("""
+            s = 'hello hell'
+            print(s.find('hell', 1, -1))
+            """)
+
+        self.assertCodeExecution("""
+            s = 'hello hell'
+            print(s.find('hell', -4))
+            """)
+
 
 class UnaryStrOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'str'

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -156,6 +156,11 @@ class StrTests(TranspileTestCase):
             print(s.count('ll', 0, 4))
             """)
 
+        self.assertCodeExecution("""
+            s = 'hello hell'
+            print(s.count('ll', 0, 100))
+            """)
+
 
 class UnaryStrOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'str'


### PR DESCRIPTION
This introduces the implementation the following `str` methods:
- `index`
- `find`
- `count`

Besides that, it does:
- fix test_str.py's `test_getitem` to test strings instead of lists;
- fix `str.__getitem__` and `list.__getitem__` to handle `start` and/or `end` out of bounds;
- add out of bounds tests for test_list.py's `test_slice`.