### PR TITLE
Fix immutability of tuples

### DIFF
--- a/python/common/org/python/types/Tuple.java
+++ b/python/common/org/python/types/Tuple.java
@@ -341,32 +341,9 @@ public class Tuple extends org.python.types.Object {
         __doc__ = ""
     )
     public void __setitem__(org.python.Object index, org.python.Object value) {
-        try {
-            int idx = (int) ((org.python.types.Int) index).value;
-            if (idx < 0) {
-                if (-idx > this.value.size()) {
-                    throw new org.python.exceptions.IndexError("tuple index out of range");
-                } else {
-                    this.value.set(this.value.size() + idx, value);
-                }
-            } else {
-                if (idx >= this.value.size()) {
-                    throw new org.python.exceptions.IndexError("tuple index out of range");
-                } else {
-                    this.value.set(idx, value);
-                }
-            }
-        } catch (ClassCastException e) {
-            if (org.Python.VERSION < 0x03050000) {
-                throw new org.python.exceptions.TypeError(
-                    "tuple indices must be integers, not " + index.typeName()
-                );
-            } else {
-                throw new org.python.exceptions.TypeError(
-                    "tuple indices must be integers or slices, not " + index.typeName()
-                );
-            }
-        }
+        throw new org.python.exceptions.TypeError(
+            "'tuple' object does not support item assignment"
+        );
     }
 
     @org.python.Method(

--- a/tests/datatypes/test_tuple.py
+++ b/tests/datatypes/test_tuple.py
@@ -79,9 +79,18 @@ class TupleTests(TranspileTestCase):
     def test_immutable(self):
         self.assertCodeExecution("""
             x = (1, 2)
-            x[0] = 3
-            x[-1] = 3
-            x[2] = 3
+            try:
+                x[0] = 3
+            except TypeError as err:
+                print(err)
+            try:
+                x[-1] = 3
+            except TypeError as err:
+                print(err)
+            try:
+                x[2] = 3
+            except TypeError as err:
+                print(err)
             """, run_in_function=False)
 
 

--- a/tests/datatypes/test_tuple.py
+++ b/tests/datatypes/test_tuple.py
@@ -76,6 +76,14 @@ class TupleTests(TranspileTestCase):
                     print(p1, "<", p2, ":", p1 < p2)
             """, run_in_function=False)
 
+    def test_immutable(self):
+        self.assertCodeExecution("""
+            x = (1, 2)
+            x[0] = 3
+            x[-1] = 3
+            x[2] = 3
+            """, run_in_function=False)
+
 
 class UnaryTupleOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'tuple'


### PR DESCRIPTION
Return a TypeError for all tuple item assignment attempts, regardless of whether the index used is valid or not.

Fixes #327 indirectly (fixing immutability instead of changing the internal type)