### PR TITLE
Fix empty return stmt

### DIFF
--- a/tests/structures/test_return.py
+++ b/tests/structures/test_return.py
@@ -6,7 +6,9 @@ class ReturnTests(TranspileTestCase):
         # Empty return
         self.assertCodeExecution("""
             def m():
+                print('haha')
                 return
+                print('haha')
 
             print(m())
         """)
@@ -14,7 +16,9 @@ class ReturnTests(TranspileTestCase):
         # Single return
         self.assertCodeExecution("""
             def m():
+                print('haha')
                 return 1
+                print('haha')
 
             print(m() + 1)
         """)
@@ -22,7 +26,10 @@ class ReturnTests(TranspileTestCase):
         # Multiple return
         self.assertCodeExecution("""
             def m():
+                print('haha')
                 return 1, 2
+                print('haha')
 
             print(m())
         """)
+

--- a/tests/structures/test_return.py
+++ b/tests/structures/test_return.py
@@ -32,4 +32,3 @@ class ReturnTests(TranspileTestCase):
 
             print(m())
         """)
-

--- a/tests/structures/test_return.py
+++ b/tests/structures/test_return.py
@@ -6,9 +6,9 @@ class ReturnTests(TranspileTestCase):
         # Empty return
         self.assertCodeExecution("""
             def m():
-                print('haha')
+                print('before return')
                 return
-                print('haha')
+                print('after return')
 
             print(m())
         """)
@@ -16,9 +16,9 @@ class ReturnTests(TranspileTestCase):
         # Single return
         self.assertCodeExecution("""
             def m():
-                print('haha')
+                print('before return')
                 return 1
-                print('haha')
+                print('after return')
 
             print(m() + 1)
         """)
@@ -26,9 +26,9 @@ class ReturnTests(TranspileTestCase):
         # Multiple return
         self.assertCodeExecution("""
             def m():
-                print('haha')
+                print('before return')
                 return 1, 2
-                print('haha')
+                print('after return')
 
             print(m())
         """)

--- a/voc/python/ast.py
+++ b/voc/python/ast.py
@@ -386,11 +386,11 @@ class Visitor(ast.NodeVisitor):
         # expr? value):
         if node.value:
             self.visit(node.value)
-            self.context.add_opcodes(
-                JavaOpcodes.ARETURN()
-            )
-            # Record how deep we were when this return was added.
-            self.context.opcodes[-1].depth = len(self.context.blocks)
+        else:
+            self.context.add_opcodes(python.NONE())
+        self.context.add_opcodes(JavaOpcodes.ARETURN())
+        # Record how deep we were when this return was added.
+        self.context.opcodes[-1].depth = len(self.context.blocks)
 
     @node_visitor
     def visit_Delete(self, node):


### PR DESCRIPTION
Refs #382 

* Empty return statement `return` now act as `return None`, in accordance with CPython.
* Modify the original test case for return statements to reflect the problem as described in issue #382