### PR TITLE
Only run py.test if flake8 doesn't fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,4 @@ install:
   - "pip install git+https://github.com/pybee/pytest-circleci"
   - "pip install flake8"
 script:
-  - flake8
-  - "py.test tests"
+  - flake8 && py.test tests


### PR DESCRIPTION
This is a followup on #386: Travis doesn't stop the build script on a failure of a command.

I decided to go with the `&&` shell operator in a single command instead of `set -e` because the latter removes the red-colored line with feedback from the build log ([example here](https://travis-ci.org/eliasdorneles/algorithm-practice/builds/207927724)), probably the set -e affects the Travis wrapper script as well.
An example of the output when flake8 fails for the single command with `&&` [can be seen here](https://travis-ci.org/eliasdorneles/algorithm-practice/builds/207928306), which is nicer and less misleading than the previous.