### PR TITLE
Accept Java 7 sources

### DIFF
--- a/ant.properties
+++ b/ant.properties
@@ -27,3 +27,4 @@ out.rs.obj.absolute.dir=build
 out.rs.libs.absolute.dir=build
 out.aidl.absolute.dir=build
 out.dexed.absolute.dir=build
+java.source=1.7

--- a/ant.properties
+++ b/ant.properties
@@ -28,3 +28,4 @@ out.rs.libs.absolute.dir=build
 out.aidl.absolute.dir=build
 out.dexed.absolute.dir=build
 java.source=1.7
+java.target=1.5


### PR DESCRIPTION
This is needed to build Android with `ant android` for the recent sources.

This is needed because the ancient Android ant build.xml is setting both `java.source` and `java.target` to 1.5.

I think it makes sense to keep the sources compatible to Java 7, since we can simply target the previous JVMs if we need (even though [at some point JDK 8 will probably deprecate the 1.5 target](http://openjdk.java.net/jeps/182)).