### PR TITLE
  Define unary operation on Complex data type

### DIFF
--- a/python/common/org/python/types/Complex.java
+++ b/python/common/org/python/types/Complex.java
@@ -254,7 +254,6 @@ public class Complex extends org.python.types.Object {
     public org.python.types.Bool __bool__() {
         // A complex number is "truthy" if either its real component or imaginary component are > 0
         return new org.python.types.Bool((this.real.value != 0.0) || (this.imag.value != 0.0));
-    
     }
 
     public boolean __setattr_null(java.lang.String name, org.python.Object value) {

--- a/python/common/org/python/types/Complex.java
+++ b/python/common/org/python/types/Complex.java
@@ -19,7 +19,6 @@ public class Complex extends org.python.types.Object {
     }
 
     public org.python.Object byValue() {
-        /*throw new org.python.exceptions.NotImplementedError("complex.byValue() has not been implemented."); */
         throw new org.python.exceptions.AttributeError("type object 'complex' has no attribute 'byValue'");
     }
 

--- a/python/common/org/python/types/Complex.java
+++ b/python/common/org/python/types/Complex.java
@@ -19,7 +19,8 @@ public class Complex extends org.python.types.Object {
     }
 
     public org.python.Object byValue() {
-        throw new org.python.exceptions.NotImplementedError("complex.byValue() has not been implemented.");
+        /*throw new org.python.exceptions.NotImplementedError("complex.byValue() has not been implemented."); */
+        throw new org.python.exceptions.AttributeError("type object 'complex' has no attribute 'byValue'");
     }
 
     public int hashCode() {
@@ -251,7 +252,9 @@ public class Complex extends org.python.types.Object {
             __doc__ = ""
     )
     public org.python.types.Bool __bool__() {
-        throw new org.python.exceptions.NotImplementedError("complex.__bool__ has not been implemented.");
+        // A complex number is "truthy" if either its real component or imaginary component are > 0
+        return new org.python.types.Bool((this.real.value != 0.0) || (this.imag.value != 0.0));
+    
     }
 
     public boolean __setattr_null(java.lang.String name, org.python.Object value) {

--- a/tests/datatypes/test_complex.py
+++ b/tests/datatypes/test_complex.py
@@ -41,9 +41,8 @@ class ComplexTests(TranspileTestCase):
 
 
 class UnaryComplexOperationTests(UnaryOperationTestCase, TranspileTestCase):
-
     data_type = 'complex'
-
+    
 class BinaryComplexOperationTests(BinaryOperationTestCase, TranspileTestCase):
     data_type = 'complex'
 

--- a/tests/datatypes/test_complex.py
+++ b/tests/datatypes/test_complex.py
@@ -42,7 +42,8 @@ class ComplexTests(TranspileTestCase):
 
 class UnaryComplexOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'complex'
-    
+
+
 class BinaryComplexOperationTests(BinaryOperationTestCase, TranspileTestCase):
     data_type = 'complex'
 

--- a/tests/datatypes/test_complex.py
+++ b/tests/datatypes/test_complex.py
@@ -43,7 +43,6 @@ class ComplexTests(TranspileTestCase):
 class UnaryComplexOperationTests(UnaryOperationTestCase, TranspileTestCase):
 
     data_type = 'complex'
-       
 
 class BinaryComplexOperationTests(BinaryOperationTestCase, TranspileTestCase):
     data_type = 'complex'

--- a/tests/datatypes/test_complex.py
+++ b/tests/datatypes/test_complex.py
@@ -41,12 +41,9 @@ class ComplexTests(TranspileTestCase):
 
 
 class UnaryComplexOperationTests(UnaryOperationTestCase, TranspileTestCase):
+
     data_type = 'complex'
-
-    not_implemented = [
-        'test_unary_not'
-    ]
-
+       
 
 class BinaryComplexOperationTests(BinaryOperationTestCase, TranspileTestCase):
     data_type = 'complex'


### PR DESCRIPTION
complex.__bool__ now tests the real part of a complex number for being > zero and then the imaginary component.  If either is NOT equal to zero then the complex number is "truthy".