### PR TITLE
Fixed test_endswith tests (passing wrong variable name)

### DIFF
--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -14,25 +14,31 @@ class StrTests(TranspileTestCase):
     def test_endswith(self):
         self.assertCodeExecution("""
             s = "abracadabra"
-            end = "abra"
-            print(s.endswith(end))
+            suffix = "abra"
+            print(s.endswith(suffix))
             """)
 
         self.assertCodeExecution("""
             s = "abracadabra"
-            end = "ABRA"
-            print(s.endswith(end))
+            suffix = "ABRA"
+            print(s.endswith(suffix))
             """)
 
         self.assertCodeExecution("""
             s = "ABRACADABRA"
-            end = "abra"
-            print(s.endswith(end))
+            suffix = "abra"
+            print(s.endswith(suffix))
             """)
 
-        # self.assertCodeExecution("""
-        #     print('abracadabra'.endswith('abra'))
-        #     """)
+        self.assertCodeExecution("""
+            print('abracadabra'.endswith('abra'))
+            """)
+
+        self.assertCodeExecution("""
+            s = "ABRACADABRA"
+            suffix = ""
+            print(s.endswith(suffix))            
+            """)
 
     def test_getattr(self):
         self.assertCodeExecution("""


### PR DESCRIPTION
Fixed test_endswith tests (variable 'end' wasn't setted properly). Also, was created a new test case with an empty string.