### PR TITLE
Added slicing for objects with __index__ PEP 357.

### DIFF
--- a/python/common/org/python/types/Slice.java
+++ b/python/common/org/python/types/Slice.java
@@ -21,7 +21,18 @@ public class Slice extends org.python.types.Object {
         } else if (start instanceof org.python.types.NoneType) {
             this.__dict__.put("start", start);
         } else {
-            throw new org.python.exceptions.TypeError("'" + start.typeName() + "' object cannot be interpreted as an integer");
+            org.python.Object index_object;
+            try {
+                index_object = start.__index__();
+            } catch (org.python.exceptions.TypeError error) {
+                throw new org.python.exceptions.TypeError("'" + start.typeName() + "' object cannot be interpreted as an integer");
+            }
+            if (index_object instanceof org.python.types.Int) {
+                this.__dict__.put("start", start);
+                this.start = (org.python.types.Int) index_object;
+            } else {
+                throw new org.python.exceptions.TypeError("TypeError: __index__ returned non-int (type " + index_object.typeName() + ")");
+            }
         }
 
         if (stop instanceof org.python.types.Int) {
@@ -30,7 +41,18 @@ public class Slice extends org.python.types.Object {
         } else if (stop instanceof org.python.types.NoneType) {
             this.__dict__.put("stop", stop);
         } else {
-            throw new org.python.exceptions.TypeError("'" + stop.typeName() + "' object cannot be interpreted as an integer");
+            org.python.Object index_object;
+            try {
+                index_object = stop.__index__();
+            } catch (org.python.exceptions.TypeError error) {
+                throw new org.python.exceptions.TypeError("'" + stop.typeName() + "' object cannot be interpreted as an integer");
+            }
+            if (index_object instanceof org.python.types.Int) {
+                this.__dict__.put("stop", stop);
+                this.stop = (org.python.types.Int) index_object;
+            } else {
+                throw new org.python.exceptions.TypeError("TypeError: __index__ returned non-int (type " + index_object.typeName() + ")");
+            }
         }
 
         if (step instanceof org.python.types.Int) {
@@ -43,7 +65,18 @@ public class Slice extends org.python.types.Object {
         } else if (step instanceof org.python.types.NoneType) {
             this.__dict__.put("step", step);
         } else {
-            throw new org.python.exceptions.TypeError("'" + step.typeName() + "' object cannot be interpreted as an integer");
+            org.python.Object index_object;
+            try {
+                index_object = step.__index__();
+            } catch (org.python.exceptions.TypeError error) {
+                throw new org.python.exceptions.TypeError("'" + step.typeName() + "' object cannot be interpreted as an integer");
+            }
+            if (index_object instanceof org.python.types.Int) {
+                this.__dict__.put("step", step);
+                this.step = (org.python.types.Int) index_object;
+            } else {
+                throw new org.python.exceptions.TypeError("TypeError: __index__ returned non-int (type " + index_object.typeName() + ")");
+            }
         }
     }
 

--- a/tests/datatypes/test_slice.py
+++ b/tests/datatypes/test_slice.py
@@ -57,7 +57,7 @@ class SliceTests(TranspileTestCase):
             print("x[:5:2] = ", x[:5:2])
             print("x[2:8:2] = ", x[2:8:2])
             """)
-    
+
     def test_slice_index(self):
         self.assertCodeExecution("""
             class C(object):
@@ -65,7 +65,6 @@ class SliceTests(TranspileTestCase):
                     self._value = value
                 def __index__(self):
                     return self._value
-                    
             x = range(0, 10)
             print("x[:] = ", x[:])
             print("x[C(5):] = ", x[C(5):])
@@ -76,6 +75,7 @@ class SliceTests(TranspileTestCase):
             print("x[:C(5):C(2] = ", x[:C(5):C(2)])
             print("x[C(2):C(8):C(2)] = ", x[C(2):C(8):C(2)])
             """)
+
 
 class UnarySliceOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'slice'

--- a/tests/datatypes/test_slice.py
+++ b/tests/datatypes/test_slice.py
@@ -57,7 +57,25 @@ class SliceTests(TranspileTestCase):
             print("x[:5:2] = ", x[:5:2])
             print("x[2:8:2] = ", x[2:8:2])
             """)
-
+    
+    def test_slice_index(self):
+        self.assertCodeExecution("""
+            class C(object):
+                def __init__(self, value):
+                    self._value = value
+                def __index__(self):
+                    return self._value
+                    
+            x = range(0, 10)
+            print("x[:] = ", x[:])
+            print("x[C(5):] = ", x[C(5):])
+            print("x[:C(5)] = ", x[:C(5)])
+            print("x[C(2):C(8)] = ", x[C(2):C(8)])
+            print("x[::C(2)] = ", x[::C(2)])
+            print("x[C(5)::C(2)] = ", x[C(5)::C(2)])
+            print("x[:C(5):C(2] = ", x[:C(5):C(2)])
+            print("x[C(2):C(8):C(2)] = ", x[C(2):C(8):C(2)])
+            """)
 
 class UnarySliceOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'slice'


### PR DESCRIPTION
Added slicing for objects with `__index__` PEP 357.

The additional logic checks to see if an object provides `__index__`  calls `__index__` on the object and verifies the result is an integer.