### PR TITLE
__mul__ function now working for the Str type and Int type

### DIFF
--- a/python/common/org/python/types/Int.java
+++ b/python/common/org/python/types/Int.java
@@ -271,7 +271,8 @@ public class Int extends org.python.types.Object {
     }
 
     @org.python.Method(
-        __doc__ = ""
+        __doc__ = "",
+        args = {"other"}
     )
     public org.python.Object __mul__(org.python.Object other) {
         if (other instanceof org.python.types.Str) {

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -384,7 +384,8 @@ public class Str extends org.python.types.Object {
     }
 
     @org.python.Method(
-        __doc__ = ""
+        __doc__ = "",
+        args = {"other"} 
     )
     public org.python.Object __mul__(org.python.Object other) {
         if (other instanceof org.python.types.Int) {
@@ -474,6 +475,7 @@ public class Str extends org.python.types.Object {
         __doc__ = ""
     )
     public org.python.Object __rmul__(org.python.Object other) {
+
         throw new org.python.exceptions.NotImplementedError("__rmul__() has not been implemented.");
     }
 


### PR DESCRIPTION
I have fixed a minor issue in the implementation of the  \_\_mul\_\_ for Int and Str types. 
``` 
print("test".__mul__(3)) 
```
or
```
a = 3 
print(a.__mul__(3))
``` 
used to give an error:-
```
Exception in thread "main" TypeError: __mul__() takes 0 positional arguments but 1 was given
	at org.python.types.Function.throwUnexpectedPositionalArgumentsError(Function.java:220)
	at org.python.types.Function.adjustArguments(Function.java:260)
	at org.python.types.Function.invoke(Function.java:373)
	at org.python.types.Method.invoke(Method.java:48)
	at python.bool.__init__.module$import(bool.py:1)
	at python.bool.__init__.main(bool.py
```
while the expected output was supposed to be :-
```
"testtesttest"
```
and
```
9
```


I edited the \_\_mul\_\_ function annotations in org/python/types/Int.java and Str.java  to fix it.

Please suggest improvements, if any! :smile: 