### PR TITLE
Resolve target for augassign, fix decorator to take args and kwargs

### DIFF
--- a/tests/structures/test_assignment.py
+++ b/tests/structures/test_assignment.py
@@ -86,3 +86,27 @@ class AssignmentTests(TranspileTestCase):
             print(y)
             print(z)
             """)
+
+    def test_increment_assignment(self):
+        self.assertCodeExecution("""
+            a = 1
+            a += 1
+            print(a)
+            """)
+
+    def test_increment_assignment_attribute(self):
+        self.assertCodeExecution("""
+            class Thing(object):
+                a = 1
+
+            t = Thing()
+            t.a += 1
+            print(t.a)
+            """)
+
+    def test_increment_assignment_subscript(self):
+        self.assertCodeExecution("""
+            a = [0, 1, 2]
+            a[0] += 1
+            print(a)
+            """)


### PR DESCRIPTION
Fixes #534 

`visit_AugAssign` was considering only the case where the target is a `Name`, but it can also take `Attribute` or `Subscript`: http://greentreesnakes.readthedocs.io/en/latest/nodes.html#AugAssign

This PR fixes the issue by checking the type of the target first and using the appropriate visitor first.
It also fixes the `@node_visitor` decorator to allow extra arguments and keyword arguments to be passed.

(thanks @eliasdorneles !)