### PR TITLE
[WIP] overriden binary operations on objects derived of derived classes

### DIFF
--- a/voc/transpiler.py
+++ b/voc/transpiler.py
@@ -25,9 +25,9 @@ class testing(ast.NodeTransformer):
                         # ast.MatMult:
                     }[type(node.op)]
             attr2 = ast.Attribute(value=node.left,attr=attr,ctx=ast.Load())
-            node.func = attr2
-            node.args = [node.right]
-            node.keywords = []
+#             node.func = attr2
+#             node.args = [node.right]
+#             node.keywords = []
             node2 = ast.Call(func=attr2,args=[node.right],keywords=[])
             node2 = ast.copy_location(node2,node)
             node2 = ast.fix_missing_locations(node2)


### PR DESCRIPTION
This PR needs discussions. To fix the issue #436 ,I have tried to use ast.NodeTransformer to convert all BinOp nodes to respective Call nodes . For Example , a*4 BinOp will be converted to a.\_\_mul\_\_(4) 
This is a temporary fix. I am not sure if this is the way we're to supposed to tackle the issue. @freakboy3742  @eliasdorneles @cflee 
