### PR TITLE
Add str.join and str.__iter__ (with help of @joystate -- thanks!)

### DIFF
--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -1,5 +1,7 @@
 package org.python.types;
 
+import java.util.ArrayList;
+
 public class Str extends org.python.types.Object {
     public java.lang.String value;
 
@@ -317,7 +319,11 @@ public class Str extends org.python.types.Object {
         __doc__ = ""
     )
     public org.python.Iterable __iter__() {
-        throw new org.python.exceptions.NotImplementedError("__iter__() has not been implemented.");
+        java.util.List<org.python.Object> listOfStrs = new ArrayList<>();
+        for (int i = 0; i < this.value.length(); i++) {
+            listOfStrs.add(new Str(this.value.substring(i, i + 1)));
+        }
+        return new org.python.types.List(listOfStrs).__iter__();
     }
 
     @org.python.Method(
@@ -794,10 +800,34 @@ public class Str extends org.python.types.Object {
     }
 
     @org.python.Method(
-        __doc__ = ""
+        __doc__ = "S.join(iterable) -> str",
+        args = {"iterable"}
     )
-    public org.python.Object join() {
-        throw new org.python.exceptions.NotImplementedError("join() has not been implemented.");
+    public org.python.Object join(org.python.Object iterable) {
+        java.util.List<org.python.Object> temp_list = new java.util.ArrayList<org.python.Object>();
+        org.python.Iterable iter = null;
+        try {
+            iter = org.Python.iter(iterable);
+        } catch (org.python.exceptions.TypeError e) {
+            throw new org.python.exceptions.TypeError("can only join an iterable");
+        }
+        try {
+            while (true) {
+                org.python.Object item = iter.__next__();
+                temp_list.add(item);
+            }
+        } catch (org.python.exceptions.StopIteration e) { }
+        StringBuilder buf = new StringBuilder();
+        boolean firstTime = true;
+        for (org.python.Object each : temp_list) {
+            if (firstTime) {
+                buf.append(each.toString());
+                firstTime = false;
+            } else {
+                buf.append(this.value).append(each.toString());
+            }
+        }
+        return new Str(buf.toString());
     }
 
     @org.python.Method(

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -11,6 +11,19 @@ class StrTests(TranspileTestCase):
                 print(err)
             """)
 
+    def test_join(self):
+        self.assertCodeExecution("""
+            print(','.join(None))
+            """, exits_early=True)
+        self.assertCodeExecution("""
+            print(','.join(12))
+            """, exits_early=True)
+        self.assertCodeExecution("""
+            print(','.join(['1', '2', '3']))
+            print(','.join([]))
+            print('asdf'.join(','))
+            """)
+
     def test_endswith(self):
         self.assertCodeExecution("""
             s = "abracadabra"


### PR DESCRIPTION
So, this adds a basic implementation for str.join and `str.__iter__`.

The `__iter__` implementation essentially just creates a list and
return the result of lists's `__iter__`.

@joystate and I also looked into making this work with dictionaries
but they're missing the `__iter__` method.