### PR TITLE
Slice refactor

### DIFF
--- a/python/common/org/python/types/ByteArray.java
+++ b/python/common/org/python/types/ByteArray.java
@@ -296,7 +296,7 @@ public class ByteArray extends org.python.types.Object {
     )
     public org.python.Object __getitem__(org.python.Object index) {
         if (index instanceof org.python.types.Slice) {
-            org.python.types.Slice slice = (org.python.types.Slice) index;
+            org.python.types.Slice.ValidatedValue slice = ((org.python.types.Slice) index).validateValueTypes();
             byte[] sliced;
 
             // if (slice.start == null && slice.stop == null && slice.step == null) {

--- a/python/common/org/python/types/Bytes.java
+++ b/python/common/org/python/types/Bytes.java
@@ -368,7 +368,7 @@ public class Bytes extends org.python.types.Object {
     }
 
     private org.python.Object __getitem__slice(org.python.Object index) {
-        org.python.types.Slice slice = (org.python.types.Slice) index;
+        org.python.types.Slice.ValidatedValue slice = ((org.python.types.Slice) index).validateValueTypes();
         byte[] sliced;
         if (slice.start == null && slice.stop == null && slice.step == null) {
             sliced = this.value;

--- a/python/common/org/python/types/List.java
+++ b/python/common/org/python/types/List.java
@@ -321,7 +321,7 @@ public class List extends org.python.types.Object {
     public org.python.Object __getitem__(org.python.Object index) {
         try {
             if (index instanceof org.python.types.Slice) {
-                org.python.types.Slice slice = (org.python.types.Slice) index;
+                org.python.types.Slice.ValidatedValue slice = ((org.python.types.Slice) index).validateValueTypes();
                 java.util.List<org.python.Object> sliced = new java.util.ArrayList<org.python.Object>();
 
                 if (slice.start == null && slice.stop == null && slice.step == null) {

--- a/python/common/org/python/types/Range.java
+++ b/python/common/org/python/types/Range.java
@@ -72,7 +72,7 @@ public class Range extends org.python.types.Object {
     public org.python.Object __getitem__(org.python.Object index) {
         try {
             if (index instanceof org.python.types.Slice) {
-                org.python.types.Slice slice = (org.python.types.Slice) index;
+                org.python.types.Slice.ValidatedValue slice = ((org.python.types.Slice) index).validateValueTypes();
                 return new org.python.types.Range(
                         slice.start == null ? this.__dict__.get("start") : slice.start,
                         slice.stop == null ? this.__dict__.get("stop") : slice.stop,

--- a/python/common/org/python/types/Slice.java
+++ b/python/common/org/python/types/Slice.java
@@ -74,6 +74,17 @@ public class Slice extends org.python.types.Object {
     }
 
     @org.python.Method(
+            __doc__ = "Return repr(self)."
+    )
+    public org.python.Object __repr__() {
+        return new org.python.types.Str(String.format(
+            "slice(%s, %s, %s)",
+            this.start.__repr__(),
+            this.stop.__repr__(),
+            this.step.__repr__()));
+    }
+
+    @org.python.Method(
             __doc__ = "",
             args = {"other"}
     )

--- a/python/common/org/python/types/Slice.java
+++ b/python/common/org/python/types/Slice.java
@@ -63,9 +63,9 @@ public class Slice extends org.python.types.Object {
 
     public ValidatedValue validateValueTypes() {
         ValidatedValue result = new ValidatedValue(
-            this.validateValueType(this.start),
-            this.validateValueType(this.stop),
-            this.validateValueType(this.step));
+                this.validateValueType(this.start),
+                this.validateValueType(this.stop),
+                this.validateValueType(this.step));
         if (result.step != null && result.step.value == 0) {
             throw new org.python.exceptions.ValueError("slice step cannot be zero");
         }

--- a/python/common/org/python/types/Slice.java
+++ b/python/common/org/python/types/Slice.java
@@ -1,30 +1,38 @@
 package org.python.types;
 
 public class Slice extends org.python.types.Object {
-    org.python.types.Int start;
-    org.python.types.Int stop;
-    org.python.types.Int step;
+    private org.python.Object start;
+    private org.python.Object stop;
+    private org.python.Object step;
 
     public Slice(org.python.Object stop) {
-        this(new org.python.types.Int(0), stop, new org.python.types.Int(1));
+        this(null, stop, null);
     }
 
     public Slice(org.python.Object start, org.python.Object stop) {
-        this(start, stop, new org.python.types.Int(1));
+        this(start, stop, null);
     }
 
     public Slice(org.python.Object start, org.python.Object stop, org.python.Object step) {
         super();
-        if (start instanceof org.python.types.Int) {
-            this.__dict__.put("start", start);
-            this.start = (org.python.types.Int) start;
-        } else if (start instanceof org.python.types.NoneType) {
-            this.__dict__.put("start", start);
+        this.start = start == null ? org.python.types.NoneType.NONE : start;
+        this.stop = stop == null ? org.python.types.NoneType.NONE : stop;
+        this.step = step == null ? org.python.types.NoneType.NONE : step;
+        this.__dict__.put("start", this.start);
+        this.__dict__.put("stop", this.stop);
+        this.__dict__.put("step", this.step);
+    }
+
+    private org.python.types.Int validateValueType(org.python.Object value) {
+        if (value instanceof org.python.types.Int) {
+            return (org.python.types.Int) value;
+        } else if (value == null || value instanceof org.python.types.NoneType) {
+            return null;
         } else {
             org.python.Object index_object = null;
             boolean error_caught = false;
             try {
-                index_object = start.__index__();
+                index_object = value.__index__();
             } catch (org.python.exceptions.TypeError error) {
                 error_caught = true;
             } catch (org.python.exceptions.AttributeError error) {
@@ -34,68 +42,35 @@ public class Slice extends org.python.types.Object {
                 throw new org.python.exceptions.TypeError("slice indices must be integers or None or have an __index__ method");
             }
             if (index_object instanceof org.python.types.Int) {
-                this.__dict__.put("start", start);
-                this.start = (org.python.types.Int) index_object;
+                return (org.python.types.Int) index_object;
             } else {
                 throw new org.python.exceptions.TypeError("TypeError: __index__ returned non-int (type " + index_object.typeName() + ")");
             }
+        }
+    }
+
+    public class ValidatedValue {
+        public org.python.types.Int start;
+        public org.python.types.Int stop;
+        public org.python.types.Int step;
+
+        ValidatedValue(org.python.types.Int start, org.python.types.Int stop, org.python.types.Int step) {
+            this.start = start;
+            this.stop = stop;
+            this.step = step;
+        }
+    }
+
+    public ValidatedValue validateValueTypes() {
+        ValidatedValue result = new ValidatedValue(
+            this.validateValueType(this.start),
+            this.validateValueType(this.stop),
+            this.validateValueType(this.step));
+        if (result.step != null && result.step.value == 0) {
+            throw new org.python.exceptions.ValueError("slice step cannot be zero");
         }
 
-        if (stop instanceof org.python.types.Int) {
-            this.__dict__.put("stop", stop);
-            this.stop = (org.python.types.Int) stop;
-        } else if (stop instanceof org.python.types.NoneType) {
-            this.__dict__.put("stop", stop);
-        } else {
-            org.python.Object index_object = null;
-            boolean error_caught = false;
-            try {
-                index_object = stop.__index__();
-            } catch (org.python.exceptions.TypeError error) {
-                error_caught = true;
-            } catch (org.python.exceptions.AttributeError error) {
-                error_caught = true;
-            }
-            if (error_caught) {
-                throw new org.python.exceptions.TypeError("slice indices must be integers or None or have an __index__ method");
-            }
-            if (index_object instanceof org.python.types.Int) {
-                this.__dict__.put("stop", stop);
-                this.stop = (org.python.types.Int) index_object;
-            } else {
-                throw new org.python.exceptions.TypeError("TypeError: __index__ returned non-int (type " + index_object.typeName() + ")");
-            }
-        }
-
-        if (step instanceof org.python.types.Int) {
-            this.step = (org.python.types.Int) step;
-            if (this.step.value == 0) {
-                throw new org.python.exceptions.ValueError("slice step cannot be zero");
-            } else {
-                this.__dict__.put("step", step);
-            }
-        } else if (step instanceof org.python.types.NoneType) {
-            this.__dict__.put("step", step);
-        } else {
-            org.python.Object index_object = null;
-            boolean error_caught = false;
-            try {
-                index_object = step.__index__();
-            } catch (org.python.exceptions.TypeError error) {
-                error_caught = true;
-            } catch (org.python.exceptions.AttributeError error) {
-                error_caught = true;
-            }
-            if (error_caught) {
-                throw new org.python.exceptions.TypeError("slice indices must be integers or None or have an __index__ method");
-            }
-            if (index_object instanceof org.python.types.Int) {
-                this.__dict__.put("step", step);
-                this.step = (org.python.types.Int) index_object;
-            } else {
-                throw new org.python.exceptions.TypeError("TypeError: __index__ returned non-int (type " + index_object.typeName() + ")");
-            }
-        }
+        return result;
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -279,7 +279,7 @@ public class Str extends org.python.types.Object {
     public org.python.Object __getitem__(org.python.Object index) {
         try {
             if (index instanceof org.python.types.Slice) {
-                org.python.types.Slice slice = (org.python.types.Slice) index;
+                org.python.types.Slice.ValidatedValue slice = ((org.python.types.Slice) index).validateValueTypes();
                 java.lang.String sliced;
 
                 if (slice.start == null && slice.stop == null && slice.step == null) {

--- a/python/common/org/python/types/Tuple.java
+++ b/python/common/org/python/types/Tuple.java
@@ -278,7 +278,7 @@ public class Tuple extends org.python.types.Object {
     public org.python.Object __getitem__(org.python.Object index) {
         try {
             if (index instanceof org.python.types.Slice) {
-                org.python.types.Slice slice = (org.python.types.Slice) index;
+                org.python.types.Slice.ValidatedValue slice = ((org.python.types.Slice) index).validateValueTypes();
                 java.util.List<org.python.Object> sliced = new java.util.ArrayList<org.python.Object>();
 
                 if (slice.start == null && slice.stop == null && slice.step == null) {

--- a/tests/builtins/test_format.py
+++ b/tests/builtins/test_format.py
@@ -10,5 +10,4 @@ class BuiltinFormatFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
 
     not_implemented = [
         'test_class',
-        'test_slice',
     ]

--- a/tests/builtins/test_print.py
+++ b/tests/builtins/test_print.py
@@ -61,5 +61,4 @@ class BuiltinPrintFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
 
     not_implemented = [
         'test_class',
-        'test_slice',
     ]

--- a/tests/builtins/test_repr.py
+++ b/tests/builtins/test_repr.py
@@ -11,5 +11,4 @@ class BuiltinReprFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     not_implemented = [
         'test_class',
         'test_complex',
-        'test_slice',
     ]

--- a/tests/builtins/test_slice.py
+++ b/tests/builtins/test_slice.py
@@ -2,7 +2,23 @@ from .. utils import TranspileTestCase, BuiltinFunctionTestCase
 
 
 class SliceTests(TranspileTestCase):
-    pass
+    def test_slice_repr_stop(self):
+        self.assertCodeExecution("""
+            print(slice(0))
+            print(slice('foo'))
+            """)
+
+    def test_slice_repr_start_stop(self):
+        self.assertCodeExecution("""
+            print(slice(0, 100))
+            print(slice('foo', Exception))
+            """)
+
+    def test_slice_repr_start_stop_step(self):
+        self.assertCodeExecution("""
+            print(slice(0, 100, 2))
+            print(slice('foo', Exception, object()))
+            """)
 
 
 class BuiltinSliceFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):

--- a/tests/builtins/test_slice.py
+++ b/tests/builtins/test_slice.py
@@ -9,21 +9,6 @@ class BuiltinSliceFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     functions = ["slice"]
 
     not_implemented = [
-        'test_bool',
-        'test_bytearray',
-        'test_bytes',
         'test_class',
         'test_complex',
-        'test_dict',
-        'test_float',
-        'test_frozenset',
-        'test_int',
-        'test_list',
-        'test_None',
-        'test_NotImplemented',
-        'test_range',
-        'test_set',
-        'test_slice',
-        'test_str',
-        'test_tuple',
     ]

--- a/tests/builtins/test_str.py
+++ b/tests/builtins/test_str.py
@@ -10,5 +10,4 @@ class BuiltinStrFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
 
     not_implemented = [
         'test_class',
-        'test_slice',
     ]


### PR DESCRIPTION
Slice-specific stuff extracted from #592.

Python’s `slice()` literally accepts *anything* as its arguments, and does not check for types until it's applied to a sequence. This refactors the constructor and attributes to match this fact, and provide an extra method (and inner class) for its callee to perform type checking.

Also implements `__repr__` to match the standard behaviour.