### PR TITLE
Fix string splice implementation

### DIFF
--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -225,17 +225,18 @@ public class Str extends org.python.types.Object {
                 } else {
                     long start;
                     if (slice.start != null) {
-                        start = toPositiveIndex(Math.min(slice.start.value, this.value.length()));
+                        start = toPositiveIndex(slice.start.value);
                     } else {
                         start = 0;
                     }
 
                     long stop;
                     if (slice.stop != null) {
-                        stop = toPositiveIndex(Math.min(slice.stop.value, this.value.length()));
+                        stop = toPositiveIndex(slice.stop.value);
                     } else {
                         stop = this.value.length();
                     }
+                    stop = Math.max(start, stop);
 
                     long step;
                     if (slice.step != null) {
@@ -686,11 +687,21 @@ public class Str extends org.python.types.Object {
         throw new org.python.exceptions.NotImplementedError("format_map() has not been implemented.");
     }
 
+    /** Normalize index into an index in the range [0, this.value.length()] */
     private long toPositiveIndex(long index) {
         if (index < 0) {
-            return this.value.length() + index;
+            if (-index > this.value.length()) {
+                return 0;
+            } else {
+                return index + this.value.length();
+            }
+        } else {
+            if (index > this.value.length()) {
+                return this.value.length();
+            } else {
+                return index;
+            }
         }
-        return index;
     }
 
     @org.python.Method(

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -191,6 +191,18 @@ class StrTests(TranspileTestCase):
             print(x[6:7])
             """)
 
+        # Slice bound in both directions with start larger than end
+        self.assertCodeExecution("""
+            x = "12345"
+            print(x[4:1])
+            """)
+
+        # Slice bound in both directions with start and end out of bounds
+        self.assertCodeExecution("""
+            x = "12345"
+            print(x[-10:10])
+            """)
+
     def test_case_changes(self):
         self.assertCodeExecution("""
             for s in ['hello, world', 'HEllo, WORLD', 'átomo', '']:


### PR DESCRIPTION
Implementation was having issues when start was larger than end, and when start or end were beyond the length of the string.
I added tests for these two cases as well as a fix.