### PR TITLE
Add (simple) impl on (bool ^ int)

### DIFF
--- a/python/common/org/python/types/Bool.java
+++ b/python/common/org/python/types/Bool.java
@@ -375,6 +375,10 @@ public class Bool extends org.python.types.Object {
     public org.python.Object __xor__(org.python.Object other) {
         if (other instanceof org.python.types.Bool) {
             return new org.python.types.Bool((((org.python.types.Bool) this).value ? 1 : 0) ^ (((org.python.types.Bool) other).value ? 1 : 0));
+        } else if (other instanceof org.python.types.Int) {
+            long operand1 = this.value ? 1L : 0L;
+            long operand2 = ((org.python.types.Int) other).value;
+            return new org.python.types.Int(operand1 ^ operand2);
         }
         throw new org.python.exceptions.TypeError("unsupported operand type(s) for ^: 'bool' and '" + other.typeName() + "'");
     }

--- a/tests/datatypes/test_bool.py
+++ b/tests/datatypes/test_bool.py
@@ -73,7 +73,6 @@ class BinaryBoolOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_true_divide_str',
         'test_true_divide_tuple',
 
-        'test_xor_int',
     ]
 
 

--- a/tests/datatypes/test_bool.py
+++ b/tests/datatypes/test_bool.py
@@ -32,13 +32,6 @@ class UnaryBoolOperationTests(UnaryOperationTestCase, TranspileTestCase):
 class BinaryBoolOperationTests(BinaryOperationTestCase, TranspileTestCase):
     data_type = 'bool'
 
-    def test_xor_int(self):
-        self.assertCodeExecution("""
-            x = True
-            x ^ 2
-            #expect 3
-            """)
-
     not_implemented = [
         'test_add_complex',
         'test_modulo_complex',
@@ -80,6 +73,7 @@ class BinaryBoolOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_true_divide_str',
         'test_true_divide_tuple',
 
+        'test_xor_int',
     ]
 
 

--- a/tests/datatypes/test_bool.py
+++ b/tests/datatypes/test_bool.py
@@ -32,6 +32,13 @@ class UnaryBoolOperationTests(UnaryOperationTestCase, TranspileTestCase):
 class BinaryBoolOperationTests(BinaryOperationTestCase, TranspileTestCase):
     data_type = 'bool'
 
+    def test_xor_int(self):
+        self.assertCodeExecution("""
+            x = True
+            x ^ 2
+            #expect 3
+            """)
+
     not_implemented = [
         'test_add_complex',
         'test_modulo_complex',
@@ -73,7 +80,6 @@ class BinaryBoolOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_true_divide_str',
         'test_true_divide_tuple',
 
-        'test_xor_int',
     ]
 
 


### PR DESCRIPTION
Utilize bit-wise XOR operation (in Java) to perform (bool: 1/0) ^ int

Tested result:
$ voc -v bool_xor_int.py 
Compiling bool_xor_int.py ...
Writing ./python/bool_xor_int.class ...
$ java -classpath ../voc/dist/python-java-support.jar:. python.bool_xor_int
bool ^ int
0
1
3
1
0
2
$ cat bool_xor_int.py 
print('bool ^ int')
print(True ^ 1)
print(True ^ 0)
print(True ^ 2)
print(False ^ 1)
print(False ^ 0)
print(False ^ 2)

