### PR TITLE
Handle return statements inside non-if structures

### DIFF
--- a/tests/builtins/test_list.py
+++ b/tests/builtins/test_list.py
@@ -9,15 +9,23 @@ class BuiltinListFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     functions = ["list"]
 
     substitutions = dict(SAMPLE_SUBSTITUTIONS)
-    substitutions["[1, 2.3456, 'another']"] = [
-        "[1, 'another', 2.3456]",
-        "[2.3456, 1, 'another']",
-        "[2.3456, 'another', 1]",
-        "['another', 1, 2.3456]",
-        "['another', 2.3456, 1]",
-    ]
-
+    substitutions.update({
+        "[1, 2.3456, 'another']": [
+            "[1, 'another', 2.3456]",
+            "[2.3456, 1, 'another']",
+            "[2.3456, 'another', 1]",
+            "['another', 1, 2.3456]",
+            "['another', 2.3456, 1]",
+        ],
+        "['a', 'c', 'd']": [
+            "['a', 'd', 'c']",
+            "['c', 'a', 'd']",
+            "['c', 'd', 'a']",
+            "['d', 'a', 'c']",
+            "['d', 'c', 'a']",
+        ]
+    })
+    print(substitutions)
     not_implemented = [
         'test_bytearray',
-        'test_dict',
     ]

--- a/tests/structures/test_function.py
+++ b/tests/structures/test_function.py
@@ -317,3 +317,36 @@ class FunctionTests(TranspileTestCase):
 
             print (myfunc())
             """)
+
+    def test_function_try_except_return_no_exception(self):
+        self.assertCodeExecution("""
+            def myfunc(x):
+                try:
+                    return x
+                except NameError:
+                    return None
+
+            print(myfunc(10))
+            """)
+
+    def test_function_try_except_return_caught_exception(self):
+        self.assertCodeExecution("""
+            def myfunc(x):
+                try:
+                    return y
+                except NameError:
+                    return x
+
+            print(myfunc(10))
+            """)
+
+    def test_function_try_except_return_uncaught_exception(self):
+        self.assertCodeExecution("""
+            def myfunc(x):
+                try:
+                    return z
+                except IndexError:
+                    return x
+
+            print(myfunc(10))
+            """, exits_early=True)

--- a/voc/python/ast.py
+++ b/voc/python/ast.py
@@ -299,7 +299,8 @@ class Visitor(ast.NodeVisitor):
             self.context.add_opcodes(python.NONE())
         self.context.add_opcodes(JavaOpcodes.ARETURN())
         # Record how deep we were when this return was added.
-        self.context.opcodes[-1].depth = len(self.context.blocks)
+        self.context.opcodes[-1].needs_implicit_return = \
+            self.context.has_nested_structure
 
     @node_visitor
     def visit_Delete(self, node):
@@ -1106,7 +1107,8 @@ class Visitor(ast.NodeVisitor):
 
         self.visit(node.body)
         self.context.add_opcodes(JavaOpcodes.ARETURN())
-        self.context.opcodes[-1].depth = len(self.context.blocks)
+        self.context.opcodes[-1].needs_implicit_return = \
+            self.context.has_nested_structure
 
         self.pop_context()
 

--- a/voc/python/blocks.py
+++ b/voc/python/blocks.py
@@ -140,6 +140,12 @@ class Block(Accumulator):
     def can_ignore_empty(self):
         return False
 
+    @property
+    def has_nested_structure(self):
+        """Whether the block has nested structures inside.
+        """
+        return any([self.blocks, self.loops, self.try_catches])
+
     def add_str(self, value):
         self.add_opcodes(
             python.Str(value),

--- a/voc/python/methods.py
+++ b/voc/python/methods.py
@@ -507,7 +507,7 @@ class Function(Block):
             # return was not added at the root level (i.e., it's not a return
             # as the last statement of an IF statement), add one.
             try:
-                return_required = self.opcodes[-1].depth > 0
+                return_required = self.opcodes[-1].needs_implicit_return
             except AttributeError:
                 return_required = True
         else:


### PR DESCRIPTION
An implicit reutrn is required in a Python function even when there is an explicit return, if the statement is inside a nested structure (loop, condition, or try-catch block).

This commit adds a property that calculates whether there is a nested structure inside a block, and use it to determine whether the block needs an extra implicit return statement when visiting the explicit one.

The same logic is added to the `visit_Lambda` as well.