### PR TITLE
Switch to py.test to split tests without hardcoding all test paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,29 +3,28 @@ python:
   - "3.4.2"
   - "3.4.4"
 env:
-  - TEST_SUITE=tests.builtins
-  - TEST_SUITE=tests.datatypes.test_bool
-  - TEST_SUITE=tests.datatypes.test_bytearray
-  - TEST_SUITE=tests.datatypes.test_bytes
-  - TEST_SUITE=tests.datatypes.test_complex
-  - TEST_SUITE=tests.datatypes.test_dict
-  - TEST_SUITE=tests.datatypes.test_float
-  - TEST_SUITE=tests.datatypes.test_frozenset
-  - TEST_SUITE=tests.datatypes.test_int
-  - TEST_SUITE=tests.datatypes.test_list
-  - TEST_SUITE=tests.datatypes.test_NoneType
-  - TEST_SUITE=tests.datatypes.test_NotImplemented
-  - TEST_SUITE=tests.datatypes.test_range
-  - TEST_SUITE=tests.datatypes.test_set
-  - TEST_SUITE=tests.datatypes.test_slice
-  - TEST_SUITE=tests.datatypes.test_str
-  - TEST_SUITE=tests.datatypes.test_tuple
-  - TEST_SUITE=tests.stdlib
-  - TEST_SUITE=tests.structures
-  - TEST_SUITE=tests.test_codecs
-  - TEST_SUITE=tests.test_utils
+  - TEST_SUITE=tests/builtins
+  - TEST_SUITE=tests/datatypes/test_bool.py
+  - TEST_SUITE=tests/datatypes/test_bytearray.py
+  - TEST_SUITE=tests/datatypes/test_bytes.py
+  - TEST_SUITE=tests/datatypes/test_complex.py
+  - TEST_SUITE=tests/datatypes/test_dict.py
+  - TEST_SUITE=tests/datatypes/test_float.py
+  - TEST_SUITE=tests/datatypes/test_frozenset.py
+  - TEST_SUITE=tests/datatypes/test_int.py
+  - TEST_SUITE=tests/datatypes/test_list.py
+  - TEST_SUITE=tests/datatypes/test_NoneType.py
+  - TEST_SUITE=tests/datatypes/test_NotImplemented.py
+  - TEST_SUITE=tests/datatypes/test_range.py
+  - TEST_SUITE=tests/datatypes/test_set.py
+  - TEST_SUITE=tests/datatypes/test_slice.py
+  - TEST_SUITE=tests/datatypes/test_str.py
+  - TEST_SUITE=tests/datatypes/test_tuple.py
+  - TEST_SUITE=tests/stdlib
+  - TEST_SUITE=tests/structures
+  - TEST_SUITE=all-the-rest
 install:
   - "pip install ."
   - "ant java"
 script:
-  - "python setup.py test -q -s $TEST_SUITE"
+  - ./run_tests.sh

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+if [ "$TEST_SUITE" = "all-the-rest" ]; then
+    py.test $(grep TEST_SUITE= .travis.yml | grep -v all-the-rest | sed 's/^.*=/--ignore /' | paste -d' ' -s)
+else
+    py.test $TEST_SUITE
+fi


### PR DESCRIPTION
This makes concrete [my proposal in this comment](https://github.com/pybee/voc/pull/310#issuecomment-262117798).

This PR switches the build to py.test in order to be able to ignore tests explicitly listed in `.travis.yml` file given a special value of TEST_SUITE environment variable.

This allow us to run all tests in the build without having to hardcode all test paths.

I had to update also the TEST_SUITE values to make them point to files instead of modules.

What do you think?