### PR TITLE
Clean up determination of ouroboros dir.

### DIFF
--- a/tools/compile_stdlib.py
+++ b/tools/compile_stdlib.py
@@ -137,15 +137,19 @@ IGNORE_MODULES = set([
 def ouroboros_repo_folder():
     """Return the folder where the ouroboros repo was cloned.
 
-    If the repo doesn't exist, clone it.
+    If the repo doesn't exist, return None. It should get cloned by
+    update_repo.
     """
-    path = os.path.join(os.path.dirname(os.path.dirname(REPO_ROOT)), 'ouroboros')
-    if os.path.isdir(os.path.join(path, '.git')):
-        return path
 
-    path = os.path.join(os.path.dirname(REPO_ROOT), 'ouroboros')
-    if not os.path.isdir(os.path.join(path, '.git')):
-        return path
+    for dirpath in (
+        os.path.dirname(os.path.dirname(REPO_ROOT)),
+        os.path.dirname(REPO_ROOT),
+    ):
+        path = os.path.join(dirpath, 'ouroboros')
+        if os.path.isdir(os.path.join(path, '.git')):
+            return path
+    else:
+        return None
 
 
 def native_modules(target):


### PR DESCRIPTION
@freakboy3742 The problem that we were looking at was actually, I believe, due to the 'not' in the second `if` statement. `os.path.isdir` can, in fact, be called on anything and it will just return True or False--not raise an exception. I took the liberty of putting those checks in a `for` loop to clean it up a bit. Take it or leave it. I've tested that the script works when the ouroboros directory exists and when it doesn't. 