### PR TITLE
Refs #361 Fix

### DIFF
--- a/python/common/org/python/ImportLib.java
+++ b/python/common/org/python/ImportLib.java
@@ -120,16 +120,8 @@ public class ImportLib {
                             python_module = importNativeModule(mod_name);
                         } else {
                             // org.Python.debug("handle IMPORT", mod_name);
-                            try {
-                                // try to import unknown native module as python..
-                                python_module = importPythonModule(mod_name);
-                            } catch (java.lang.ClassNotFoundException e) {
-                                // .. but try again to import as native module
-                                // if is not found, otherwise some modules like
-                                // generated resource modules can not be imported
-                                // org.Python.debug("handle NATIVE IMPORT as fallback", mod_name);
-                                python_module = importNativeModule(mod_name);
-                            }
+                            // try to import unknown native module as python..
+                            python_module = importPythonModule(mod_name);
                         }
                     } catch (java.lang.ClassNotFoundException e) {
                         throw new org.python.exceptions.ImportError("No module named '" + python_name + "'");
@@ -246,11 +238,11 @@ public class ImportLib {
                 // as one and continue.
                 throw (org.python.exceptions.BaseException) e.getCause();
             } catch (ClassCastException java_e) {
-                throw new org.python.exceptions.RuntimeError(e.getCause().getMessage());
+                throw new java.lang.ClassNotFoundException();
             }
         } catch (java.lang.InstantiationException e) {
             // e.printStackTrace();
-            throw new org.python.exceptions.RuntimeError(e.getCause().toString());
+            throw new java.lang.ClassNotFoundException();
         } finally {
             // org.Python.debug("CONSTRUCTOR DONE");
         }

--- a/python/common/org/python/ImportLib.java
+++ b/python/common/org/python/ImportLib.java
@@ -120,16 +120,8 @@ public class ImportLib {
                             python_module = importNativeModule(mod_name);
                         } else {
                             // org.Python.debug("handle IMPORT", mod_name);
-                            try {
-                                // try to import unknown native module as python..
-                                python_module = importPythonModule(mod_name);
-                            } catch (java.lang.ClassNotFoundException e) {
-                                // .. but try again to import as native module
-                                // if is not found, otherwise some modules like
-                                // generated resource modules can not be imported
-                                // org.Python.debug("handle NATIVE IMPORT as fallback", mod_name);
-                                python_module = importNativeModule(mod_name);
-                            }
+                            // try to import unknown native module as python..
+                            python_module = importPythonModule(mod_name);
                         }
                     } catch (java.lang.ClassNotFoundException e) {
                         throw new org.python.exceptions.ImportError("No module named '" + python_name + "'");
@@ -246,10 +238,12 @@ public class ImportLib {
                 // as one and continue.
                 throw (org.python.exceptions.BaseException) e.getCause();
             } catch (ClassCastException java_e) {
-                throw new org.python.exceptions.RuntimeError(e.getCause().getMessage());
+                throw new java.lang.ClassNotFoundException();
             }
         } catch (java.lang.InstantiationException e) {
             // e.printStackTrace();
+            throw new java.lang.ClassNotFoundException();
+        } finally {
             throw new org.python.exceptions.RuntimeError(e.getCause().toString());
         // } finally {
             // org.Python.debug("CONSTRUCTOR DONE");

--- a/python/common/org/python/ImportLib.java
+++ b/python/common/org/python/ImportLib.java
@@ -243,8 +243,6 @@ public class ImportLib {
         } catch (java.lang.InstantiationException e) {
             // e.printStackTrace();
             throw new java.lang.ClassNotFoundException();
-        } finally {
-            throw new org.python.exceptions.RuntimeError(e.getCause().toString());
         // } finally {
             // org.Python.debug("CONSTRUCTOR DONE");
         }


### PR DESCRIPTION
**Changes**

- Change exception from Runtime to ClassNotFound in importPythonModule. This is because the method itself throws ClassNotFound exception rather than Runtime

- Removed the try catch block, This is because if a module doesn't exist in python too then why are we catching the ClassNotFoundException rather than simply throwing it. Main reason of issue#361

**Testing**

- test_import successfully completed

- Expected o/p for issue #361 