### PR TITLE
Allow class definition inside a class

### DIFF
--- a/tests/structures/test_class.py
+++ b/tests/structures/test_class.py
@@ -190,3 +190,39 @@ class StaticMethodTests(TranspileTestCase):
             obj.foo(1, 2)
             MyClass.foo(3, 4)
             """, run_in_function=False)
+
+
+class InnerClassTests(TranspileTestCase):
+    def test_inner_simple(self):
+        self.assertCodeExecution("""
+            class MyClass:
+                class InnerClass:
+                    def __init__(self, val):
+                        print("VAL: ", val)
+                        self.value = val
+
+                    def stuff(self, delta):
+                        print("DELTA: ", delta)
+                        return self.value + delta
+
+            obj = MyClass.InnerClass(4)
+            obj.stuff(5)
+        """, run_in_function=False)
+
+    def test_inner_namespaced(self):
+        self.assertCodeExecution("""
+            class MyClass1:
+                class InnerClass:
+                    def stuff(self):
+                        print('STUFF FROM 1')
+
+            class MyClass2:
+                class InnerClass:
+                    def stuff(self):
+                        print('STUFF FROM 2')
+
+            obj = MyClass1.InnerClass()
+            obj.stuff()
+            obj = MyClass2.InnerClass()
+            obj.stuff()
+        """, run_in_function=False)

--- a/voc/python/methods.py
+++ b/voc/python/methods.py
@@ -210,8 +210,8 @@ class MethodCodeTooLarge(Exception):
 
 
 class Function(Block):
-    def __init__(self, module, name, code, parameters, returns, static=False):
-        super().__init__(parent=module)
+    def __init__(self, parent, name, code, parameters, returns, static=False):
+        super().__init__(parent=parent)
         self.name = name
 
         # Python can redefine function symbols. Keep a track of any
@@ -428,11 +428,11 @@ class Function(Block):
 
     def add_function(self, name, code, parameter_signatures, return_signature):
         # If a function is added to a function, it is added as an anonymous
-        # inner class.
+        # inner class to the function/method's parent module/class.
         from .klass import ClosureClass
         klass = ClosureClass(
-            module=self.module,
-            name='%s$%s$%s' % (self.module.name, self.name, name),
+            parent=self._parent,
+            name=name,
             closure_var_names=code.co_freevars,
         )
         self.module.classes.append(klass)

--- a/voc/python/modules.py
+++ b/voc/python/modules.py
@@ -72,6 +72,9 @@ class Module(Block):
     def class_descriptor(self):
         return '/'.join(self.namespace.split('.') + ([self.name, '__init__'] if self.has_init_file else [self.name]))
 
+    def build_child_class_descriptor(self, child_name):
+        return '/'.join([self.descriptor, child_name])
+
     def store_name(self, name, declare=False):
         self.add_opcodes(
             ASTORE_name('#value'),


### PR DESCRIPTION
This implements the inner class functionality following the solution @eliasdorneles mentions in #586.

The `add_class` methods in `Class`, `Method`, and `Module` are actually completely compatible if all `self` reference is pointed to `self.module` (which points to `self` in `Module`) instead. It seems weird to me to move it to `Block` though… maybe move it to a mixin instead? (What should it be called?)