### PR TITLE
Handle bytes.__iadd__ TypeError change in 3.6.2

### DIFF
--- a/python/common/org/python/types/ByteArray.java
+++ b/python/common/org/python/types/ByteArray.java
@@ -242,17 +242,14 @@ public class ByteArray extends org.python.types.Object {
             System.arraycopy(other_bytes, 0, new_bytes, this.value.length, other_bytes.length);
             return new ByteArray(new_bytes);
         }
-        throw new org.python.exceptions.TypeError("can't concat " + this.typeName() + " to " + other.typeName());
+        throw new org.python.exceptions.TypeError("can't concat " + other.typeName() + " to " + this.typeName());
     }
 
     @org.python.Method(
             __doc__ = ""
     )
     public org.python.Object __iadd__(org.python.Object other) {
-        if (other instanceof org.python.types.Bytes || other instanceof org.python.types.ByteArray) {
-            return this.__add__(other);
-        }
-        throw new org.python.exceptions.TypeError("can't concat " + other.typeName() + " to " + this.typeName());
+        return this.__add__(other);
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/ByteArray.java
+++ b/python/common/org/python/types/ByteArray.java
@@ -253,7 +253,10 @@ public class ByteArray extends org.python.types.Object {
             __doc__ = ""
     )
     public org.python.Object __iadd__(org.python.Object other) {
-        return this.__add__(other);
+        if (other instanceof org.python.types.Bytes || other instanceof org.python.types.ByteArray) {
+            return this.__add__(other);
+        }
+        throw new org.python.exceptions.TypeError("can't concat " + other.typeName() + " to " + this.typeName());
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/ByteArray.java
+++ b/python/common/org/python/types/ByteArray.java
@@ -242,7 +242,11 @@ public class ByteArray extends org.python.types.Object {
             System.arraycopy(other_bytes, 0, new_bytes, this.value.length, other_bytes.length);
             return new ByteArray(new_bytes);
         }
-        throw new org.python.exceptions.TypeError("can't concat " + other.typeName() + " to " + this.typeName());
+        if (org.Python.VERSION < 0x03060200) {
+            throw new org.python.exceptions.TypeError("can't concat " + this.typeName() + " to " + other.typeName());
+        } else {
+            throw new org.python.exceptions.TypeError("can't concat " + other.typeName() + " to " + this.typeName());
+        }
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Bytes.java
+++ b/python/common/org/python/types/Bytes.java
@@ -125,7 +125,7 @@ public class Bytes extends org.python.types.Object {
             System.arraycopy(other_bytes, 0, new_bytes, this.value.length, other_bytes.length);
             return new Bytes(new_bytes);
         }
-        throw new org.python.exceptions.TypeError("can't concat bytes to " + other.typeName());
+        throw new org.python.exceptions.TypeError("can't concat " + other.typeName() + " to bytes" );
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Bytes.java
+++ b/python/common/org/python/types/Bytes.java
@@ -125,7 +125,11 @@ public class Bytes extends org.python.types.Object {
             System.arraycopy(other_bytes, 0, new_bytes, this.value.length, other_bytes.length);
             return new Bytes(new_bytes);
         }
-        throw new org.python.exceptions.TypeError("can't concat " + other.typeName() + " to bytes" );
+        if (org.Python.VERSION < 0x03060200) {
+            throw new org.python.exceptions.TypeError("can't concat bytes to " + other.typeName());
+        } else {
+            throw new org.python.exceptions.TypeError("can't concat " + other.typeName() + " to bytes");
+        }
     }
 
     @org.python.Method(


### PR DESCRIPTION
This fixes issue #595 

Has a version check for less than python 3.6.2, reordering the type referred to in the error message