### PR TITLE
[WIP] Add test for extending java class

### DIFF
--- a/tests/test_interoperability.py
+++ b/tests/test_interoperability.py
@@ -1,0 +1,56 @@
+from .utils import TranspileTestCase
+
+
+class InteroperabilityTest(TranspileTestCase):
+    def test_extend_java_class_with_simple_constructor(self):
+        self.assertJavaExecution(
+            """
+            class MyPythonClass(extends=com.example.MyClass):
+                pass
+
+            MyPythonClass()
+            print("Done.")
+            """,
+            java={
+                'com/example/MyClass': """
+                package com.example;
+
+                public class MyClass {
+                    public MyClass() {
+                        System.out.println("MyClass started");
+                    }
+                }
+                """
+            },
+            out="""
+            MyClass started
+            Done.
+            """,
+        )
+
+    def test_extend_java_class_with_constructor_that_needs_args(self):
+        self.assertJavaExecution(
+            """
+            class MyPythonClass(extends=com.example.MyClass):
+                def __init__(self, x: java.lang.Integer) -> void:
+                    print('x', x)
+
+            MyPythonClass()
+            print("Done.")
+            """,
+            java={
+                'com/example/MyClass': """
+                package com.example;
+
+                public class MyClass {
+                    public MyClass(Integer x) {
+                        System.out.println("MyClass started with " + x);
+                    }
+                }
+                """
+            },
+            out="""
+            MyClass started with 1
+            Done.
+            """,
+        )

--- a/tests/test_interoperability.py
+++ b/tests/test_interoperability.py
@@ -51,6 +51,7 @@ class InteroperabilityTest(TranspileTestCase):
             },
             out="""
             MyClass started with 1
+            x 1
             Done.
             """,
         )


### PR DESCRIPTION
I've come up with a test for the issue I'm having while I try to build my next Android app using VOC.

I need to extend the class `android.view.View` to write a custom view, and I keep getting an `IllegalAccessError` like this:

```
java.lang.IllegalAccessError: Method 'void android.view.View.<init>()' is inaccessible to class 'org.eliasdorneles.drawingapp.app.SomeViewGroup' (declaration of 'org.eliasdorneles.drawingapp.app.SomeViewGroup' appears in /data/app/org.eliasdorneles-2/base.apk)
```

I've not been able to reproduce the exact same error outside Android environment, but the tests here already show part of the problem (I can't extend the Java class without providing an alternate constructor that does the right thing).

I have to dig a bit more to see how to do this, any pointers are appreciated. :)