### PR TITLE
put flake8 before py.test in travis ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ install:
   - "pip install git+https://github.com/pybee/pytest-circleci"
   - "pip install flake8"
 script:
-  - "py.test tests"
   - flake8
+  - "py.test tests"


### PR DESCRIPTION
Hi all.

I suggest we put `flake8` before `py.test tests` in `.travis.yml`, because the style checking always completes faster than the unit tests. In this way, if some code has style issues, the travis build will be able to detect the style issues more quickly and "fail fast" so that it won't bother to run the lengthy unit testing process, and we save time by this way.