### PR TITLE
Add virtualenv commands for Windows to contribution guide

### DIFF
--- a/docs/internals/contributing.rst
+++ b/docs/internals/contributing.rst
@@ -47,6 +47,15 @@ Then create a virtual environment and install VOC into it:
     $ cd voc
     $ pip install -e .
 
+For Windows the use of cmd under Administrator permission is suggested instead of PowerShell.
+
+.. code-block:: batch
+
+    > virtualenv -p "C:\Python34\python.exe" env
+    > env\Scripts\activate.bat
+    > cd voc
+    > pip install -e .
+
 You're now ready to run the test suite!
 
 Running the test suite


### PR DESCRIPTION
There are Windows commands to set up `virtualenv` in the intro/install, but only bash commands are present in the development/contributing. I have added missing commands to development/contributing.

I think it is related to #298.