### PR TITLE
Implemented binary data type operation modulo with complex type

### DIFF
--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -612,7 +612,11 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
             args = {"other"}
     )
     public org.python.Object __mod__(org.python.Object other) {
-        throw new org.python.exceptions.TypeError("unsupported operand type(s) for %: '" + this.typeName() + "' and '" + other.typeName() + "'");
+        if (other instanceof org.python.types.Complex) {
+            throw new org.python.exceptions.TypeError("can't mod complex numbers.");
+        } else {
+            throw new org.python.exceptions.TypeError("unsupported operand type(s) for %: '" + this.typeName() + "' and '" + other.typeName() + "'");
+        }
     }
 
     @org.python.Method(

--- a/tests/datatypes/test_NoneType.py
+++ b/tests/datatypes/test_NoneType.py
@@ -29,8 +29,6 @@ class BinaryNoneTypeOperationTests(BinaryOperationTestCase, TranspileTestCase):
     data_type = 'None'
 
     not_implemented = [
-        'test_modulo_complex',
-
         'test_multiply_bytes',
         'test_multiply_bytearray',
     ]

--- a/tests/datatypes/test_NotImplemented.py
+++ b/tests/datatypes/test_NotImplemented.py
@@ -17,8 +17,6 @@ class BinaryNotImplementedOperationTests(BinaryOperationTestCase, TranspileTestC
     data_type = 'NotImplemented'
 
     not_implemented = [
-        'test_modulo_complex',
-
         'test_multiply_bytes',
         'test_multiply_bytearray',
 

--- a/tests/datatypes/test_dict.py
+++ b/tests/datatypes/test_dict.py
@@ -305,8 +305,6 @@ class BinaryDictOperationTests(BinaryOperationTestCase, TranspileTestCase):
     data_type = 'dict'
 
     not_implemented = [
-        'test_modulo_complex',
-
         'test_multiply_bytearray',
 
         'test_subscr_bytearray',

--- a/tests/datatypes/test_frozenset.py
+++ b/tests/datatypes/test_frozenset.py
@@ -329,8 +329,6 @@ class BinaryFrozensetOperationTests(BinaryOperationTestCase, TranspileTestCase):
     data_type = 'frozenset'
 
     not_implemented = [
-        'test_modulo_complex',
-
         'test_subscr_bool',
         'test_subscr_bytearray',
         'test_subscr_bytes',

--- a/tests/datatypes/test_list.py
+++ b/tests/datatypes/test_list.py
@@ -599,7 +599,6 @@ class BinaryListOperationTests(BinaryOperationTestCase, TranspileTestCase):
     data_type = 'list'
 
     not_implemented = [
-        'test_modulo_complex',
         'test_subscr_bool',
     ]
 

--- a/tests/datatypes/test_range.py
+++ b/tests/datatypes/test_range.py
@@ -94,8 +94,6 @@ class BinaryRangeOperationTests(BinaryOperationTestCase, TranspileTestCase):
 
         'test_eq_range',
 
-        'test_modulo_complex',
-
         'test_multiply_bytearray',
         'test_multiply_bytes',
         'test_multiply_list',

--- a/tests/datatypes/test_set.py
+++ b/tests/datatypes/test_set.py
@@ -358,12 +358,6 @@ class UnarySetOperationTests(UnaryOperationTestCase, TranspileTestCase):
 class BinarySetOperationTests(BinaryOperationTestCase, TranspileTestCase):
     data_type = 'set'
 
-    not_implemented = [
-
-        'test_modulo_complex',
-
-    ]
-
 
 class InplaceSetOperationTests(InplaceOperationTestCase, TranspileTestCase):
     data_type = 'set'

--- a/tests/datatypes/test_slice.py
+++ b/tests/datatypes/test_slice.py
@@ -247,8 +247,6 @@ class BinarySliceOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_le_slice',
         'test_lt_slice',
 
-        'test_modulo_complex',
-
         'test_multiply_bytearray',
         'test_multiply_bytes',
         'test_multiply_list',

--- a/tests/datatypes/test_tuple.py
+++ b/tests/datatypes/test_tuple.py
@@ -270,8 +270,6 @@ class BinaryTupleOperationTests(BinaryOperationTestCase, TranspileTestCase):
     data_type = 'tuple'
 
     not_implemented = [
-        'test_modulo_complex',
-
         'test_subscr_slice',
     ]
 


### PR DESCRIPTION
Python doesn't allow binary data type operation with modulo complex type

## Additions
- Added implementation to throw correct error on modulo data type with complex type
