### PR TITLE
Add initial support for Python>=3.5

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -4,8 +4,11 @@
   </description>
 
   <property environment="env"/>
-  <property name="python-version" value="3.4"/>
   <property name="release" value="2"/>
+  <exec executable="python" outputProperty="python-version">
+    <arg value="-c"/>
+    <arg value="import sys; print('.'.join(sys.version.split('.',3)[:2]))"/>
+  </exec>
 
   <condition property="build" value="${env.VOC_BUILD_DIR}" else="build">
     <isset property="env.VOC_BUILD_DIR" />

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import sys
 
-if sys.version_info[:2] != (3, 4):
+if sys.version_info[:2] < (3, 4):
     raise SystemExit("VOC requires Python 3.4+")
 
 import io


### PR DESCRIPTION
This allows VOC to work under Python 3.5. Some tests still fail
over minor differences between 3.4 and 3.5, but this solves the
major issue of change in the parsing of *args and **kwargs in
call sites.

Also: This is my first contribution which I see some depth in. When this is merged, I will consider myself worthy of a coin.