### PR TITLE
Change C:\Python35\python.exe to C:\Python34\python.exe in installation doc

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,11 +6,11 @@ VOC
 
 **VOC is an early alpha project. If it breaks, you get to keep all the shiny pieces.**
 
-VOC is a transpiler that takes Python 3.4 source code, and compile it into a Java
+VOC is a transpiler that takes Python 3.4+ source code, and compile it into a Java
 class file that can then be executed on a JVM, or run through a DEX tool to
 run on Android. It does this *at the bytecode level*, rather than the source code level.
 
-It honors Python 3.4 syntax and conventions, but also provides the ability to
+It honors Python 3.4+ syntax and conventions, but also provides the ability to
 reference objects and classes defined in Java code, and implement interfaces
 defined in Java code.
 

--- a/docs/internals/contributing.rst
+++ b/docs/internals/contributing.rst
@@ -23,11 +23,11 @@ instead of using the official PyBee repository, you'll be using your own
 Github fork.
 
 As with the getting started guide, these instructions will assume that you
-have Python3, a Java 7 or Java 8 JDK, and Apache ANT installed, and have virtualenv available for use.
+have Python 3.4+, a Java 7 or Java 8 JDK, and Apache ANT installed, and have virtualenv available for use.
 
 **Note:** If you are on Linux, you will need to install an extra package to be able to run the test suite. 
 * **Ubuntu** 12.04 and 14.04: ``libpython3.4-testsuite`` This can be done by running ``apt-get install libpython3.4-testsuite``.
-* **Ubuntu** 16.04: The default version apt-get provides on Ubuntu 16.04 is 3.5+. voc does not build on Python3.5+. A seperate Python3.4 is required.
+* **Ubuntu** 16.04 and 16.10: ``libpython3.5-testsuite`` This can be done by running ``apt-get install libpython3.5-testsuite``.
 
 Start by forking VOC into your own Github repository; then
 check out your fork to your own computer into a development directory:

--- a/docs/intro/index.rst
+++ b/docs/intro/index.rst
@@ -1,10 +1,10 @@
 Getting Started
 ===============
 
-VOC is a transpiler that takes Python 3.4 source code, and compiles it into a
+VOC is a transpiler that takes Python 3.4+ source code, and compiles it into a
 Java class file that can then be executed on a JVM.
 
-It honors Python 3.4 syntax and conventions, but also provides the ability to
+It honors Python 3.4+ syntax and conventions, but also provides the ability to
 reference objects and classes defined in Java code, and implement interfaces
 defined in Java code.
 

--- a/docs/intro/install.rst
+++ b/docs/intro/install.rst
@@ -57,7 +57,7 @@ For Windows the use of cmd under Administrator permission is suggested instead o
 
 .. code-block:: bash
 
-    > virtualenv -p "C:\Python35\python.exe" env
+    > virtualenv -p "C:\Python34\python.exe" env
     > env\Scripts\activate.bat
     > cd voc
     > pip install -e .

--- a/docs/intro/install.rst
+++ b/docs/intro/install.rst
@@ -2,11 +2,8 @@ Installation
 ============
 
 In this guide we will walk you through setting up your VOC environment for
-development and testing. We will assume that you have a working Python 3, JDK,
-Apache ANT installation and use virtualenv.
-
-The default version apt-get provides on Ubuntu 16.04 is 3.5+ but VOC won't build on Python3.5+. Hence, a separate 
-Python 3.4+ installation would be required. 
+development and testing. We will assume that you have Python 3.4+, Java 7 or Java 8 JDK,
+and Apache ANT installed, and have virtualenv available for use.
 
 Checking Dependencies
 ---------------------

--- a/docs/tutorials/tutorial-0.rst
+++ b/docs/tutorials/tutorial-0.rst
@@ -13,7 +13,7 @@ This tutorial assumes you've read and followed the instructions in
 * Java 6 (or higher) installed and available on your path,
 * An ``env`` directory for your virtualenv
 * A ``tutorial`` directory with a VOC checkout,
-* An activated Python 3.4 virtual environment,
+* An activated Python 3.4+ virtual environment,
 * VOC installed in that virtual environment,
 * A compiled VOC support library.
 


### PR DESCRIPTION
I believe there's a typo in the installation doc for setting up the virtual environment on Windows. 
As it is right now, it is going to use Python 3.5 to set up the environment instead of Python 3.4

Throughout the docs, it says that VOC won’t build on Python3.5+ and that a separate Python 3.4+ installation is required, so I am pretty sure this is just a typo.