### PR TITLE
Fix maximum stack size for a generator edge case

### DIFF
--- a/tests/structures/test_generator.py
+++ b/tests/structures/test_generator.py
@@ -33,3 +33,14 @@ class GeneratorTests(TranspileTestCase):
 
             print(list(fizz_buzz(1, 20)))
             """)
+
+    def test_simplest_generator(self):
+        self.assertCodeExecution("""
+            def somegen():
+                yield 1
+                yield 2
+                yield 3
+
+            for i in somegen():
+                print(i)
+            """)

--- a/voc/python/methods.py
+++ b/voc/python/methods.py
@@ -1104,7 +1104,7 @@ class GeneratorFunction(Function):
                 static=self.static,
                 attributes=[
                     JavaCode(
-                        max_stack=len(self.parameters) + 8,
+                        max_stack=len(self.parameters) + 9,
                         max_locals=len(self.parameters) + 8,
                         code=wrapper.opcodes
                     )


### PR DESCRIPTION
The bytecode generated for the test case added in this commit
reaches the limit of the stack size, see the ASM analysis here:

https://gist.github.com/eliasdorneles/742ccff84a0474e6904a369293ab1dd9

In the max_stack value calculation, len(self.parameters) was 0,
so that max_stack ends up with value 8.

Looking at the ASM analysis linked above, one can see that it
reaches the limit, and even though the INVOKESTATIC function
would consume 1 element from the stack (the argument) before
adding its result to the stack, this seems to not be enough.