### PR TITLE
Patch rich comparisons to handle classes/types

### DIFF
--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -1105,7 +1105,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         }
 
         org.python.Object comparator = x.__getattribute_null(methodName);
-        if (comparator == null) {
+        if (comparator == null || !(comparator instanceof org.python.types.Method)) {
             return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
         }
 

--- a/tests/datatypes/test_NoneType.py
+++ b/tests/datatypes/test_NoneType.py
@@ -64,22 +64,17 @@ class BinaryNoneTypeOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_direct_le_frozenset',
         'test_direct_lt_frozenset',
 
-        'test_eq_class',
         'test_eq_frozenset',
 
-        'test_ge_class',
         'test_ge_frozenset',
 
-        'test_gt_class',
         'test_gt_frozenset',
 
-        'test_le_class',
         'test_le_frozenset',
 
         'test_lshift_class',
         'test_lshift_frozenset',
 
-        'test_lt_class',
         'test_lt_frozenset',
 
         'test_modulo_class',
@@ -91,7 +86,6 @@ class BinaryNoneTypeOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_multiply_class',
         'test_multiply_frozenset',
 
-        'test_ne_class',
         'test_ne_frozenset',
 
         'test_or_class',

--- a/tests/datatypes/test_NotImplemented.py
+++ b/tests/datatypes/test_NotImplemented.py
@@ -37,22 +37,17 @@ class BinaryNotImplementedOperationTests(BinaryOperationTestCase, TranspileTestC
         'test_direct_lt_frozenset',
         'test_direct_ne_frozenset',
 
-        'test_eq_class',
         'test_eq_frozenset',
 
-        'test_ge_class',
         'test_ge_frozenset',
 
-        'test_gt_class',
         'test_gt_frozenset',
 
-        'test_le_class',
         'test_le_frozenset',
 
         'test_lshift_class',
         'test_lshift_frozenset',
 
-        'test_lt_class',
         'test_lt_frozenset',
 
         'test_modulo_class',
@@ -64,7 +59,6 @@ class BinaryNotImplementedOperationTests(BinaryOperationTestCase, TranspileTestC
         'test_multiply_class',
         'test_multiply_frozenset',
 
-        'test_ne_class',
         'test_ne_frozenset',
 
         'test_or_class',

--- a/tests/datatypes/test_bool.py
+++ b/tests/datatypes/test_bool.py
@@ -54,22 +54,17 @@ class BinaryBoolOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_direct_lt_frozenset',
         'test_direct_ne_frozenset',
 
-        'test_eq_class',
         'test_eq_frozenset',
 
-        'test_ge_class',
         'test_ge_frozenset',
 
-        'test_gt_class',
         'test_gt_frozenset',
 
-        'test_le_class',
         'test_le_frozenset',
 
         'test_lshift_class',
         'test_lshift_frozenset',
 
-        'test_lt_class',
         'test_lt_frozenset',
 
         'test_modulo_class',
@@ -80,7 +75,6 @@ class BinaryBoolOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_multiply_complex',
         'test_multiply_frozenset',
 
-        'test_ne_class',
         'test_ne_frozenset',
 
         'test_or_class',

--- a/tests/datatypes/test_bytearray.py
+++ b/tests/datatypes/test_bytearray.py
@@ -45,22 +45,17 @@ class BinaryBytearrayOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_direct_lt_frozenset',
         'test_direct_ne_frozenset',
 
-        'test_eq_class',
         'test_eq_frozenset',
 
-        'test_ge_class',
         'test_ge_frozenset',
 
-        'test_gt_class',
         'test_gt_frozenset',
 
-        'test_le_class',
         'test_le_frozenset',
 
         'test_lshift_class',
         'test_lshift_frozenset',
 
-        'test_lt_class',
         'test_lt_frozenset',
 
         'test_modulo_class',
@@ -70,7 +65,6 @@ class BinaryBytearrayOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_multiply_class',
         'test_multiply_frozenset',
 
-        'test_ne_class',
         'test_ne_frozenset',
 
         'test_or_class',

--- a/tests/datatypes/test_bytes.py
+++ b/tests/datatypes/test_bytes.py
@@ -160,22 +160,16 @@ class BinaryBytesOperationTests(BinaryOperationTestCase, TranspileTestCase):
 
         'test_eq_bytearray',
         'test_eq_bytes',
-        'test_eq_class',
         'test_eq_frozenset',
 
-        'test_ne_class',
         'test_ne_frozenset',
 
-        'test_ge_class',
         'test_ge_frozenset',
 
-        'test_gt_class',
         'test_gt_frozenset',
 
-        'test_le_class',
         'test_le_frozenset',
 
-        'test_lt_class',
         'test_lt_frozenset',
 
         'test_lshift_class',

--- a/tests/datatypes/test_complex.py
+++ b/tests/datatypes/test_complex.py
@@ -85,25 +85,20 @@ class BinaryComplexOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_direct_ne_float',
         'test_direct_ne_int',
 
-        'test_eq_class',
         'test_eq_frozenset',
 
         'test_floor_divide_class',
         'test_floor_divide_frozenset',
 
-        'test_ge_class',
         'test_ge_frozenset',
 
-        'test_gt_class',
         'test_gt_frozenset',
 
-        'test_le_class',
         'test_le_frozenset',
 
         'test_lshift_class',
         'test_lshift_frozenset',
 
-        'test_lt_class',
         'test_lt_frozenset',
 
         'test_modulo_class',
@@ -112,7 +107,6 @@ class BinaryComplexOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_multiply_class',
         'test_multiply_frozenset',
 
-        'test_ne_class',
         'test_ne_frozenset',
 
         'test_or_class',

--- a/tests/datatypes/test_dict.py
+++ b/tests/datatypes/test_dict.py
@@ -325,22 +325,17 @@ class BinaryDictOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_direct_lt_frozenset',
         'test_direct_ne_frozenset',
 
-        'test_eq_class',
         'test_eq_frozenset',
 
-        'test_ge_class',
         'test_ge_frozenset',
 
-        'test_gt_class',
         'test_gt_frozenset',
 
-        'test_le_class',
         'test_le_frozenset',
 
         'test_lshift_class',
         'test_lshift_frozenset',
 
-        'test_lt_class',
         'test_lt_frozenset',
 
         'test_modulo_class',
@@ -351,7 +346,6 @@ class BinaryDictOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_multiply_class',
         'test_multiply_frozenset',
 
-        'test_ne_class',
         'test_ne_frozenset',
 
         'test_or_class',

--- a/tests/datatypes/test_float.py
+++ b/tests/datatypes/test_float.py
@@ -128,22 +128,17 @@ class BinaryFloatOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_direct_lt_frozenset',
         'test_direct_ne_frozenset',
 
-        'test_eq_class',
         'test_eq_frozenset',
 
-        'test_ge_class',
         'test_ge_frozenset',
 
-        'test_gt_class',
         'test_gt_frozenset',
 
-        'test_le_class',
         'test_le_frozenset',
 
         'test_lshift_class',
         'test_lshift_frozenset',
 
-        'test_lt_class',
         'test_lt_frozenset',
 
         'test_modulo_class',
@@ -158,7 +153,6 @@ class BinaryFloatOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_multiply_NotImplemented',
         'test_multiply_range',
 
-        'test_ne_class',
         'test_ne_frozenset',
 
         'test_or_class',

--- a/tests/datatypes/test_frozenset.py
+++ b/tests/datatypes/test_frozenset.py
@@ -441,8 +441,6 @@ class BinaryFrozensetOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_direct_gt_str',
         'test_direct_gt_tuple',
 
-        'test_eq_class',
-
         'test_floor_divide_bool',
         'test_floor_divide_bytearray',
         'test_floor_divide_bytes',
@@ -459,12 +457,6 @@ class BinaryFrozensetOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_floor_divide_slice',
         'test_floor_divide_str',
         'test_floor_divide_tuple',
-
-        'test_ge_class',
-
-        'test_gt_class',
-
-        'test_le_class',
 
         'test_lshift_bool',
         'test_lshift_bytearray',
@@ -483,8 +475,6 @@ class BinaryFrozensetOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_lshift_slice',
         'test_lshift_str',
         'test_lshift_tuple',
-
-        'test_lt_class',
 
         'test_modulo_bool',
         'test_modulo_bytearray',
@@ -509,7 +499,6 @@ class BinaryFrozensetOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_ne_bool',
         'test_ne_bytearray',
         'test_ne_bytes',
-        'test_ne_class',
         'test_ne_complex',
         'test_ne_dict',
         'test_ne_float',

--- a/tests/datatypes/test_int.py
+++ b/tests/datatypes/test_int.py
@@ -56,22 +56,17 @@ class BinaryIntOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_direct_lt_frozenset',
         'test_direct_ne_frozenset',
 
-        'test_eq_class',
         'test_eq_frozenset',
 
-        'test_ge_class',
         'test_ge_frozenset',
 
-        'test_gt_class',
         'test_gt_frozenset',
 
-        'test_le_class',
         'test_le_frozenset',
 
         'test_lshift_class',
         'test_lshift_frozenset',
 
-        'test_lt_class',
         'test_lt_frozenset',
 
         'test_modulo_class',
@@ -82,7 +77,6 @@ class BinaryIntOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_multiply_complex',
         'test_multiply_frozenset',
 
-        'test_ne_class',
         'test_ne_frozenset',
 
         'test_or_class',

--- a/tests/datatypes/test_list.py
+++ b/tests/datatypes/test_list.py
@@ -624,25 +624,20 @@ class BinaryListOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_direct_lt_frozenset',
         'test_direct_ne_frozenset',
 
-        'test_eq_class',
         'test_eq_frozenset',
 
-        'test_ge_class',
         'test_ge_frozenset',
         'test_ge_list',
 
-        'test_gt_class',
         'test_gt_frozenset',
         'test_gt_list',
 
-        'test_le_class',
         'test_le_frozenset',
         'test_le_list',
 
         'test_lshift_class',
         'test_lshift_frozenset',
 
-        'test_lt_class',
         'test_lt_frozenset',
         'test_lt_list',
 
@@ -653,7 +648,6 @@ class BinaryListOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_multiply_class',
         'test_multiply_frozenset',
 
-        'test_ne_class',
         'test_ne_frozenset',
 
         'test_or_class',

--- a/tests/datatypes/test_range.py
+++ b/tests/datatypes/test_range.py
@@ -105,7 +105,6 @@ class BinaryRangeOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_direct_eq_range',
         'test_direct_ne_range',
 
-        'test_eq_class',
         'test_eq_frozenset',
         'test_eq_range',
 
@@ -196,7 +195,6 @@ class BinaryRangeOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_multiply_str',
         'test_multiply_tuple',
 
-        'test_ne_class',
         'test_ne_frozenset',
         'test_ne_range',
 

--- a/tests/datatypes/test_set.py
+++ b/tests/datatypes/test_set.py
@@ -399,18 +399,8 @@ class BinarySetOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_direct_gt_tuple',
         'test_direct_le_tuple',
 
-        'test_eq_class',
-
-        'test_ge_class',
-
-        'test_gt_class',
-
-        'test_le_class',
-
         'test_lshift_class',
         'test_lshift_frozenset',
-
-        'test_lt_class',
 
         'test_modulo_class',
         'test_modulo_complex',
@@ -421,7 +411,6 @@ class BinarySetOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_multiply_class',
         'test_multiply_frozenset',
 
-        'test_ne_class',
         'test_ne_frozenset',
 
         'test_or_class',

--- a/tests/datatypes/test_slice.py
+++ b/tests/datatypes/test_slice.py
@@ -94,7 +94,6 @@ class BinarySliceOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_direct_lt_slice',
         'test_direct_ne_slice',
 
-        'test_eq_class',
         'test_eq_frozenset',
         'test_eq_slice',
 
@@ -185,7 +184,6 @@ class BinarySliceOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_multiply_str',
         'test_multiply_tuple',
 
-        'test_ne_class',
         'test_ne_frozenset',
         'test_ne_slice',
 

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -717,22 +717,17 @@ class BinaryStrOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_direct_lt_frozenset',
         'test_direct_ne_frozenset',
 
-        'test_eq_class',
         'test_eq_frozenset',
 
-        'test_ge_class',
         'test_ge_frozenset',
 
-        'test_gt_class',
         'test_gt_frozenset',
 
-        'test_le_class',
         'test_le_frozenset',
 
         'test_lshift_class',
         'test_lshift_frozenset',
 
-        'test_lt_class',
         'test_lt_frozenset',
 
         'test_modulo_bool',
@@ -756,7 +751,6 @@ class BinaryStrOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_multiply_class',
         'test_multiply_frozenset',
 
-        'test_ne_class',
         'test_ne_frozenset',
 
         'test_or_class',

--- a/tests/datatypes/test_tuple.py
+++ b/tests/datatypes/test_tuple.py
@@ -295,25 +295,20 @@ class BinaryTupleOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_direct_le_tuple',
         'test_direct_lt_tuple',
 
-        'test_eq_class',
         'test_eq_frozenset',
 
-        'test_ge_class',
         'test_ge_frozenset',
         'test_ge_tuple',
 
-        'test_gt_class',
         'test_gt_frozenset',
         'test_gt_tuple',
 
-        'test_le_class',
         'test_le_frozenset',
         'test_le_tuple',
 
         'test_lshift_class',
         'test_lshift_frozenset',
 
-        'test_lt_class',
         'test_lt_frozenset',
         'test_lt_tuple',
 
@@ -324,7 +319,6 @@ class BinaryTupleOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_multiply_class',
         'test_multiply_frozenset',
 
-        'test_ne_class',
         'test_ne_frozenset',
 
         'test_or_class',


### PR DESCRIPTION
I was investigating #543, #545, #546, #547 all of which are implementing comparisons with class, and found that the TypeError messages are rather similar... I think a better place to fix those issues might be in the underlying rich comparisons logic, instead of on the individual datatypes.

The implementation I did in #122 assumes that when calling `__getattribute_null()` on an operand to obtain the comparison method, it always returns a Method, which can be duly invoked for a result. However, this assumption is faulty for org.python.types.Type operands (`type(1)`), as its `__getattribute_null()` returns a Function which isn’t already bound to an object instance.

In any case it only makes sense to invoke the comparison method on an object, not on a class/type, so just let's avoid this entirely. Testing if it’s a Method and returning NotImplemented otherwise (instead of a NullPointerException) allows `__cmp__()` to generate the appropriate TypeError string.