### PR TITLE
Refs #36: Modified __mod__ to throw intended exception

### DIFF
--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -11,6 +11,7 @@ public class Str extends org.python.types.Object {
      */
     void setValue(org.python.Object obj) {
         this.value = ((org.python.types.Str) obj).value;
+
     }
 
     public java.lang.Object toJava() {
@@ -458,12 +459,21 @@ public class Str extends org.python.types.Object {
             for (org.python.Object obj : oth.value) {
                 format_args.add(obj.toJava());
             }
+        } else if (other instanceof org.python.types.Range) {
+            try {
+                format_args.add(other.toJava());
+                Object obj = new org.python.types.Str(java.lang.String.format(this.value, format_args.toArray()));
+
+            } catch (Exception e) {
+                throw new org.python.exceptions.TypeError("not enough arguments for format string");
+
+            }
         } else if (other instanceof org.python.types.NoneType) {
             throw new org.python.exceptions.TypeError("not all arguments converted during string formatting");
+
         } else {
             format_args.add(other.toJava());
         }
-
         return new org.python.types.Str(java.lang.String.format(this.value, format_args.toArray()));
     }
 

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -543,9 +543,19 @@ public class Str extends org.python.types.Object {
     public org.python.Object __imod__(org.python.Object other) {
         if (other instanceof org.python.types.NoneType) {
             throw new org.python.exceptions.TypeError("not all arguments converted during string formatting");
+        } else if (other instanceof org.python.types.Range) {
+            try {
+                super.__imod__(other);
+                return this;
+
+            } catch (Exception e) {
+                throw new org.python.exceptions.TypeError("not enough arguments for format string");
+
+            }
+        } else {
+            super.__imod__(other);
+            return this;
         }
-        super.__imod__(other);
-        return this;
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -464,7 +464,7 @@ public class Str extends org.python.types.Object {
                 format_args.add(other.toJava());
                 Object obj = new org.python.types.Str(java.lang.String.format(this.value, format_args.toArray()));
 
-            } catch (Exception e) {
+            } catch (IllegalArgumentException e) {
                 throw new org.python.exceptions.TypeError("not enough arguments for format string");
 
             }
@@ -548,7 +548,7 @@ public class Str extends org.python.types.Object {
                 super.__imod__(other);
                 return this;
 
-            } catch (Exception e) {
+            } catch (org.python.exceptions.TypeError e) {
                 throw new org.python.exceptions.TypeError("not enough arguments for format string");
 
             }

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -756,7 +756,6 @@ class BinaryStrOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_modulo_list',
         'test_modulo_None',
         'test_modulo_NotImplemented',
-        'test_modulo_range',
         'test_modulo_set',
         'test_modulo_str',
         'test_modulo_tuple',

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -782,7 +782,6 @@ class InplaceStrOperationTests(InplaceOperationTestCase, TranspileTestCase):
         'test_modulo_list',
         'test_modulo_None',
         'test_modulo_NotImplemented',
-        'test_modulo_range',
         'test_modulo_set',
         'test_modulo_str',
         'test_modulo_tuple',


### PR DESCRIPTION
I've added a try catch block into Str.java under __mod__ to throw the proper exceptions for 
`test_modulo_range (tests.datatypes.test_str.BinaryStrOperationTests.test_modulo_range)`