### PR TITLE
Adjust checkstyle config

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -130,6 +130,7 @@
         <module name="Indentation">
             <property name="lineWrappingIndentation" value="8"/>
         </module>
+        <module name="SingleSpaceSeparator"/>
 
         <!-- Modifier Checks                                    -->
         <!-- See http://checkstyle.sf.net/config_modifiers.html -->
@@ -139,7 +140,7 @@
         <!-- Checks for blocks. You know, those {}'s         -->
         <!-- See http://checkstyle.sf.net/config_blocks.html -->
         <module name="AvoidNestedBlocks"/>
-        <!--<module name="EmptyBlock"/>-->
+        <module name="EmptyBlock"/>
         <module name="LeftCurly"/>
         <module name="NeedBraces"/>
         <module name="RightCurly"/>

--- a/python/common/org/python/ImportLib.java
+++ b/python/common/org/python/ImportLib.java
@@ -205,7 +205,7 @@ public class ImportLib {
         } catch (java.lang.ClassNotFoundException e) {
             python_module = new org.python.java.Module(import_name);
             python.sys.__init__.modules.__setitem__(new org.python.types.Str(import_name), python_module);
-        } finally {
+        // } finally {
             // org.Python.debug("CONSTRUCTOR DONE");
         }
         return python_module;
@@ -251,7 +251,7 @@ public class ImportLib {
         } catch (java.lang.InstantiationException e) {
             // e.printStackTrace();
             throw new org.python.exceptions.RuntimeError(e.getCause().toString());
-        } finally {
+        // } finally {
             // org.Python.debug("CONSTRUCTOR DONE");
         }
         return python_module;

--- a/python/common/org/python/java/Function.java
+++ b/python/common/org/python/java/Function.java
@@ -543,7 +543,7 @@ public class Function extends org.python.types.Object implements org.python.Call
                     );
                 }
             }
-        } finally {
+        // } finally {
             //     org.Python.debug("INVOKE METHOD DONE");
         }
     }

--- a/python/common/org/python/java/Type.java
+++ b/python/common/org/python/java/Type.java
@@ -276,7 +276,7 @@ public class Type extends org.python.types.Type {
             }
         } catch (java.lang.InstantiationException e) {
             throw new org.python.exceptions.RuntimeError(e.getCause().toString());
-        } finally {
+        // } finally {
             //     System.out.println("CONSTRUCTOR DONE");
         }
     }

--- a/python/common/org/python/types/Dict.java
+++ b/python/common/org/python/types/Dict.java
@@ -362,7 +362,7 @@ public class Dict extends org.python.types.Object {
     public org.python.Object fromkeys(org.python.Object iterable, org.python.Object value) {
         org.python.types.Dict result = new org.python.types.Dict();
         try {
-            org.python.Iterable iter  = iterable.__iter__();
+            org.python.Iterable iter = iterable.__iter__();
             if (value == null) {
                 value = org.python.types.NoneType.NONE;
             }

--- a/python/common/org/python/types/Function.java
+++ b/python/common/org/python/types/Function.java
@@ -411,7 +411,7 @@ public class Function extends org.python.types.Object implements org.python.Call
                 }
                 throw new org.python.exceptions.RuntimeError(message);
             }
-        } finally {
+        // } finally {
             //     System.out.println("INVOKE METHOD DONE");
         }
     }

--- a/python/common/org/python/types/Generator.java
+++ b/python/common/org/python/types/Generator.java
@@ -75,7 +75,7 @@ public class Generator extends org.python.types.Object implements org.python.Ite
                 }
                 throw new org.python.exceptions.RuntimeError(message);
             }
-        } finally {
+        // } finally {
             //     System.out.println("INVOKE METHOD DONE");
         }
     }

--- a/python/common/org/python/types/Type.java
+++ b/python/common/org/python/types/Type.java
@@ -449,7 +449,7 @@ public class Type extends org.python.types.Object implements org.python.Callable
             }
         } catch (java.lang.InstantiationException e) {
             throw new org.python.exceptions.RuntimeError(e.getCause().toString());
-        } finally {
+        // } finally {
             //     System.out.println("CONSTRUCTOR DONE");
         }
     }

--- a/python/common/python/importlib/__init__.java
+++ b/python/common/python/importlib/__init__.java
@@ -4,9 +4,6 @@ package python.importlib;
         __doc__ = "A pure Python implementation of import."
 )
 public class __init__ extends org.python.types.Module {
-    static {
-    }
-
     @org.python.Method(
             __doc__ = "Create and return a new object.  See help(type) for accurate signature."
     )

--- a/python/testdaemon/python/testdaemon/TestDaemon.java
+++ b/python/testdaemon/python/testdaemon/TestDaemon.java
@@ -65,21 +65,17 @@ public class TestDaemon {
                 method.invoke(null, (Object) inputArgs);
             } catch (ReflectiveOperationException e) {
                 // InvocationTargetException may contain an ExitException
-                if (e instanceof InvocationTargetException && e.getCause() != null
-                        && e.getCause() instanceof ExitException) {
-                    // System.exit() was invoked somewhere, and caught due to
-                    // the custom SecurityManager
-                    // Do nothing, there should be no output
-                } else {
+                if (!(e instanceof InvocationTargetException) || e.getCause() == null
+                        || !(e.getCause() instanceof ExitException)) {
                     // ClassNotFound, NoSuchMethod, IllegalAccess Exceptions
+                    // This was _not_ a case of System.exit() being invoked somewhere
+                    // and being caught due to the custom SecurityManager.
                     e.printStackTrace();
                 }
             } catch (ExceptionInInitializerError e) {
-                if (e.getCause() != null && e.getCause() instanceof ExitException) {
-                    // System.exit() was invoked somewhere, and caught due to
-                    // the custom SecurityManager
-                    // Do nothing, there should be no output
-                } else {
+                if (e.getCause() == null || !(e.getCause() instanceof ExitException)) {
+                    // This was _not_ a case of System.exit() being invoked somewhere
+                    // and being caught due to the custom SecurityManager.
                     e.printStackTrace();
                 }
             } catch (Throwable e) {


### PR DESCRIPTION
After a couple of PR reviews, found that some options should be added:

- [SingleSpaceSeparator](http://checkstyle.sourceforge.net/config_whitespace.html#SingleSpaceSeparator): "Checks that non-whitespace characters are separated by no more than one whitespace."
  This prevent things like `x instanceof  y` where there are two spaces after `instanceof` (and which GFM eats in comments...). Side-effect: it also forbids horizontal alignment outside of comments, which seems like a reasonable tradeoff.
- [EmptyBlock](http://checkstyle.sourceforge.net/config_blocks.html#EmptyBlock): "Checks for empty blocks."
  This prevents things like `if (conditional) {} else { //code }`, where the conditional should be inverted.

I'm deliberately pushing a commit with only the checkstyle config change first to demonstrate that the build fails, and will follow up with the code fixes.