### PR TITLE
Fix len() for bytes, bytearray

### DIFF
--- a/python/common/org/python/types/ByteArray.java
+++ b/python/common/org/python/types/ByteArray.java
@@ -624,7 +624,7 @@ public class ByteArray extends org.python.types.Object {
     @org.python.Method(
             __doc__ = ""
     )
-    public org.python.types.Int __len__(java.util.List<org.python.Object> args, java.util.Map<java.lang.String, org.python.Object> kwargs, java.util.List<org.python.Object> default_args, java.util.Map<java.lang.String, org.python.Object> default_kwargs) {
+    public org.python.types.Int __len__() {
         return new org.python.types.Int(this.value.length);
     }
 

--- a/python/common/org/python/types/Bytes.java
+++ b/python/common/org/python/types/Bytes.java
@@ -479,7 +479,7 @@ public class Bytes extends org.python.types.Object {
     @org.python.Method(
             __doc__ = ""
     )
-    public org.python.types.Int __len__(java.util.List<org.python.Object> args, java.util.Map<java.lang.String, org.python.Object> kwargs, java.util.List<org.python.Object> default_args, java.util.Map<java.lang.String, org.python.Object> default_kwargs) {
+    public org.python.types.Int __len__() {
         return new org.python.types.Int(this.value.length);
     }
 

--- a/tests/builtins/test_len.py
+++ b/tests/builtins/test_len.py
@@ -9,8 +9,5 @@ class BuiltinLenFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     functions = ["len"]
 
     not_implemented = [
-        'test_bytearray',
-        'test_bytes',
-        'test_class',
         'test_frozenset',
     ]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -672,7 +672,7 @@ SAMPLE_DATA = {
         ],
     'set': [
             'set()',
-            '{1, 2.3456, "another"}',
+            'set({1, 2.3456, "another"})',
         ],
     'slice': [
             'slice(0)',


### PR DESCRIPTION
**Changes**

- Fix len() in bytes, bytearray datatype

- Fix a typo in set of utils.py in tests

- Updated the not implemented section in test_len.py

**Next Steps**
Will be working on FrozenSet Implementation for builtin fns