### PR TITLE
Handle dict keyword arguments (closes #359)

### DIFF
--- a/python/common/org/python/types/Dict.java
+++ b/python/common/org/python/types/Dict.java
@@ -89,6 +89,9 @@ public class Dict extends org.python.types.Object {
                 this.value = generated;
             }
         }
+        for(java.util.Map.Entry<java.lang.String, org.python.Object> entry: kwargs.entrySet()){
+            this.value.put(new Str(entry.getKey()), entry.getValue());
+        }
     }
 
     // @org.python.Method(

--- a/tests/datatypes/test_dict.py
+++ b/tests/datatypes/test_dict.py
@@ -114,6 +114,21 @@ class DictTests(TranspileTestCase):
                 print(err)
         """)
 
+    def test_builtin_constructor_kwargs(self):
+        self.assertCodeExecution("""
+            d = dict(a=1, b=2)
+            print('a' in d)
+            print('b' in d)
+            print('c' not in d)
+            print(d['b'])
+
+            d = dict(d, b=3)
+            print('a' in d)
+            print('b' in d)
+            print('c' in d)
+            print(d['b'])
+        """)
+
     def test_builtin_non_2_tuples(self):
         # One of the elements isn't a 2-tuple
         self.assertCodeExecution("""


### PR DESCRIPTION
This adds code to handle the `dict()` builtin keyword arguments, which were previously being ignored.

Solves issue #359 