### PR TITLE
Support informing a custom platform via environment variable

### DIFF
--- a/build-android.xml
+++ b/build-android.xml
@@ -9,6 +9,9 @@
     <condition property="sdk.dir" value="${env.ANDROID_HOME}">
         <isset property="env.ANDROID_HOME" />
     </condition>
+    <condition property="target.platform" value="${env.ANDROID_TARGET}" else="android-14">
+        <isset property="env.ANDROID_TARGET" />
+    </condition>
 
     <!-- quick check on sdk.dir -->
     <fail
@@ -27,7 +30,7 @@
             destdir="${build}/android">
           <src path="${src}/common" />
           <src path="${src}/android" />
-          <classpath path="${sdk.dir}/platforms/android-14/android.jar" />
+          <classpath path="${sdk.dir}/platforms/${target.platform}/android.jar" />
         </javac>
     </target>
 


### PR DESCRIPTION
Since #602 the Android target platform is hardcoded to `android-24` when building the Android support package with `ant android`.

This introduces support to customizing that through an environment variable `ANDROID_TARGET`.

I think we could also support this using a java property with `-Dtarget.platform`, but I thought using an environment variable would make it easier to support in the long term (since we might migrate to gradle later or something).