### PR TITLE
Update Range object methods

### DIFF
--- a/python/common/org/python/types/Range.java
+++ b/python/common/org/python/types/Range.java
@@ -86,7 +86,12 @@ public class Range extends org.python.types.Object {
                 return new org.python.types.Range(substart, substop, substep);
             } else {
                 long len = ((org.python.types.Int) (this.__len__())).value;
-                long idx = ((org.python.types.Int) index).value;
+                long idx;
+                if (index instanceof org.python.types.Bool) {
+                    idx = ((org.python.types.Bool)index).value ? 1 : 0;
+                } else {
+                    idx = ((org.python.types.Int) index).value;
+                }
 
                 if (idx < 0) {
                     idx = len + idx;

--- a/python/common/org/python/types/Range.java
+++ b/python/common/org/python/types/Range.java
@@ -72,12 +72,18 @@ public class Range extends org.python.types.Object {
     public org.python.Object __getitem__(org.python.Object index) {
         try {
             if (index instanceof org.python.types.Slice) {
-                org.python.types.Slice.ValidatedValue slice = ((org.python.types.Slice) index).validateValueTypes();
-                return new org.python.types.Range(
-                        slice.start == null ? this.__dict__.get("start") : slice.start,
-                        slice.stop == null ? this.__dict__.get("stop") : slice.stop,
-                        slice.step == null ? this.__dict__.get("step") : slice.step
-                );
+                org.python.types.Slice.ValidatedValue val = ((org.python.types.Slice)index).validateValueTypes();
+                org.python.types.Slice slice = new org.python.types.Slice(val.start, val.stop, val.step);
+                org.python.types.Tuple indices = slice.indices((org.python.types.Int) (this.__len__()));
+                org.python.Object start = indices.__getitem__(new org.python.types.Int(0));
+                org.python.Object stop = indices.__getitem__(new org.python.types.Int(1));
+                org.python.Object step = indices.__getitem__(new org.python.types.Int(2));
+                org.python.Object rstart = this.__dict__.get("start");
+                org.python.Object rstep = this.__dict__.get("step");
+                org.python.Object substep = step.__mul__(rstep);
+                org.python.Object substart = rstart.__add__(rstep.__mul__(start));
+                org.python.Object substop = rstart.__add__(rstep.__mul__(stop));
+                return new org.python.types.Range(substart, substop, substep);
             } else {
                 long len = ((org.python.types.Int) (this.__len__())).value;
                 long idx = ((org.python.types.Int) index).value;

--- a/python/common/org/python/types/Range.java
+++ b/python/common/org/python/types/Range.java
@@ -203,6 +203,21 @@ public class Range extends org.python.types.Object {
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
 
+    @org.python.Method(
+            __doc__ = "Implement self*value.",
+            args = {"other"}
+    )
+    public org.python.Object __mul__(org.python.Object other) {
+        if ((other instanceof org.python.types.ByteArray) ||
+                (other instanceof org.python.types.Bytes) ||
+                (other instanceof org.python.types.List) ||
+                (other instanceof org.python.types.Str) ||
+                (other instanceof org.python.types.Tuple)) {
+            throw new org.python.exceptions.TypeError("can't multiply sequence by non-int of type 'range'");
+        }
+        throw new org.python.exceptions.TypeError("unsupported operand type(s) for *: 'range' and '" + other.typeName() + "'");
+    }
+
     public class RangeIterator extends org.python.types.Object implements org.python.Object {
 
         public static final java.lang.String PYTHON_TYPE_NAME = "range_iterator";

--- a/tests/datatypes/test_range.py
+++ b/tests/datatypes/test_range.py
@@ -96,7 +96,6 @@ class BinaryRangeOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_multiply_tuple',
 
         'test_subscr_bool',
-        'test_subscr_slice',
     ]
 
     not_implemented_versions = {

--- a/tests/datatypes/test_range.py
+++ b/tests/datatypes/test_range.py
@@ -89,12 +89,6 @@ class BinaryRangeOperationTests(BinaryOperationTestCase, TranspileTestCase):
     data_type = 'range'
 
     not_implemented = [
-        'test_multiply_bytearray',
-        'test_multiply_bytes',
-        'test_multiply_list',
-        'test_multiply_str',
-        'test_multiply_tuple',
-
         'test_subscr_bool',
     ]
 

--- a/tests/datatypes/test_range.py
+++ b/tests/datatypes/test_range.py
@@ -88,10 +88,6 @@ class UnaryRangeOperationTests(UnaryOperationTestCase, TranspileTestCase):
 class BinaryRangeOperationTests(BinaryOperationTestCase, TranspileTestCase):
     data_type = 'range'
 
-    not_implemented = [
-        'test_subscr_bool',
-    ]
-
     not_implemented_versions = {
         'test_subscr_None': (3.4,),
         'test_subscr_NotImplemented': (3.4,),


### PR DESCRIPTION
The previous implementation of Range.__getitem__ was incomplete when given a Slice object.  Now it will use the result of Slice.indices and compute the correct values for the Range object to be returned.