### PR TITLE
Bytes.count

### DIFF
--- a/python/common/org/python/types/Bytes.java
+++ b/python/common/org/python/types/Bytes.java
@@ -609,7 +609,11 @@ public class Bytes extends org.python.types.Object {
         } else if (sub instanceof org.python.types.Bytes) {
             sub_array = ((org.python.types.Bytes) sub).value;
         } else {
-            throw new org.python.exceptions.TypeError("a bytes-like object is required, not '" + sub.typeName() + "'\n");
+            String error_message = "a bytes-like object is required, not '" + sub.typeName() + "'\n";
+            if (org.Python.VERSION < 0x03050000) {
+                error_message = "'" + sub.typeName() + "' does not support the buffer interface\n";
+            }
+            throw new org.python.exceptions.TypeError(error_message);
         }
         //If the sub string is longer than the value string a match cannot exist
         if (sub_array.length > this.value.length) {

--- a/tests/datatypes/test_bytes.py
+++ b/tests/datatypes/test_bytes.py
@@ -43,6 +43,34 @@ class BytesTests(TranspileTestCase):
             print([b for b in b'hello world'])
         """)
 
+    def test_count(self):
+        self.assertCodeExecution("""
+            print(b'abcabca'.count(97))
+            print(b'abcabca'.count(b'abc'))
+            print(b'qqq'.count(b'q'))
+            print(b'qqq'.count(b'qq'))
+            print(b'qqq'.count(b'qqq'))
+            print(b'qqq'.count(b'qqqq'))
+            print(b'abcdefgh'.count(b'bc',-7, -5))
+            print(b'abcdefgh'.count(b'bc',1, -5))
+            print(b'abcdefgh'.count(b'bc',0, 3))
+            print(b'abcdefgh'.count(b'bc',-7, 500))
+            print(b'qqaqqbqqqcqqqdqqqqeqqqqf'.count(b'qq'),1)
+            print(b''.count(b'q'),0)
+        """)
+        self.assertCodeExecution("""
+            b'abcabc'.count([]) #Test TypeError invalid byte array
+        """, exits_early=True)
+        self.assertCodeExecution("""
+            b'abcabc'.count(256) #Test ValueError invalid integer range
+        """, exits_early=True)
+        self.assertCodeExecution("""
+            print(b'abcabca'.count(97, [], 3)) #Test Slicing Error on Start
+        """, exits_early=True)
+        self.assertCodeExecution("""
+            print(b'abcabca'.count(97, 3, [])) #Test Slicing Error on End
+        """, exits_early=True)
+
 
 class UnaryBytesOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'bytes'


### PR DESCRIPTION
Implemented Bytes.count and associated unit tests.  Slices indices start and end handle the cases for integer and none.  According to the python error any object which supports `__index__` is supported for slicing.  Objects coming in are currently not evaluated for `__index__`, recommend implementing this as part of `__getitem__` and refactoring Bytes.count to reuse the slicing provided by `__getitem__`.