### PR TITLE
Implements the isalpha() String method

### DIFF
--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -719,12 +719,11 @@ public class Str extends org.python.types.Object {
     )
     public org.python.Object isalpha() {
         int c = 0;
-        java.lang.String checkString = this.value.toUpperCase();
+        java.lang.String checkString = this.value;
         char currentCharacter;
         while (c < (checkString.length()-1)) {
             currentCharacter = checkString.charAt(c);
-            int ascii = (int) currentCharacter;
-            if (ascii<65 || ascii>90) {
+            if (!Character.isLetter(currentCharacter)) {
                 return new org.python.types.Bool(false);
             }
             c++;

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -721,12 +721,17 @@ public class Str extends org.python.types.Object {
         int c = 0;
         java.lang.String checkString = this.value;
         char currentCharacter;
-        while (c < (checkString.length())) {
-            currentCharacter = checkString.charAt(c);
-            if (!Character.isLetter(currentCharacter)) {
-                return new org.python.types.Bool(false);
+
+        if (checkString.length() == 0) {
+            return new org.python.types.Bool(false);
+        } else {
+            while (c < (checkString.length())) {
+                currentCharacter = checkString.charAt(c);
+                if (!Character.isLetter(currentCharacter)) {
+                    return new org.python.types.Bool(false);
+                }
+                c++;
             }
-            c++;
         }
         return new org.python.types.Bool(true);
     }

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -721,7 +721,7 @@ public class Str extends org.python.types.Object {
         int c = 0;
         java.lang.String checkString = this.value;
         char currentCharacter;
-        while (c < (checkString.length()-1)) {
+        while (c < (checkString.length() - 1)) {
             currentCharacter = checkString.charAt(c);
             if (!Character.isLetter(currentCharacter)) {
                 return new org.python.types.Bool(false);

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -718,7 +718,18 @@ public class Str extends org.python.types.Object {
             __doc__ = ""
     )
     public org.python.Object isalpha() {
-        return new org.python.types.Bool(this.value.matches("[a-zA-Z]+"));
+        int c = 0;
+        java.lang.String checkString = this.value.toUpperCase();
+        char currentCharacter;
+        while (c < (checkString.length()-1)) {
+            currentCharacter = checkString.charAt(c);
+            int ascii = (int) currentCharacter;
+            if (ascii<65 || ascii>90) {
+                return new org.python.types.Bool(false);
+            }
+            c++;
+        }
+        return new org.python.types.Bool(true);
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -718,7 +718,7 @@ public class Str extends org.python.types.Object {
             __doc__ = ""
     )
     public org.python.Object isalpha() {
-        throw new org.python.exceptions.NotImplementedError("isalpha() has not been implemented.");
+        return new org.python.types.Bool(this.value.matches("[a-zA-Z]+"));
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -721,7 +721,7 @@ public class Str extends org.python.types.Object {
         int c = 0;
         java.lang.String checkString = this.value;
         char currentCharacter;
-        while (c < (checkString.length() - 1)) {
+        while (c < (checkString.length())) {
             currentCharacter = checkString.charAt(c);
             if (!Character.isLetter(currentCharacter)) {
                 return new org.python.types.Bool(false);

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -32,7 +32,7 @@ class StrTests(TranspileTestCase):
 
     def test_isalpha(self):
         self.assertCodeExecution("""
-            for s in ['Hello World', 'hello wORLd.', 'Hello world.', '', 'this', 'this is string example....wow!!!']:
+            for s in ['Hello World', 'hello wORLd.', 'Hello world.', '', 'this', 'this is string example....wow!!!', 'átomo', 'CasesLikeTheseWithoutSpaces']:
                 print(s.isalpha())
             """)
 

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -32,7 +32,7 @@ class StrTests(TranspileTestCase):
 
     def test_isalpha(self):
         self.assertCodeExecution("""
-            for s in ['Hello World', 'hello wORLd.', 'Hello world.', '', 'hello1'
+            for s in ['Hello World', 'hello wORLd.', 'Hello world.', '', 'hello1',
             'this', 'this is string example....wow!!!', 'átomo', 'CasesLikeTheseWithoutSpaces']:
                 print(s.isalpha())
             """)

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -30,6 +30,12 @@ class StrTests(TranspileTestCase):
                 print(s.isspace())
             """)
 
+    def test_isalpha(self):
+        self.assertCodeExecution("""
+            for s in ['Hello World', 'hello wORLd.', 'Hello world.', '', 'this', 'this is string example....wow!!!']:
+                print(s.isalpha())
+            """)
+
     def test_istitle(self):
         self.assertCodeExecution("""
             for s in ['Hello World', 'hello wORLd.', 'Hello world.', '']:

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -32,7 +32,8 @@ class StrTests(TranspileTestCase):
 
     def test_isalpha(self):
         self.assertCodeExecution("""
-            for s in ['Hello World', 'hello wORLd.', 'Hello world.', '', 'this', 'this is string example....wow!!!', 'átomo', 'CasesLikeTheseWithoutSpaces']:
+            for s in ['Hello World', 'hello wORLd.', 'Hello world.', '',
+            'this', 'this is string example....wow!!!', 'átomo', 'CasesLikeTheseWithoutSpaces']:
                 print(s.isalpha())
             """)
 

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -32,7 +32,7 @@ class StrTests(TranspileTestCase):
 
     def test_isalpha(self):
         self.assertCodeExecution("""
-            for s in ['Hello World', 'hello wORLd.', 'Hello world.', '',
+            for s in ['Hello World', 'hello wORLd.', 'Hello world.', '', 'hello1'
             'this', 'this is string example....wow!!!', 'átomo', 'CasesLikeTheseWithoutSpaces']:
                 print(s.isalpha())
             """)


### PR DESCRIPTION
Signed-off-by: Ashutosh Saboo <ashutosh.saboo96@gmail.com>

This PR implements the [isalpha()](https://docs.python.org/3/library/stdtypes.html#str.isalpha) method for strings. 

Please review this PR. ~~Also, are there any tests needed before merging this PR?~~ 
Update: Added test cases for isalpha() too. @freakboy3742 @eliasdorneles  It'd great if you could review this PR. :smiley: 

Does it seem ready to merge? Thanks! :smile: 