### PR TITLE
Update for list test_slices for VOC

### DIFF
--- a/python/common/org/python/types/Slice.java
+++ b/python/common/org/python/types/Slice.java
@@ -35,8 +35,13 @@ public class Slice extends org.python.types.Object {
         }
 
         if (step instanceof org.python.types.Int) {
-            this.__dict__.put("step", step);
             this.step = (org.python.types.Int) step;
+            if (this.step.value == 0 ){
+                throw new org.python.exceptions.ValueError("slice step cannot be zero");
+            }
+            else{
+                this.__dict__.put("step", step);   
+            }
         } else if (step instanceof org.python.types.NoneType) {
             this.__dict__.put("step", step);
         } else {

--- a/python/common/org/python/types/Slice.java
+++ b/python/common/org/python/types/Slice.java
@@ -39,7 +39,7 @@ public class Slice extends org.python.types.Object {
             if (this.step.value == 0) {
                 throw new org.python.exceptions.ValueError("slice step cannot be zero");
             } else {
-                this.__dict__.put("step", step);   
+                this.__dict__.put("step", step);
             }
         } else if (step instanceof org.python.types.NoneType) {
             this.__dict__.put("step", step);

--- a/python/common/org/python/types/Slice.java
+++ b/python/common/org/python/types/Slice.java
@@ -36,10 +36,9 @@ public class Slice extends org.python.types.Object {
 
         if (step instanceof org.python.types.Int) {
             this.step = (org.python.types.Int) step;
-            if (this.step.value == 0 ){
+            if (this.step.value == 0) {
                 throw new org.python.exceptions.ValueError("slice step cannot be zero");
-            }
-            else{
+            } else {
                 this.__dict__.put("step", step);   
             }
         } else if (step instanceof org.python.types.NoneType) {

--- a/tests/datatypes/test_list.py
+++ b/tests/datatypes/test_list.py
@@ -1,6 +1,7 @@
 from .. utils import TranspileTestCase, UnaryOperationTestCase, BinaryOperationTestCase, InplaceOperationTestCase
 from unittest import expectedFailure
 
+
 class ListTests(TranspileTestCase):
     def test_setattr(self):
         self.assertCodeExecution("""
@@ -181,9 +182,8 @@ class ListTests(TranspileTestCase):
             print(x[6:7])
             """)
 
-    
     # when step is 0
-    def test_slice_with_zero_step(self):    
+    def test_slice_with_zero_step(self):
         self.assertCodeExecution("""
             x = [1, 2, 3, 4, 5]
             try:
@@ -192,7 +192,7 @@ class ListTests(TranspileTestCase):
                 print(err)
             """)
 
-    @expectedFailure 
+    @expectedFailure
     def test_slice_in_reverse(self):
         # Full slice with a negative step
         self.assertCodeExecution("""
@@ -205,13 +205,13 @@ class ListTests(TranspileTestCase):
             print (x[4::-2])
             """)
 
-        #Right bound slice with a negative step
+        # Right bound slice with a negative step
         self.assertCodeExecution("""
             x=[1,2,3,4,5]
             print (x[:4:-1])
             """)
 
-        #Right bound and left bound slice with a negative step
+        # Right bound and left bound slice with a negative step
         self.assertCodeExecution("""
             x=[1,2,3,4,5]
             print (x[1:4:-2])

--- a/tests/datatypes/test_list.py
+++ b/tests/datatypes/test_list.py
@@ -196,25 +196,25 @@ class ListTests(TranspileTestCase):
     def test_slice_in_reverse(self):
         # Full slice with a negative step
         self.assertCodeExecution("""
-            x = [1,2,3,4,5]
+            x = [1, 2, 3, 4, 5]
             print (x[::-1])
             """)
 
         # left bound slice with a negative step
         self.assertCodeExecution("""
-            x = [1,2,3,4,5]
+            x = [1, 2, 3, 4, 5]
             print (x[4::-2])
             """)
 
         # Right bound slice with a negative step
         self.assertCodeExecution("""
-            x = [1,2,3,4,5]
+            x = [1, 2, 3, 4, 5]
             print (x[:4:-1])
             """)
 
         # Right bound and left bound slice with a negative step
         self.assertCodeExecution("""
-            x = [1,2,3,4,5]
+            x = [1, 2, 3, 4, 5]
             print (x[1:4:-2])
             """)
 

--- a/tests/datatypes/test_list.py
+++ b/tests/datatypes/test_list.py
@@ -1,5 +1,5 @@
 from .. utils import TranspileTestCase, UnaryOperationTestCase, BinaryOperationTestCase, InplaceOperationTestCase
-
+from unittest import expectedFailure
 
 class ListTests(TranspileTestCase):
     def test_setattr(self):
@@ -179,6 +179,42 @@ class ListTests(TranspileTestCase):
         self.assertCodeExecution("""
             x = [1, 2, 3, 4, 5]
             print(x[6:7])
+            """)
+
+    @expectedFailure
+    # when step is 0
+    def test_slice_with_zero_step(self):    
+        self.assertCodeExecution("""
+            x = [1, 2, 3, 4, 5]
+            try:
+                print(x[1:3:0])
+            except ValueError as err:
+                print(err)
+            """)
+
+    @expectedFailure
+    def test_slice_in_reverse(self):
+        # Full slice with a negative step
+        self.assertCodeExecution("""
+            x=[1,2,3,4,5]
+            print (x[::-1])
+            """)
+        # left bound slice with a negative step
+        self.assertCodeExecution("""
+            x=[1,2,3,4,5]
+            print (x[4::-2])
+            """)
+
+        #Right bound slice with a negative step
+        self.assertCodeExecution("""
+            x=[1,2,3,4,5]
+            print (x[:4:-1])
+            """)
+
+        #Right bound and left bound slice with a negative step
+        self.assertCodeExecution("""
+            x=[1,2,3,4,5]
+            print (x[1:4:-2])
             """)
 
     def test_count(self):

--- a/tests/datatypes/test_list.py
+++ b/tests/datatypes/test_list.py
@@ -181,7 +181,7 @@ class ListTests(TranspileTestCase):
             print(x[6:7])
             """)
 
-    @expectedFailure
+    
     # when step is 0
     def test_slice_with_zero_step(self):    
         self.assertCodeExecution("""
@@ -192,7 +192,7 @@ class ListTests(TranspileTestCase):
                 print(err)
             """)
 
-    @expectedFailure
+    @expectedFailure 
     def test_slice_in_reverse(self):
         # Full slice with a negative step
         self.assertCodeExecution("""

--- a/tests/datatypes/test_list.py
+++ b/tests/datatypes/test_list.py
@@ -196,24 +196,25 @@ class ListTests(TranspileTestCase):
     def test_slice_in_reverse(self):
         # Full slice with a negative step
         self.assertCodeExecution("""
-            x=[1,2,3,4,5]
+            x = [1,2,3,4,5]
             print (x[::-1])
             """)
+
         # left bound slice with a negative step
         self.assertCodeExecution("""
-            x=[1,2,3,4,5]
+            x = [1,2,3,4,5]
             print (x[4::-2])
             """)
 
         # Right bound slice with a negative step
         self.assertCodeExecution("""
-            x=[1,2,3,4,5]
+            x = [1,2,3,4,5]
             print (x[:4:-1])
             """)
 
         # Right bound and left bound slice with a negative step
         self.assertCodeExecution("""
-            x=[1,2,3,4,5]
+            x = [1,2,3,4,5]
             print (x[1:4:-2])
             """)
 


### PR DESCRIPTION
Adding tests for list slicing operations not implemented in Java.

1. test_slice_with_zero_step() to test if a value error is raised when step=0 is used for slicing and implementation in java.

2. test_slice_in_reverse() to test the use of steps less than 0 during slicing.