### PR TITLE
Add bytes.capitalize and bytes.__iter__

### DIFF
--- a/python/common/org/python/types/Bytes.java
+++ b/python/common/org/python/types/Bytes.java
@@ -563,7 +563,7 @@ public class Bytes extends org.python.types.Object {
         byte[] value = new byte[this.value.length];
         for (int i = 0; i < this.value.length; i++) {
             byte b = this.value[i];
-            if (b < 128) { // TODO: double check if this is sufficient safeguard for ascii
+            if (b < 127 && b > 32) {
                 char c = (char) b;
                 if (i == 0) {
                     c = Character.toUpperCase(c);

--- a/python/common/org/python/types/Bytes.java
+++ b/python/common/org/python/types/Bytes.java
@@ -472,8 +472,12 @@ public class Bytes extends org.python.types.Object {
     @org.python.Method(
             __doc__ = ""
     )
-    public org.python.Iterable __iter__(java.util.List<org.python.Object> args, java.util.Map<java.lang.String, org.python.Object> kwargs, java.util.List<org.python.Object> default_args, java.util.Map<java.lang.String, org.python.Object> default_kwargs) {
-        throw new org.python.exceptions.NotImplementedError("bytes.__iter__ has not been implemented.");
+    public org.python.Iterable __iter__() {
+        java.util.List<org.python.Object> listOfBytes = new java.util.ArrayList<org.python.Object>();
+        for (byte b: this.value) {
+            listOfBytes.add(new org.python.types.Int(b));
+        }
+        return new org.python.types.List(listOfBytes).__iter__();
     }
 
     @org.python.Method(
@@ -555,8 +559,23 @@ public class Bytes extends org.python.types.Object {
     @org.python.Method(
             __doc__ = ""
     )
-    public org.python.Object capitalize(java.util.List<org.python.Object> args, java.util.Map<java.lang.String, org.python.Object> kwargs, java.util.List<org.python.Object> default_args, java.util.Map<java.lang.String, org.python.Object> default_kwargs) {
-        throw new org.python.exceptions.NotImplementedError("bytes.capitalize has not been implemented.");
+    public org.python.Object capitalize() {
+        byte[] value = new byte[this.value.length];
+        for (int i = 0; i < this.value.length; i++) {
+            byte b = this.value[i];
+            if (b < 128) { // TODO: double check if this is sufficient safeguard for ascii
+                char c = (char) b;
+                if (i == 0) {
+                    c = Character.toUpperCase(c);
+                } else {
+                    c = Character.toLowerCase(c);
+                }
+                value[i] = (byte) c;
+            } else {
+                value[i] = b;
+            }
+        }
+        return new Bytes(value);
     }
 
     @org.python.Method(

--- a/tests/builtins/test_map.py
+++ b/tests/builtins/test_map.py
@@ -1,7 +1,5 @@
 from .. utils import TranspileTestCase, BuiltinTwoargFunctionTestCase
 
-from unittest import expectedFailure
-
 
 class MapTests(TranspileTestCase):
     base_code = """
@@ -22,7 +20,6 @@ class MapTests(TranspileTestCase):
     def test_bool(self):
         self.assertCodeExecution(self.base_code % ("[True, False, True]", "bool(x)"))
 
-    @expectedFailure
     def test_bytearray(self):
         self.assertCodeExecution(self.base_code % ("b'123'", "x"))
 

--- a/tests/datatypes/test_bytes.py
+++ b/tests/datatypes/test_bytes.py
@@ -1,5 +1,7 @@
 from .. utils import TranspileTestCase, UnaryOperationTestCase, BinaryOperationTestCase, InplaceOperationTestCase
 
+import unittest
+
 
 class BytesTests(TranspileTestCase):
     def test_setattr(self):
@@ -26,6 +28,12 @@ class BytesTests(TranspileTestCase):
             print(b'helloWORLD'.capitalize())
             print(b'HELLO WORLD'.capitalize())
             print(b'2015638687'.capitalize())
+        """)
+
+    @unittest.skip("Move this to test_capitalize upon resolution of #530")
+    def test_capitalize_with_nonascii(self):
+        self.assertCodeExecution("""
+            print(b'\xc8'.capitalize())
         """)
 
     def test_iter(self):

--- a/tests/datatypes/test_bytes.py
+++ b/tests/datatypes/test_bytes.py
@@ -1,6 +1,6 @@
 from .. utils import TranspileTestCase, UnaryOperationTestCase, BinaryOperationTestCase, InplaceOperationTestCase
 
-import unittest
+from unittest import expectedFailure
 
 
 class BytesTests(TranspileTestCase):
@@ -30,8 +30,9 @@ class BytesTests(TranspileTestCase):
             print(b'2015638687'.capitalize())
         """)
 
-    @unittest.skip("Move this to test_capitalize upon resolution of #530")
+    @expectedFailure
     def test_capitalize_with_nonascii(self):
+        # Move this to test_capitalize upon resolution of #530
         self.assertCodeExecution("""
             print(b'\xc8'.capitalize())
         """)

--- a/tests/datatypes/test_bytes.py
+++ b/tests/datatypes/test_bytes.py
@@ -20,6 +20,20 @@ class BytesTests(TranspileTestCase):
                 print(err)
             """)
 
+    def test_capitalize(self):
+        self.assertCodeExecution("""
+            print(b'hello, world'.capitalize())
+            print(b'helloWORLD'.capitalize())
+            print(b'HELLO WORLD'.capitalize())
+            print(b'2015638687'.capitalize())
+        """)
+
+    def test_iter(self):
+        self.assertCodeExecution("""
+            print([b for b in b''])
+            print([b for b in b'hello world'])
+        """)
+
 
 class UnaryBytesOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'bytes'


### PR DESCRIPTION
Here is an implementation of the bytes.capitalize and byte.__iter__() methods.

I ran into a problem while testing the capitalize function with other byte values:

    print(b'\\xfa'.capitalize()[0])

I saw an error related to writing to the test suite, and left it alone for now.

Does this look good?
