### PR TITLE
Add implementation for many set methods

### DIFF
--- a/python/common/org/python/types/Set.java
+++ b/python/common/org/python/types/Set.java
@@ -434,10 +434,14 @@ public class Set extends org.python.types.Object {
     }
 
     @org.python.Method(
-        __doc__ = ""
+        __doc__ = "Remove an element from a set; it must be a member.\n\nIf the element is not a member, raise a KeyError.",
+        args = {"item"}
     )
-    public org.python.Object remove(org.python.Object other) {
-        throw new org.python.exceptions.NotImplementedError("remove() has not been implemented.");
+    public org.python.Object remove(org.python.Object item) {
+        if (!this.value.remove(item)) {
+            throw new org.python.exceptions.KeyError(item);
+        }
+        return org.python.types.NoneType.NONE;
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Set.java
+++ b/python/common/org/python/types/Set.java
@@ -380,10 +380,13 @@ public class Set extends org.python.types.Object {
     }
 
     @org.python.Method(
-        __doc__ = ""
+        __doc__ = "Return the intersection of two sets as a new set.\n\n(i.e. all elements that are in both sets.)",
+        args = {"other"}
     )
     public org.python.Object intersection(org.python.Object other) {
-        throw new org.python.exceptions.NotImplementedError("intersection() has not been implemented.");
+        java.util.Set set = ((Set) this.copy()).value;
+        set.retainAll(((Set) other).value);
+        return new Set(set);
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Set.java
+++ b/python/common/org/python/types/Set.java
@@ -459,10 +459,13 @@ public class Set extends org.python.types.Object {
     }
 
     @org.python.Method(
-        __doc__ = ""
+        __doc__ = "Return the union of sets as a new set.\n\n(i.e. all elements that are in either set.)",
+        args = {"other"}
     )
     public org.python.Object union(org.python.Object other) {
-        throw new org.python.exceptions.NotImplementedError("union() has not been implemented.");
+        java.util.Set set = ((Set) this.copy()).value;
+        set.addAll(((Set) other).value);
+        return new Set(set);
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Set.java
+++ b/python/common/org/python/types/Set.java
@@ -357,10 +357,12 @@ public class Set extends org.python.types.Object {
     }
 
     @org.python.Method(
-        __doc__ = ""
+        __doc__ = "Remove all elements of another set from this set.",
+        args = {"other"}
     )
     public org.python.Object difference_update(org.python.Object other) {
-        throw new org.python.exceptions.NotImplementedError("difference_update() has not been implemented.");
+        this.value.removeAll(((Set) other).value);
+        return org.python.types.NoneType.NONE;
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Set.java
+++ b/python/common/org/python/types/Set.java
@@ -347,10 +347,13 @@ public class Set extends org.python.types.Object {
     }
 
     @org.python.Method(
-        __doc__ = ""
+        __doc__ = "Return the difference of two or more sets as a new set.\n\n(i.e. all elements that are in this set but not the others.)",
+        args = {"other"}
     )
     public org.python.Object difference(org.python.Object other) {
-        throw new org.python.exceptions.NotImplementedError("difference() has not been implemented.");
+        java.util.Set set = ((Set) this.copy()).value;
+        set.removeAll(((Set) other).value);
+        return new Set(set);
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Set.java
+++ b/python/common/org/python/types/Set.java
@@ -392,10 +392,12 @@ public class Set extends org.python.types.Object {
     }
 
     @org.python.Method(
-        __doc__ = ""
+        __doc__ = "Update a set with the intersection of itself and another.",
+        args = {"other"}
     )
     public org.python.Object intersection_update(org.python.Object other) {
-        throw new org.python.exceptions.NotImplementedError("intersection_update() has not been implemented.");
+        this.value.retainAll(((Set) other).value);
+        return org.python.types.NoneType.NONE;
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Set.java
+++ b/python/common/org/python/types/Set.java
@@ -340,10 +340,10 @@ public class Set extends org.python.types.Object {
     }
 
     @org.python.Method(
-        __doc__ = ""
+        __doc__ = "Return a shallow copy of a set."
     )
     public org.python.Object copy() {
-        throw new org.python.exceptions.NotImplementedError("copy() has not been implemented.");
+        return new Set(new java.util.HashSet<org.python.Object>(this.value));
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Set.java
+++ b/python/common/org/python/types/Set.java
@@ -364,10 +364,12 @@ public class Set extends org.python.types.Object {
     }
 
     @org.python.Method(
-        __doc__ = ""
+        __doc__ = "Remove an element from a set if it is a member.\n\nIf the element is not a member, do nothing.",
+        args = {"item"}
     )
-    public org.python.Object discard(org.python.Object other) {
-        throw new org.python.exceptions.NotImplementedError("discard() has not been implemented.");
+    public org.python.Object discard(org.python.Object item) {
+        this.value.remove(item);
+        return org.python.types.NoneType.NONE;
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Set.java
+++ b/python/common/org/python/types/Set.java
@@ -473,9 +473,11 @@ public class Set extends org.python.types.Object {
     }
 
     @org.python.Method(
-        __doc__ = ""
+        __doc__ = "Update a set with the union of itself and others.",
+        args = {"other"}
     )
     public org.python.Object update(org.python.Object other) {
-        throw new org.python.exceptions.NotImplementedError("update() has not been implemented.");
+        this.value.addAll(((Set) other).value);
+        return org.python.types.NoneType.NONE;
     }
 }

--- a/tests/datatypes/test_set.py
+++ b/tests/datatypes/test_set.py
@@ -147,6 +147,14 @@ class SetTests(TranspileTestCase):
             print(x)
             """)
 
+    def test_update(self):
+        self.assertCodeExecution("""
+            x = {1, 2, 3}
+            y = {3, 4, 5}
+            print(x.update(y))
+            print(x)
+            """)
+
 
 class UnarySetOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'set'

--- a/tests/datatypes/test_set.py
+++ b/tests/datatypes/test_set.py
@@ -116,6 +116,14 @@ class SetTests(TranspileTestCase):
             print(x)
             """)
 
+    def test_union(self):
+        self.assertCodeExecution("""
+            x = {1, 2, 3}
+            y = {3, 4, 5}
+            z = x.union(y)
+            print(z)
+            """)
+
 
 class UnarySetOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'set'

--- a/tests/datatypes/test_set.py
+++ b/tests/datatypes/test_set.py
@@ -139,6 +139,14 @@ class SetTests(TranspileTestCase):
             print(x)
             """)
 
+    def test_intersection_update(self):
+        self.assertCodeExecution("""
+            x = {1, 2, 3}
+            y = {3, 4, 5}
+            x.intersection_update(y)
+            print(x)
+            """)
+
 
 class UnarySetOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'set'

--- a/tests/datatypes/test_set.py
+++ b/tests/datatypes/test_set.py
@@ -108,6 +108,14 @@ class SetTests(TranspileTestCase):
             print(z)
             """)
 
+    def test_remove(self):
+        self.assertCodeExecution("""
+            x = {1, 2, 3}
+            x.remove(1)
+            x.remove(4)
+            print(x)
+            """)
+
 
 class UnarySetOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'set'

--- a/tests/datatypes/test_set.py
+++ b/tests/datatypes/test_set.py
@@ -84,6 +84,15 @@ class SetTests(TranspileTestCase):
             print(x.pop() is y.pop())
             """)
 
+    def test_difference(self):
+        self.assertCodeExecution("""
+            x = {1, 2, 3}
+            y = {3, 4, 5}
+            z = x.difference(y)
+            print(z)
+            """)
+
+
 
 class UnarySetOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'set'

--- a/tests/datatypes/test_set.py
+++ b/tests/datatypes/test_set.py
@@ -69,6 +69,21 @@ class SetTests(TranspileTestCase):
             print(y in x)
         """)
 
+    def test_copy(self):
+        self.assertCodeExecution("""
+            x = {1, 2, 3}
+            y = x.copy()
+            print(x == y)
+            print(x is not y)
+            """)
+
+        # ensures that it did a shallow copy
+        self.assertCodeExecution("""
+            x = {(1, 2, 3)}
+            y = x.copy()
+            print(x.pop() is y.pop())
+            """)
+
 
 class UnarySetOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'set'

--- a/tests/datatypes/test_set.py
+++ b/tests/datatypes/test_set.py
@@ -124,6 +124,14 @@ class SetTests(TranspileTestCase):
             print(z)
             """)
 
+    def test_difference_update(self):
+        self.assertCodeExecution("""
+            x = {1, 2, 3}
+            y = {3, 4, 5}
+            x.difference_update(y)
+            print(x)
+            """)
+
 
 class UnarySetOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'set'

--- a/tests/datatypes/test_set.py
+++ b/tests/datatypes/test_set.py
@@ -100,7 +100,13 @@ class SetTests(TranspileTestCase):
             print(x)
             """)
 
-
+    def test_intersection(self):
+        self.assertCodeExecution("""
+            x = {1, 2, 3}
+            y = {3, 4, 5}
+            z = x.intersection(y)
+            print(z)
+            """)
 
 
 class UnarySetOperationTests(UnaryOperationTestCase, TranspileTestCase):

--- a/tests/datatypes/test_set.py
+++ b/tests/datatypes/test_set.py
@@ -108,6 +108,13 @@ class SetTests(TranspileTestCase):
             print(z)
             """)
 
+        self.assertCodeExecution("""
+            x = {1, 2, 3}
+            y = {4, 5}
+            z = x.intersection(y)
+            print(z)
+            """)
+
     def test_remove(self):
         self.assertCodeExecution("""
             x = {1, 2, 3}

--- a/tests/datatypes/test_set.py
+++ b/tests/datatypes/test_set.py
@@ -92,6 +92,15 @@ class SetTests(TranspileTestCase):
             print(z)
             """)
 
+    def test_discard(self):
+        self.assertCodeExecution("""
+            x = {1, 2, 3}
+            x.discard(1)
+            x.discard(4)
+            print(x)
+            """)
+
+
 
 
 class UnarySetOperationTests(UnaryOperationTestCase, TranspileTestCase):

--- a/tests/datatypes/test_set.py
+++ b/tests/datatypes/test_set.py
@@ -89,6 +89,8 @@ class SetTests(TranspileTestCase):
             x = {1, 2, 3}
             y = {3, 4, 5}
             z = x.difference(y)
+            print(x)
+            print(y)
             print(z)
             """)
 
@@ -105,6 +107,8 @@ class SetTests(TranspileTestCase):
             x = {1, 2, 3}
             y = {3, 4, 5}
             z = x.intersection(y)
+            print(x)
+            print(y)
             print(z)
             """)
 
@@ -112,6 +116,8 @@ class SetTests(TranspileTestCase):
             x = {1, 2, 3}
             y = {4, 5}
             z = x.intersection(y)
+            print(x)
+            print(y)
             print(z)
             """)
 
@@ -128,6 +134,8 @@ class SetTests(TranspileTestCase):
             x = {1, 2, 3}
             y = {3, 4, 5}
             z = x.union(y)
+            print(x)
+            print(y)
             print(z)
             """)
 


### PR DESCRIPTION
This implements the following methods for sets:

- `set.copy`
- `set.difference`
- `set.discard`
- `set.intersection`
- `set.remove`
- `set.union`
- `set.difference_update`
- `set.intersection_update`
- `set.update`
