### PR TITLE
implementation of casefold

### DIFF
--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -520,7 +520,7 @@ public class Str extends org.python.types.Object {
                     "Return a version of S suitable for caseless comparisons.\n"
     )
     public org.python.Object casefold() {
-        throw new org.python.exceptions.NotImplementedError("casefold() has not been implemented.");
+        return new org.python.types.Str(this.value.toUpperCase().toLowerCase());
     }
 
     @org.python.Method(

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -603,7 +603,7 @@ class StrTests(TranspileTestCase):
             print("ÅAÆΣß".casefold())
             print("ß.nfG".casefold())
             print("HeLlo_worldʃ!".casefold())
-
+            """)
 
 class UnaryStrOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'str'

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -574,6 +574,13 @@ class StrTests(TranspileTestCase):
                 print(err)
             """)
 
+    def test_casefold(self):
+        self.assertCodeExecution("""
+            print("ÅAÆΣß".casefold())
+            print("ß.nfG".casefold())
+            print("HeLlo_worldʃ!".casefold())
+            """)
+
 
 class UnaryStrOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'str'

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -605,6 +605,7 @@ class StrTests(TranspileTestCase):
             print("HeLlo_worldʃ!".casefold())
             """)
 
+
 class UnaryStrOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'str'
 


### PR DESCRIPTION
While researching about casefold, I figured that the real problem while matching cases would actually arise when the upper case of a character didnt exist (like ß and ʃ). On calling `toUpperCase()` on ß, I found that it was converted to 'SS'! While not being a very solid approach (I'll be happy to find a failing test case), it still solves the problem :smiley: 