### PR TITLE
fix issue list comprehensions causes runtime crash

### DIFF
--- a/python/common/org/python/types/Function.java
+++ b/python/common/org/python/types/Function.java
@@ -37,7 +37,7 @@ public class Function extends org.python.types.Object implements org.python.Call
         org.python.Object doc;
         try {
             org.python.types.Tuple consts = (org.python.types.Tuple) this.code.co_consts;
-            if (consts != null) {
+            if (consts != null && ((org.python.types.Int)consts.count()).value != 0) {
                 doc = consts.__getitem__(new org.python.types.Int(0));
             } else {
                 doc = org.python.types.NoneType.NONE;

--- a/tests/structures/test_list_comprehension.py
+++ b/tests/structures/test_list_comprehension.py
@@ -8,6 +8,11 @@ class ListComprehensionTests(TranspileTestCase):
             print([v**2 for v in x])
             """)
 
+        self.assertCodeExecution("""
+            x = [1, 2, 3, 4, 5]
+            print([v for v in x])
+            """)
+
     def test_method(self):
         self.assertCodeExecution("""
             x = [1, 2, 3, 4, 5]


### PR DESCRIPTION
This PR fixes https://github.com/pybee/voc/issues/369

The problem was that, `consts` tuple has length zero and we were trying to get first index ([here](https://github.com/pybee/voc/blob/master/python/common/org/python/types/Function.java#L41)), so I added check for count.