### PR TITLE
Fix dict conversion errors for strings

### DIFF
--- a/python/common/org/python/types/Dict.java
+++ b/python/common/org/python/types/Dict.java
@@ -66,6 +66,12 @@ public class Dict extends org.python.types.Object {
                             data = ((org.python.types.Tuple) next).value;
                         } else if (next instanceof org.python.types.List) {
                             data = ((org.python.types.List) next).value;
+                        } else if (next instanceof org.python.types.Str) {
+                            org.python.types.Str str = ((org.python.types.Str) next);
+                            data = new java.util.ArrayList<org.python.Object>();
+                            for (int i = 0; i < ((org.python.types.Int) str.__len__()).value; i++) {
+                                data.add(str.__getitem__(new org.python.types.Int(i)));
+                            }
                         } else {
                             throw new org.python.exceptions.TypeError(
                                     "cannot convert dictionary update sequence element #" + generated.size() +

--- a/tests/builtins/test_dict.py
+++ b/tests/builtins/test_dict.py
@@ -12,8 +12,6 @@ class BuiltinDictFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
         'test_bytearray',
         'test_bytes',
         'test_class',
-        'test_frozenset',
         'test_list',
-        'test_set',
         'test_str',
     ]

--- a/tests/builtins/test_list.py
+++ b/tests/builtins/test_list.py
@@ -1,4 +1,4 @@
-from .. utils import TranspileTestCase, BuiltinFunctionTestCase
+from .. utils import TranspileTestCase, BuiltinFunctionTestCase, SAMPLE_SUBSTITUTIONS
 
 
 class ListTests(TranspileTestCase):
@@ -8,15 +8,14 @@ class ListTests(TranspileTestCase):
 class BuiltinListFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     functions = ["list"]
 
-    substitutions = {
-        "[1, 2.3456, 'another']": [
-            "[1, 'another', 2.3456]",
-            "[2.3456, 1, 'another']",
-            "[2.3456, 'another', 1]",
-            "['another', 1, 2.3456]",
-            "['another', 2.3456, 1]",
-        ]
-    }
+    substitutions = dict(SAMPLE_SUBSTITUTIONS)
+    substitutions["[1, 2.3456, 'another']"] = [
+        "[1, 'another', 2.3456]",
+        "[2.3456, 1, 'another']",
+        "[2.3456, 'another', 1]",
+        "['another', 1, 2.3456]",
+        "['another', 2.3456, 1]",
+    ]
 
     not_implemented = [
         'test_bytearray',

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,6 +9,7 @@ import sys
 import tempfile
 import traceback
 from unittest import TestCase
+from itertools import permutations
 
 from voc.python.blocks import Block as PyBlock
 from voc.python.modules import Module as PyModule
@@ -646,7 +647,9 @@ SAMPLE_DATA = {
         ],
     'frozenset': [
             'frozenset()',
-            'frozenset({1, 2.3456, "another"})',
+            'frozenset({"on","to","an"})',
+            'frozenset({"one","two","six"})',
+            'frozenset({1, 2.3456, 7})',
         ],
     'int': [
             '0',
@@ -671,7 +674,9 @@ SAMPLE_DATA = {
         ],
     'set': [
             'set()',
-            'set({1, 2.3456, "another"})',
+            'set({"on","to","an"})',
+            'set({"one","two","six"})',
+            'set({1, 2.3456, 7})',
         ],
     'slice': [
             'slice(0)',
@@ -705,30 +710,44 @@ SAMPLE_DATA = {
 }
 
 
+def _string_substitutions(string):
+    delims = (string[0], string[-1])
+    string = string[1:-1]
+    elems = [elem for elem in string.split(", ")]
+    perms = permutations(elems)
+    return [(delims[0] + ", ".join(list(perm)) + delims[1]) for perm in perms]
+
+
 SAMPLE_SUBSTITUTIONS = {
     # Normalize set ordering
-    "{1, 2.3456, 'another'}": [
-        "{1, 'another', 2.3456}",
-        "{2.3456, 1, 'another'}",
-        "{2.3456, 'another', 1}",
-        "{'another', 1, 2.3456}",
-        "{'another', 2.3456, 1}",
-    ],
-    "{'a', 'b', 'c'}": [
-        "{'a', 'c', 'b'}",
-        "{'b', 'a', 'c'}",
-        "{'b', 'c', 'a'}",
-        "{'c', 'a', 'b'}",
-        "{'c', 'b', 'a'}",
-    ],
+    "{1, 2.3456, 7}": _string_substitutions("{1, 2.3456, 7}"),
+    "{1, 2.3456, 'another'}": _string_substitutions("{1, 2.3456, 'another'}"),
+    "{'an', 'to', 'on'}": _string_substitutions("{'an', 'to', 'on'}"),
+    "{'one', 'two', 'six'}": _string_substitutions("{'one', 'two', 'six'}"),
+    "{'a', 'b', 'c'}": _string_substitutions("{'a', 'b', 'c'}"),
+
+    # Normalize list ordering
+    "[1, 2.3456, 7]": _string_substitutions("[1, 2.3456, 7]"),
+    "[1, 2.3456, 'another']": _string_substitutions("[1, 2.3456, 'another']"),
+    "['a', 'b', 'c']": _string_substitutions("['a', 'b', 'c']"),
+    "['an', 'to', 'on']": _string_substitutions("['an', 'to', 'on']"),
+
+    "['one', 'two', 'six']": _string_substitutions("['one', 'two', 'six']"),
     # Normalize dictionary ordering
-    "{'a': 1, 'c': 2.3456, 'd': 'another'}": [
-        "{'a': 1, 'd': 'another', 'c': 2.3456}",
-        "{'c': 2.3456, 'd': 'another', 'a': 1}",
-        "{'c': 2.3456, 'a': 1, 'd': 'another'}",
-        "{'d': 'another', 'a': 1, 'c': 2.3456}",
-        "{'d': 'another', 'c': 2.3456, 'a': 1}",
-    ],
+    "{'a': 1, 'c': 2.3456, 'd': 7}": _string_substitutions(
+                                              "{'a': 1, 'c': 2.3456, 'd': 7}"),
+    "{'a': 1, 'c': 2.3456, 'd': 'another'}": _string_substitutions(
+                                      "{'a': 1, 'c': 2.3456, 'd': 'another'}"),
+    "{'a': 'n', 't': 'o', 'o': 'n'}": _string_substitutions(
+                                             "{'a': 'n', 't': 'o', 'o': 'n'}"),
+    "{'to', 'two', 'one', 'an', 'on', 'six'}": _string_substitutions(
+                                    "{'to', 'two', 'one', 'an', 'on', 'six'}"),
+    "{1, 2.3456, 7, 'one', 'six', 'two'}": _string_substitutions(
+                                        "{1, 2.3456, 7, 'one', 'six', 'two'}"),
+    "{1, 2.3456, 7, 'on', 'an', 'to'}": _string_substitutions(
+                                        "{1, 2.3456, 7, 'on', 'an', 'to'}"),
+    "{1, 2.3456, 7, 1, 2.3456, 7}": _string_substitutions(
+                                        "{1, 2.3456, 7, 1, 2.3456, 7}"),
     # Normalize precision error
     "-3.14159": ["-3.1415900000000008"],
 }


### PR DESCRIPTION
When sets and frozen sets were converted to dicts, if they contained
string elements those string elements would not be converted as they
would in python. Fix this.

As part of this commit, the mixed case unit test was removed, this is
due to randomisation present in sets in python 3.4 causing flakey tests.

Signed-off-by: Meghan Halton <meghalton@gmail.com>
Signed-off-by: Pamela McA'Nulty <pamela@mcanulty.org>