### PR TITLE
Ref #36: In-place multiplication with ints

### DIFF
--- a/python/common/org/python/types/Int.java
+++ b/python/common/org/python/types/Int.java
@@ -665,6 +665,16 @@ public class Int extends org.python.types.Object {
     @org.python.Method(
             __doc__ = ""
     )
+    public org.python.Object __imul__(org.python.Object other) {
+        if (other instanceof org.python.types.Str) {
+            return this.__mul__(other);
+        }
+        throw new org.python.exceptions.TypeError("unsupported operand type(s) for *=: 'int' and '" + other.typeName() + "'");
+    }
+
+    @org.python.Method(
+            __doc__ = ""
+    )
     public org.python.Object __ilshift__(org.python.Object other) {
         if (other instanceof org.python.types.Bool) {
             this.value <<= (((org.python.types.Bool) other).value ? 1 : 0);

--- a/python/common/org/python/types/Int.java
+++ b/python/common/org/python/types/Int.java
@@ -666,7 +666,7 @@ public class Int extends org.python.types.Object {
             __doc__ = ""
     )
     public org.python.Object __imul__(org.python.Object other) {
-        if (other instanceof org.python.types.Str) {
+        if (other instanceof org.python.types.Int || other instanceof org.python.types.Str) {
             return this.__mul__(other);
         }
         throw new org.python.exceptions.TypeError("unsupported operand type(s) for *=: 'int' and '" + other.typeName() + "'");

--- a/tests/datatypes/test_int.py
+++ b/tests/datatypes/test_int.py
@@ -62,7 +62,6 @@ class InplaceIntOperationTests(InplaceOperationTestCase, TranspileTestCase):
         'test_multiply_complex',
         'test_multiply_float',
         'test_multiply_list',
-        'test_multiply_str',
         'test_multiply_tuple',
 
         'test_power_complex',


### PR DESCRIPTION
Implement to pass `test_multiply_str` (and `test_multiply_int` just because making the new method breaks the way it was previously handled).