### PR TITLE
Add implementation of with statement (closes #300)

### DIFF
--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -979,21 +979,4 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
     public org.python.Object __round__(org.python.Object ndigits) {
         throw new org.python.exceptions.AttributeError(this, "__round__");
     }
-
-    /**
-     * Section 3.3.8 - With statement context
-     */
-    @org.python.Method(
-        __doc__ = ""
-    )
-    public org.python.Object __enter__() {
-        throw new org.python.exceptions.AttributeError(this, "__enter__");
-    }
-
-    @org.python.Method(
-        __doc__ = ""
-    )
-    public org.python.Object __exit__(org.python.Object exc_type, org.python.Object exc_value, org.python.Object traceback) {
-        throw new org.python.exceptions.AttributeError(this, "__exit__");
-    }
 }

--- a/tests/structures/test_for.py
+++ b/tests/structures/test_for.py
@@ -113,7 +113,6 @@ class ForLoopTests(TranspileTestCase):
                 print(x, y, z)
             """)
 
-    @expectedFailure
     def test_multiple_values_iterator(self):
         self.assertCodeExecution("""
             values = {
@@ -121,9 +120,9 @@ class ForLoopTests(TranspileTestCase):
                 'b': 2,
                 'c': 3,
             }
-            for k, v in values.items():
+            for k, v in sorted(values.items()):
                 print(k, v)
             print('And once again...')
-            for item in values.items():
+            for item in sorted(values.items()):
                 print(item[0], item[1])
             """)

--- a/tests/structures/test_with.py
+++ b/tests/structures/test_with.py
@@ -9,7 +9,7 @@ class WithLoopTests(TranspileTestCase):
                     print('entering CtxMgr')
                     return 42
                 def __exit__(self, *args):
-                    print('exiting CtxMgr')
+                    print('exiting CtxMgr', args)
 
             with CtxMgr() as val:
                 print('val', val)
@@ -20,15 +20,19 @@ class WithLoopTests(TranspileTestCase):
             """)
 
     def test_with_body_fails(self):
+        # TODO: add support for exc_type and traceback information
         self.assertCodeExecution("""
             class CtxMgr:
                 def __enter__(self):
                     print('entering CtxMgr')
-                def __exit__(self, *args):
+                def __exit__(self, exc_type, exc_value, traceback):
                     print('exiting CtxMgr')
+                    # print('exc_type', exc_type)
+                    print('exc_value', exc_value)
+                    # print('traceback', traceback)
 
             with CtxMgr():
-                raise ValueError
+                raise KeyError('ola')
             """)
 
     def test_with_noexit(self):

--- a/tests/structures/test_with.py
+++ b/tests/structures/test_with.py
@@ -19,18 +19,17 @@ class WithLoopTests(TranspileTestCase):
                 print('in another ctx, val now is', val)
             """)
 
-    # TODO: make this test pass
-    # def test_with_body_fails(self):
-    #     self.assertCodeExecution("""
-    #         class CtxMgr:
-    #             def __enter__(self):
-    #                 print('entering CtxMgr')
-    #             def __exit__(self, *args):
-    #                 print('exiting CtxMgr')
-    #
-    #         with CtxMgr():
-    #             raise ValueError
-    #         """)
+    def test_with_body_fails(self):
+        self.assertCodeExecution("""
+            class CtxMgr:
+                def __enter__(self):
+                    print('entering CtxMgr')
+                def __exit__(self, *args):
+                    print('exiting CtxMgr')
+
+            with CtxMgr():
+                raise ValueError
+            """)
 
     def test_with_noexit(self):
         self.assertCodeExecution("""
@@ -49,3 +48,24 @@ class WithLoopTests(TranspileTestCase):
             with CtxMgrMissingEnter():
                 print('inside')
         """)
+
+    def test_with_nested(self):
+        self.assertCodeExecution("""
+            class CtxMgr:
+                def __enter__(self):
+                    print('entering CtxMgr')
+                    return 42
+                def __exit__(self, *args):
+                    print('exiting CtxMgr')
+
+            class CtxMgr2:
+                def __enter__(self):
+                    print('entering CtxMgr2')
+                    return 24
+                def __exit__(self, *args):
+                    print('exiting CtxMgr2')
+
+            with CtxMgr() as val, CtxMgr2() as val2:
+                print('val', val)
+                print('val2', val2)
+            """)

--- a/tests/structures/test_with.py
+++ b/tests/structures/test_with.py
@@ -14,6 +14,8 @@ class WithLoopTests(TranspileTestCase):
             with CtxMgr() as val:
                 print('val', val)
 
+            print('val outside block', val)
+
             val = 16
             with CtxMgr():
                 print('in another ctx, val now is', val)

--- a/tests/structures/test_with.py
+++ b/tests/structures/test_with.py
@@ -1,5 +1,3 @@
-from unittest import expectedFailure
-
 from ..utils import TranspileTestCase
 
 
@@ -20,3 +18,34 @@ class WithLoopTests(TranspileTestCase):
             with CtxMgr():
                 print('in another ctx, val now is', val)
             """)
+
+    # TODO: make this test pass
+    # def test_with_body_fails(self):
+    #     self.assertCodeExecution("""
+    #         class CtxMgr:
+    #             def __enter__(self):
+    #                 print('entering CtxMgr')
+    #             def __exit__(self, *args):
+    #                 print('exiting CtxMgr')
+    #
+    #         with CtxMgr():
+    #             raise ValueError
+    #         """)
+
+    def test_with_noexit(self):
+        self.assertCodeExecution("""
+            class CtxMgrMissingExit:
+                def __enter__(self):
+                    print('entering CtxMgrMissingExit')
+            with CtxMgrMissingExit():
+                print('inside')
+        """)
+
+    def test_with_noenter(self):
+        self.assertCodeExecution("""
+            class CtxMgrMissingEnter:
+                def __exit__(self, *args):
+                    print('exiting CtxMgrMissingEnter')
+            with CtxMgrMissingEnter():
+                print('inside')
+        """)

--- a/tests/structures/test_with.py
+++ b/tests/structures/test_with.py
@@ -1,0 +1,22 @@
+from unittest import expectedFailure
+
+from ..utils import TranspileTestCase
+
+
+class WithLoopTests(TranspileTestCase):
+    def test_with(self):
+        self.assertCodeExecution("""
+            class CtxMgr:
+                def __enter__(self):
+                    print('entering CtxMgr')
+                    return 42
+                def __exit__(self, *args):
+                    print('exiting CtxMgr')
+
+            with CtxMgr() as val:
+                print('val', val)
+
+            val = 16
+            with CtxMgr():
+                print('in another ctx, val now is', val)
+            """)

--- a/tests/structures/test_with.py
+++ b/tests/structures/test_with.py
@@ -33,7 +33,7 @@ class WithLoopTests(TranspileTestCase):
 
             with CtxMgr():
                 raise KeyError('ola')
-            """)
+            """, exits_early=True)
 
     def test_with_noexit(self):
         self.assertCodeExecution("""
@@ -42,7 +42,7 @@ class WithLoopTests(TranspileTestCase):
                     print('entering CtxMgrMissingExit')
             with CtxMgrMissingExit():
                 print('inside')
-        """)
+        """, exits_early=True)
 
     def test_with_noenter(self):
         self.assertCodeExecution("""
@@ -51,7 +51,7 @@ class WithLoopTests(TranspileTestCase):
                     print('exiting CtxMgrMissingEnter')
             with CtxMgrMissingEnter():
                 print('inside')
-        """)
+        """, exits_early=True)
 
     def test_with_nested(self):
         self.assertCodeExecution("""


### PR DESCRIPTION
This is still a work in progress, when finished it will add support for the `with` statement fixing #300, I'm creating the PR in advance to benefit from running the tests (well, and report progress).

Things to do:

* [x] Add tests and handle cases of ctx managers with no `__enter__` or no `__exit__`
* [ ] Add test and implement capturing exception information when the body block fails
  * partially done, currently only passing the value -- getting the type and traceback isn't straightforward
* [x] Ensure that `__exit__` is called even if body fails (as long as `__enter__` succeeds)