### PR TITLE
Add workaround to avoid builds timing out b/c of no output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ install:
   - "pip install ."
   - "ant java"
 script:
-  - "python setup.py test -q"
+  - travis_wait "python setup.py test -q"


### PR DESCRIPTION
Hey, just trying out to add [the workaround documented here](https://docs.travis-ci.com/user/common-build-problems/#My-builds-are-timing-out) to avoid builds timing out while keeping the output terse.