### PR TITLE
fix issue#362 Setting instance attributes

### DIFF
--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -366,8 +366,13 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         if (attr == null) {
             this.__dict__.put(name, value);
         } else {
+            // if attribute is not a descriptor add it to local instance
+            if (!(attr instanceof org.python.types.Property)) {
+                this.__dict__.put(name, value);
+            }
             attr.__set__(this, value);
         }
+
         return true;
     }
 

--- a/tests/structures/test_class.py
+++ b/tests/structures/test_class.py
@@ -138,3 +138,23 @@ class ClassTests(TranspileTestCase):
             obj = MyClass(4)
             obj.stuff(5)
             """, run_in_function=False)
+
+    def test_overwrite_class_attributes(self):
+        self.assertCodeExecution("""
+            class MyClass:
+                x = 1
+
+            print(MyClass.x)
+
+            inst = MyClass()
+            print(inst.x)
+
+            inst.x = 123
+            print(inst.x)
+
+            print(MyClass.x)
+
+            inst2 = MyClass()
+            inst2.x = 5
+            print(inst2.x)
+            """, run_in_function=False)


### PR DESCRIPTION
This PR fixes https://github.com/pybee/voc/issues/362. 

The main problem was in setting attributes ([here](https://github.com/pybee/voc/blob/master/python/common/org/python/types/Object.java#L368)), Local data attribute that matches with class attribute was never saved in the `Object.__dict__` if modified directly.