### PR TITLE
Add --version to voc cmdline

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -60,7 +60,7 @@ def setUpSuite():
     )
 
     try:
-        out, err = proc.communicate(timeout=15)
+        out, err = proc.communicate(timeout=30)
     except subprocess.TimeoutExpired:
         proc.kill()
         out, err = proc.communicate()

--- a/voc/__init__.py
+++ b/voc/__init__.py
@@ -6,4 +6,4 @@
 # __version__ = '1.2.3'       # Final Release
 # __version__ = '1.2.3.post1' # Post Release 1
 
-__version__ = '0.1.2'
+__version__ = '0.1.2-dev'

--- a/voc/__main__.py
+++ b/voc/__main__.py
@@ -1,3 +1,4 @@
+import voc
 import argparse
 
 from .transpiler import transpile
@@ -28,6 +29,11 @@ def main():
         '-v', '--verbosity',
         action='count',
         default=0
+    )
+    parser.add_argument(
+        '--version',
+        action='version',
+        version='voc %s' % voc.__version__,
     )
     parser.add_argument(
         'input',


### PR DESCRIPTION
This adds `--version` argument to the `voc` entrypoint script and adds a suffix `-dev` to the `voc.__version__` for the code in master.

This helps to quickly check which VOC version is being used and it's something we can ask to be included in bug reports.

Does this look good?