### PR TITLE
Use built-in virtual environment (not 3rd party)

### DIFF
--- a/docs/internals/contributing.rst
+++ b/docs/internals/contributing.rst
@@ -23,7 +23,7 @@ instead of using the official PyBee repository, you'll be using your own
 Github fork.
 
 As with the getting started guide, these instructions will assume that you
-have Python 3.4+, a Java 7 or Java 8 JDK, and Apache ANT installed, and have virtualenv available for use.
+have Python 3.4+, a Java 7 or Java 8 JDK, and Apache ANT installed.
 
 **Note:** If you are on Linux, you will need to install an extra package to be able to run the test suite. 
  * **Ubuntu** 12.04 and 14.04: ``libpython3.4-testsuite`` This can be done by running ``apt-get install libpython3.4-testsuite``.
@@ -42,7 +42,7 @@ Then create a virtual environment and install VOC into it:
 
 .. code-block:: bash
 
-    $ virtualenv -p $(which python3) env
+    $ python3 -m venv env
     $ . env/bin/activate
     $ cd voc
     $ pip install -e .
@@ -51,7 +51,7 @@ For Windows the use of cmd under Administrator permission is suggested instead o
 
 .. code-block:: batch
 
-    > virtualenv -p "C:\Python34\python.exe" env
+    > C:\Python34\python.exe -m venv env
     > env\Scripts\activate.bat
     > cd voc
     > pip install -e .

--- a/docs/internals/contributing.rst
+++ b/docs/internals/contributing.rst
@@ -51,7 +51,7 @@ For Windows the use of cmd under Administrator permission is suggested instead o
 
 .. code-block:: batch
 
-    > C:\Python34\python.exe -m venv env
+    > py -3 -m venv env
     > env\Scripts\activate.bat
     > cd voc
     > pip install -e .

--- a/docs/intro/install.rst
+++ b/docs/intro/install.rst
@@ -59,7 +59,7 @@ For Windows the use of cmd under Administrator permission is suggested instead o
 
 .. code-block:: bash
 
-    > C:\Python34\python.exe -m venv env
+    > py -3 -m venv env
     > env\Scripts\activate.bat
     > cd voc
     > pip install -e .

--- a/docs/intro/install.rst
+++ b/docs/intro/install.rst
@@ -3,7 +3,7 @@ Installation
 
 In this guide we will walk you through setting up your VOC environment for
 development and testing. We will assume that you have Python 3.4 or 3.5, Java 7 or Java 8 JDK,
-and Apache ANT installed, and have virtualenv available for use.
+and Apache ANT installed.
 
 Checking Dependencies
 ---------------------
@@ -50,7 +50,7 @@ Then create a virtual environment and install VOC into it:
 
 .. code-block:: bash
 
-    $ virtualenv -p $(which python3) env
+    $ python3 -m venv env
     $ . env/bin/activate
     $ cd voc
     $ pip install -e .
@@ -59,7 +59,7 @@ For Windows the use of cmd under Administrator permission is suggested instead o
 
 .. code-block:: bash
 
-    > virtualenv -p "C:\Python34\python.exe" env
+    > C:\Python34\python.exe -m venv env
     > env\Scripts\activate.bat
     > cd voc
     > pip install -e .


### PR DESCRIPTION
Python 3 comes with a `venv` package which allows you to create a virtual environment.

Asking users to use `virtualenv` presumes that they've installed the third-party `virtualenv` package. That package is necessary for using virtual environments in Python 2, but there isn't any benefit to using it (that I've ever seen at least) over the built-in Python 3 `venv` package.

I think it would probably be easiest for new users if we removed the requirement for `virtualenv` by using the built-in `venv`. This is how I usually teach Python 3 and this is what the Django Girls tutorial [recommends](https://tutorial.djangogirls.org/en/installation/#virtual-environment).