### PR TITLE
Fix keyword-only function definition

### DIFF
--- a/tests/structures/test_function.py
+++ b/tests/structures/test_function.py
@@ -1,7 +1,5 @@
 from ..utils import TranspileTestCase
 
-from unittest import expectedFailure
-
 
 class LambdaTests(TranspileTestCase):
     def test_lambda(self):
@@ -20,8 +18,6 @@ class LambdaTests(TranspileTestCase):
 
             """)
 
-    @expectedFailure
-    # keyword only args not handled
     def test_lambda_kwonly(self):
         self.assertCodeExecution("""
             print((lambda *,x='something': x + '!!!')())
@@ -308,8 +304,6 @@ class FunctionTests(TranspileTestCase):
             print(i.a_method())
             """, exits_early=True)
 
-    @expectedFailure
-    # keyword only args not handled
     def test_function_kwonly(self):
         self.assertCodeExecution("""
             def myfunc(*,x=100):

--- a/voc/python/ast.py
+++ b/voc/python/ast.py
@@ -974,7 +974,7 @@ class Visitor(ast.NodeVisitor):
         for i, arg in enumerate(node.args.kwonlyargs):
             index = len(node.args.kw_defaults) - len(node.args.kwonlyargs) + i
             arg_index[arg.arg] = None
-            if index >= 0:
+            if index >= 0 and node.args.kw_defaults[index] is not None:
                 default = '#%s-kw_default-%s-%x' % (func_name, i, id(node))
                 self.visit(node.args.kw_defaults[index])
                 self.context.add_opcodes(

--- a/voc/python/blocks.py
+++ b/voc/python/blocks.py
@@ -355,7 +355,9 @@ class Block(Accumulator):
         )
 
         for arg in function.parameters:
-            if arg['kind'] == ArgType.POSITIONAL_OR_KEYWORD and arg['default']:
+            if arg['kind'] in (
+                    ArgType.POSITIONAL_OR_KEYWORD,
+                    ArgType.KEYWORD_ONLY) and arg['default']:
                 self.add_opcodes(
                     JavaOpcodes.DUP(),
                     JavaOpcodes.LDC_W(arg['name']),


### PR DESCRIPTION
This solves the two problems mentioned in #432.

First, the transpiler throws TypeError for a keyword-only argument without a default value because it tries to visit the `None` value as a node. Checking against this situation avoids the issue.

Second, the compiled JVM bytecode throws a NullPointerException when a function with keyword-only arguments is called using the default value because the bytecode emitter does not put the default value correctly for keyword-only arguments (it only did this for `ArgType.POSITIONAL_OR_KEYWORD`). Submit the default value for `ArgType.KEYWORD_ONLY` and this is fixed.

Two more tests are now expected to pass :D