### PR TITLE
Refs #36: Implement indexing tuples with bools

### DIFF
--- a/python/common/org/python/types/Int.java
+++ b/python/common/org/python/types/Int.java
@@ -469,8 +469,10 @@ public class Int extends org.python.types.Object {
             if (this.value == 0 && other_val < 0.0) {
                 throw new org.python.exceptions.ZeroDivisionError("0.0 cannot be raised to a negative power");
             }
-            // TODO: if this.value < 0 && other_val is not an integer, this will be a Complex result, so change this.value to Complex and delegate it out
-            // return (new org.python.types.Complex(this.value, 0)).__pow__(other, modulo);
+            if (this.value < 0 && Math.floor(other_val) != other_val) {
+                // The result will be complex, so make it a complex type instead
+                return (new org.python.types.Complex(this.value, 0)).__pow__(other, modulo);
+            }
             return new org.python.types.Float(java.lang.Math.pow((double) this.value, other_val));
         } else if (other instanceof org.python.types.Bool) {
             if (((org.python.types.Bool) other).value) {
@@ -699,6 +701,14 @@ public class Int extends org.python.types.Object {
             return new org.python.types.Complex(this.value - other_cmplx_obj.real.value, -(other_cmplx_obj.imag.value));
         }
         throw new org.python.exceptions.TypeError("unsupported operand type(s) for -=: 'int' and '" + other.typeName() + "'");
+    }
+
+
+    @org.python.Method(
+            __doc__ = ""
+    )
+    public org.python.Object __ipow__(org.python.Object other) {
+        return this.__pow__(other, null);
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Int.java
+++ b/python/common/org/python/types/Int.java
@@ -712,6 +712,18 @@ public class Int extends org.python.types.Object {
         }
     }
 
+
+    @org.python.Method(
+            __doc__ = ""
+    )
+    public org.python.Object __ifloordiv__(org.python.Object other) {
+        if (other instanceof org.python.types.Int || other instanceof org.python.types.Float || other instanceof org.python.types.Bool || other instanceof org.python.types.Complex) {
+            return this.__floordiv__(other);
+        } else {
+            throw new org.python.exceptions.TypeError("unsupported operand type(s) for //=: 'int' and '" + other.typeName() + "'");
+        }
+    }
+
     @org.python.Method(
             __doc__ = ""
     )

--- a/python/common/org/python/types/Tuple.java
+++ b/python/common/org/python/types/Tuple.java
@@ -311,7 +311,12 @@ public class Tuple extends org.python.types.Object {
                 }
                 return new org.python.types.Tuple(sliced);
             } else {
-                int idx = (int) ((org.python.types.Int) index).value;
+                int idx;
+                if (index instanceof org.python.types.Bool) {
+                    idx = (int) ((org.python.types.Bool) index).__int__().value;
+                } else {
+                    idx = (int) ((org.python.types.Int) index).value;
+                }
                 if (idx < 0) {
                     if (-idx > this.value.size()) {
                         throw new org.python.exceptions.IndexError("tuple index out of range");

--- a/tests/builtins/test_pow.py
+++ b/tests/builtins/test_pow.py
@@ -118,7 +118,6 @@ class BuiltinTwoargPowFunctionTests(BuiltinTwoargFunctionTestCase, TranspileTest
         'test_float_float',
 
         'test_int_complex',
-        'test_int_float',
     ]
 
     is_flakey = [

--- a/tests/datatypes/test_int.py
+++ b/tests/datatypes/test_int.py
@@ -53,7 +53,6 @@ class InplaceIntOperationTests(InplaceOperationTestCase, TranspileTestCase):
 
     not_implemented = [
 
-        'test_floor_divide_float',
 
         'test_modulo_complex',
         'test_modulo_float',

--- a/tests/datatypes/test_int.py
+++ b/tests/datatypes/test_int.py
@@ -42,7 +42,6 @@ class BinaryIntOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_multiply_complex',
 
         'test_power_complex',
-        'test_power_float',
 
         'test_true_divide_complex',
     ]
@@ -66,8 +65,8 @@ class InplaceIntOperationTests(InplaceOperationTestCase, TranspileTestCase):
         'test_multiply_tuple',
 
         'test_power_complex',
-        'test_power_float',
-        'test_power_int',
+
+
 
         'test_true_divide_complex',
     ]

--- a/tests/datatypes/test_tuple.py
+++ b/tests/datatypes/test_tuple.py
@@ -271,7 +271,7 @@ class BinaryTupleOperationTests(BinaryOperationTestCase, TranspileTestCase):
 
     not_implemented = [
         'test_modulo_complex',
-        'test_subscr_bool',
+
         'test_subscr_slice',
     ]
 


### PR DESCRIPTION
Uses the .\_\_int\_\_() method, although another alternative would be to check if the value is true and if so use 1, else 0.