### PR TITLE
Remove special handling for mainline

### DIFF
--- a/tests/stdlib/test_sys.py
+++ b/tests/stdlib/test_sys.py
@@ -334,14 +334,13 @@ class SysModuleTests(TranspileTestCase):
             print(sys.exit())
             """, exits_early=True)
 
-    @expectedFailure
     def test_exit(self):
         # From inside main
         self.assertCodeExecution("""
             import sys
             if __name__ == '__main__':
                 print(sys.exit())
-            """, run_in_function=False)
+            """, run_in_function=False, exits_early=True)
 
         # From a method called from inside main
         self.assertCodeExecution("""
@@ -352,7 +351,7 @@ class SysModuleTests(TranspileTestCase):
 
             if __name__ == '__main__':
                 foo()
-            """, run_in_function=False)
+            """, run_in_function=False, exits_early=True)
 
     ############################################################
     # flags

--- a/tests/structures/test_function.py
+++ b/tests/structures/test_function.py
@@ -1,7 +1,5 @@
 from ..utils import TranspileTestCase
 
-from unittest import expectedFailure
-
 
 class FunctionTests(TranspileTestCase):
     def test_function(self):
@@ -41,7 +39,6 @@ class FunctionTests(TranspileTestCase):
             myfunc(5)
             """)
 
-    @expectedFailure
     def test_mainline(self):
         self.assertCodeExecution("""
             if __name__ == '__main__':

--- a/tests/structures/test_import.py
+++ b/tests/structures/test_import.py
@@ -35,6 +35,31 @@ class ImportTests(TranspileTestCase):
                     """
             })
 
+    def test_import_module_main(self):
+        "You can import a Python module with if __name__ == '__main__'"
+        self.assertCodeExecution(
+            """
+            import example
+
+            print('A')
+
+            if __name__ == "__main__":
+                print('main')
+
+            print('B')
+            """,
+            extra_code={
+                'example':
+                    """
+                    print('C')
+
+                    if __name__ == "__main__":
+                        print('example main')
+
+                    print('D')
+                    """
+            })
+
     def test_multiple_module_import(self):
         "You can import a multiple Python modules implemented in Python"
         self.assertCodeExecution(


### PR DESCRIPTION
- Now that the module’s `__name__` is set to `"__main__"` in the Java main method, remove the special handling for the “main if” block.
- Add a test for this behavior, and mark other tests as passing. Two (of three) tests marked as expected failure in #344 are now back to passing.

Fixes #346 