### PR TITLE
Contributing: Reference Cricket for tests

### DIFF
--- a/docs/internals/contributing.rst
+++ b/docs/internals/contributing.rst
@@ -108,6 +108,14 @@ Or, to run all the datatypes tests:
 
     $ python setup.py test -s tests.datatypes
 
+Or you can use Cricket, a GUI tool for running test suites. To start cricket in the background:
+
+.. code-block:: bash
+
+    $ pip install -r requirements/tests.txt
+    $ cricket-unittest &
+
+This should open a GUI window that lists all the tests. From there you can "Run all" or select specific tests and "Run selected."
 
 Running the code style checks
 -----------------------------

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -10,3 +10,6 @@ pytest==2.9.2
 
 # Support for parallel test execution
 pytest-xdist==1.14
+
+# Install cricket for GUI testsuite
+cricket


### PR DESCRIPTION
Add Cricket to the testing reqs, and suggest using it in the docs.