### PR TITLE
Fix bytecode writing and bytes representation (closes #530)

### DIFF
--- a/python/common/org/python/types/Bytes.java
+++ b/python/common/org/python/types/Bytes.java
@@ -70,11 +70,17 @@ public class Bytes extends org.python.types.Object {
     public org.python.types.Str __str__() {
         StringBuilder sb = new StringBuilder();
         sb.append("b'");
-        for (int c : this.value) {
-            if (c >= 32 && c < 128) {
+        for (byte c : this.value) {
+            if (c == '\n') {
+                sb.append("\\n");
+            } else if (c == '\t') {
+                sb.append("\\t");
+            } else if (c == '\r') {
+                sb.append("\\r");
+            } else if (c >= 32 && c < 127) {
                 sb.append((char) c);
             } else {
-                sb.append(String.format("\\x%02d", c));
+                sb.append(String.format("\\x%02x", c));
             }
         }
         sb.append("'");

--- a/tests/datatypes/test_bytes.py
+++ b/tests/datatypes/test_bytes.py
@@ -23,18 +23,20 @@ class BytesTests(TranspileTestCase):
             """)
 
     def test_capitalize(self):
-        self.assertCodeExecution("""
+        self.assertCodeExecution(r"""
             print(b'hello, world'.capitalize())
             print(b'helloWORLD'.capitalize())
             print(b'HELLO WORLD'.capitalize())
             print(b'2015638687'.capitalize())
+            print(b'\xc8'.capitalize())
         """)
 
-    @expectedFailure
-    def test_capitalize_with_nonascii(self):
-        # Move this to test_capitalize upon resolution of #530
-        self.assertCodeExecution("""
-            print(b'\xc8'.capitalize())
+    def test_repr(self):
+        self.assertCodeExecution(r"""
+            print(repr(b'\xc8'))
+            print(repr(b'abcdef \xc8 abcdef'))
+            print(repr(b'abcdef \xc8 abcdef\n\r\t'))
+            print(b'abcdef \xc8 abcdef\n\r\t')
         """)
 
     def test_iter(self):

--- a/tests/datatypes/test_bytes.py
+++ b/tests/datatypes/test_bytes.py
@@ -1,7 +1,5 @@
 from .. utils import TranspileTestCase, UnaryOperationTestCase, BinaryOperationTestCase, InplaceOperationTestCase
 
-from unittest import expectedFailure
-
 
 class BytesTests(TranspileTestCase):
     def test_setattr(self):

--- a/voc/java/opcodes.py
+++ b/voc/java/opcodes.py
@@ -467,7 +467,7 @@ class BIPUSH(Opcode):
         return cls(const)
 
     def write_extra(self, writer):
-        writer.write_s1(self.const)
+        writer.write_u1(self.const)
 
     @property
     def produce_count(self):


### PR DESCRIPTION
This fixes the bytecode writing issue that was being triggered by unsigned bytes and also fixes printing bytes representation.

This was making the tests for `bytes()` hard to write, so I expect having this will help to implement the stuff that it's lacking.