### PR TITLE
Remove 3.4.2 from python versions that CI will test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.4.2"
   - "3.4.5"
   - "3.5"
   - "3.6"


### PR DESCRIPTION
- Remove 3.4.2 as we would only like to test against ‘latest’ release of each version to cover bugfixes. In this case, 3.4 has already entered “security fixes only” mode, so 3.4.4 was the latest “bugfix” release.
  - Impact: we can avoid implementing quirks due to bugs in 3.4.2 that were fixed in 3.4.{3,4}.
- The 3.5 and 3.6 aliases will float and update whenever Travis CI updates their build images.