### PR TITLE
Implement builtin reversed

### DIFF
--- a/python/common/org/Python.java
+++ b/python/common/org/Python.java
@@ -1447,18 +1447,11 @@ public class Python {
     @org.python.Method(
             __doc__ = "reversed(sequence) -> reverse iterator over values of the sequence" +
                     "\n" +
-                    "Return a reverse iterator\n"
+                    "Return a reverse iterator\n",
+            args = {"sequence"}
     )
-    public static org.python.Object reversed(
-            java.util.List<org.python.Object> args,
-            java.util.Map<java.lang.String, org.python.Object> kwargs) {
-        if (kwargs != null && kwargs.size() != 0) {
-            throw new org.python.exceptions.TypeError("reversed() takes no keyword arguments");
-        }
-        if (args == null || args.size() != 1) {
-            throw new org.python.exceptions.TypeError("reversed() takes exactly one argument (" + args.size() + " given)");
-        }
-        return args.get(0).__reversed__();
+    public static org.python.Object reversed(org.python.Object sequence) {
+        return sequence.__reversed__();
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/ByteArray.java
+++ b/python/common/org/python/types/ByteArray.java
@@ -621,8 +621,12 @@ public class ByteArray extends org.python.types.Object {
     @org.python.Method(
             __doc__ = "Implement iter(self)."
     )
-    public org.python.Object __iter__(java.util.List<org.python.Object> args, java.util.Map<java.lang.String, org.python.Object> kwargs, java.util.List<org.python.Object> default_args, java.util.Map<java.lang.String, org.python.Object> default_kwargs) {
-        throw new org.python.exceptions.NotImplementedError("bytearray.__iter__ has not been implemented.");
+    public org.python.Object __iter__() {
+        java.util.List<org.python.Object> listOfBytes = new java.util.ArrayList<org.python.Object>();
+        for (byte b: this.value) {
+            listOfBytes.add(new org.python.types.Int(b));
+        }
+        return new org.python.types.List(listOfBytes).__iter__();
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Dict_KeyIterator.java
+++ b/python/common/org/python/types/Dict_KeyIterator.java
@@ -2,6 +2,6 @@ package org.python.types;
 
 class Dict_KeyIterator extends org.python.types.Iterator {
     public Dict_KeyIterator(org.python.types.Dict dict) {
-        super(dict);
+        this.iterator = dict.value.keySet().iterator();
     }
 }

--- a/python/common/org/python/types/Iterator.java
+++ b/python/common/org/python/types/Iterator.java
@@ -7,22 +7,6 @@ class Iterator extends org.python.types.Object implements org.python.Object {
         return this.iterator.hashCode();
     }
 
-    public Iterator(org.python.types.List list) {
-        this.iterator = list.value.iterator();
-    }
-
-    public Iterator(org.python.types.Tuple tuple) {
-        this.iterator = tuple.value.iterator();
-    }
-
-    public Iterator(org.python.types.Set set) {
-        this.iterator = set.value.iterator();
-    }
-
-    public Iterator(org.python.types.Dict dict) {
-        this.iterator = dict.value.keySet().iterator();
-    }
-
     @org.python.Method(
             __doc__ = "Implement iter(self)."
     )

--- a/python/common/org/python/types/List.java
+++ b/python/common/org/python/types/List.java
@@ -495,12 +495,7 @@ public class List extends org.python.types.Object {
                       "modify the original list."
     )
     public org.python.Object __reversed__() {
-        org.python.types.List list = new org.python.types.List();
-        for (int i = this.value.size() - 1; i >= 0; i--) {
-            list.append(this.value.get(i));
-        }
-        org.python.Object iter = new org.python.types.List_Iterator(list);
-        return iter;
+        return new org.python.types.List_ReverseIterator(this);
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/List_Iterator.java
+++ b/python/common/org/python/types/List_Iterator.java
@@ -2,6 +2,6 @@ package org.python.types;
 
 class List_Iterator extends org.python.types.Iterator {
     public List_Iterator(org.python.types.List list) {
-        super(list);
+        this.iterator = list.value.iterator();
     }
 }

--- a/python/common/org/python/types/List_ReverseIterator.java
+++ b/python/common/org/python/types/List_ReverseIterator.java
@@ -1,0 +1,7 @@
+package org.python.types;
+
+class List_ReverseIterator extends ReverseIterator {
+    public List_ReverseIterator(org.python.types.List list) {
+        this.iterator = list.value.listIterator(list.value.size());
+    }
+}

--- a/python/common/org/python/types/Range.java
+++ b/python/common/org/python/types/Range.java
@@ -66,6 +66,22 @@ public class Range extends org.python.types.Object {
     }
 
     @org.python.Method(
+            __doc__ = "Reverse the list in place and returns\n" +
+                      "an iterator that iterates over all the objects\n" +
+                      "in the list in reverse order. Does not\n" +
+                      "modify the original list."
+    )
+    public org.python.Object __reversed__() {
+        // TODO: Will need to check for overflows and underflows and many
+        // other edge cases in the future...
+        long n = (this.stop - this.start + 1) / this.step;
+        long start = this.start + (n - 1) * this.step;
+        long stop = this.start - this.step;
+        long step = 0 - this.step;
+        return new RangeIterator(start, stop, step);
+    }
+
+    @org.python.Method(
             __doc__ = "Implement __getitem__(self).",
             args = {"index"}
     )

--- a/python/common/org/python/types/ReverseIterator.java
+++ b/python/common/org/python/types/ReverseIterator.java
@@ -1,0 +1,49 @@
+package org.python.types;
+
+
+class ReverseIterator extends org.python.types.Object implements org.python.Object {
+    java.util.ListIterator<org.python.Object> iterator;
+
+    public int hashCode() {
+        return this.iterator.hashCode();
+    }
+
+    @org.python.Method(
+            __doc__ = "Implement iter(self)."
+    )
+    public org.python.Object __iter__(java.util.List<org.python.Object> args, java.util.Map<java.lang.String, org.python.Object> kwargs, java.util.List<org.python.Object> default_args, java.util.Map<java.lang.String, org.python.Object> default_kwargs) {
+        if (kwargs != null && kwargs.size() != 0) {
+            throw new org.python.exceptions.TypeError("__iter__ doesn't take keyword arguments");
+        }
+        if (args != null && args.size() != 0) {
+            throw new org.python.exceptions.TypeError("Expected 0 arguments, got " + args.size());
+        }
+        return this;
+    }
+
+    public org.python.Object __iter__() {
+        return this.__iter__(null, null, null, null);
+    }
+
+    @org.python.Method(
+            __doc__ = "Implement next(self)."
+    )
+    public org.python.Object __next__(java.util.List<org.python.Object> args, java.util.Map<java.lang.String, org.python.Object> kwargs, java.util.List<org.python.Object> default_args, java.util.Map<java.lang.String, org.python.Object> default_kwargs) {
+        if (kwargs != null && kwargs.size() != 0) {
+            throw new org.python.exceptions.TypeError("__next__ doesn't take keyword arguments");
+        }
+        if (args != null && args.size() != 0) {
+            throw new org.python.exceptions.TypeError("Expected 0 arguments, got " + args.size());
+        }
+
+        try {
+            return this.iterator.previous();
+        } catch (java.util.NoSuchElementException e) {
+            throw new org.python.exceptions.StopIteration();
+        }
+    }
+
+    public org.python.Object __next__() {
+        return this.__next__(null, null, null, null);
+    }
+}

--- a/python/common/org/python/types/Reversed.java
+++ b/python/common/org/python/types/Reversed.java
@@ -7,7 +7,7 @@ public class Reversed extends Object implements org.python.Object {
 
     public Reversed(org.python.Object sequence) {
         this.sequence = sequence;
-        this.index = ((Int)sequence.__len__()).value - 1;
+        this.index = ((Int) sequence.__len__()).value - 1;
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Reversed.java
+++ b/python/common/org/python/types/Reversed.java
@@ -1,0 +1,31 @@
+package org.python.types;
+
+
+public class Reversed extends Object implements org.python.Object {
+    org.python.Object sequence;
+    long index;
+
+    public Reversed(org.python.Object sequence) {
+        this.sequence = sequence;
+        this.index = ((Int)sequence.__len__()).value - 1;
+    }
+
+    @org.python.Method(
+            __doc__ = "Implement iter(self)."
+    )
+    public org.python.Object __iter__() {
+        return this;
+    }
+
+    @org.python.Method(
+            __doc__ = "Implement next(self)."
+    )
+    public org.python.Object __next__() {
+        if (this.index < 0) {
+            throw new org.python.exceptions.StopIteration();
+        }
+        org.python.Object item = this.sequence.__getitem__(new Int(this.index));
+        this.index--;
+        return item;
+    }
+}

--- a/python/common/org/python/types/Set_Iterator.java
+++ b/python/common/org/python/types/Set_Iterator.java
@@ -2,10 +2,10 @@ package org.python.types;
 
 class Set_Iterator extends org.python.types.Iterator {
     public Set_Iterator(org.python.types.Set set) {
-        super(set);
+        this.iterator = set.value.iterator();
     }
 
     public Set_Iterator(org.python.types.FrozenSet set) {
-        super(new org.python.types.Set(set.value));
+        this.iterator = set.value.iterator();
     }
 }

--- a/python/common/org/python/types/Tuple_Iterator.java
+++ b/python/common/org/python/types/Tuple_Iterator.java
@@ -2,6 +2,6 @@ package org.python.types;
 
 class Tuple_Iterator extends org.python.types.Iterator {
     public Tuple_Iterator(org.python.types.Tuple tuple) {
-        super(tuple);
+        this.iterator = tuple.value.iterator();
     }
 }

--- a/tests/builtins/test_all.py
+++ b/tests/builtins/test_all.py
@@ -7,7 +7,3 @@ class AllTests(TranspileTestCase):
 
 class BuiltinAllFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     functions = ["all"]
-
-    not_implemented = [
-        'test_bytearray',
-    ]

--- a/tests/builtins/test_any.py
+++ b/tests/builtins/test_any.py
@@ -7,7 +7,3 @@ class AnyTests(TranspileTestCase):
 
 class BuiltinAnyFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     functions = ["any"]
-
-    not_implemented = [
-        'test_bytearray',
-    ]

--- a/tests/builtins/test_bytearray.py
+++ b/tests/builtins/test_bytearray.py
@@ -10,7 +10,6 @@ class BuiltinBytearrayFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
 
     not_implemented = [
         'test_bool',
-        'test_bytearray',
         'test_class',
         'test_complex',
         'test_dict',

--- a/tests/builtins/test_dict.py
+++ b/tests/builtins/test_dict.py
@@ -7,7 +7,3 @@ class DictTests(TranspileTestCase):
 
 class BuiltinDictFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     functions = ["dict"]
-
-    not_implemented = [
-        'test_bytearray',
-    ]

--- a/tests/builtins/test_filter.py
+++ b/tests/builtins/test_filter.py
@@ -53,8 +53,6 @@ class BuiltinFilterFunctionTests(BuiltinTwoargFunctionTestCase, TranspileTestCas
         'test_bytes_str',
         'test_bytes_tuple',
 
-        'test_class_bytearray',
-
         'test_complex_bytearray',
         'test_complex_bytes',
         'test_complex_dict',
@@ -114,8 +112,6 @@ class BuiltinFilterFunctionTests(BuiltinTwoargFunctionTestCase, TranspileTestCas
         'test_list_set',
         'test_list_str',
         'test_list_tuple',
-
-        'test_None_bytearray',
 
         'test_NotImplemented_bytearray',
         'test_NotImplemented_bytes',

--- a/tests/builtins/test_frozenset.py
+++ b/tests/builtins/test_frozenset.py
@@ -9,7 +9,6 @@ class BuiltinFrozensetFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     functions = ["frozenset"]
 
     not_implemented = [
-        'test_bytearray',
         'test_bytes',
         'test_str',
     ]

--- a/tests/builtins/test_list.py
+++ b/tests/builtins/test_list.py
@@ -25,7 +25,3 @@ class BuiltinListFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
             "['d', 'c', 'a']",
         ]
     })
-
-    not_implemented = [
-        'test_bytearray',
-    ]

--- a/tests/builtins/test_map.py
+++ b/tests/builtins/test_map.py
@@ -32,23 +32,3 @@ class MapTests(TranspileTestCase):
 
 class BuiltinMapFunctionTests(BuiltinTwoargFunctionTestCase, TranspileTestCase):
     functions = ["map"]
-
-    not_implemented = [
-        'test_bool_bytearray',
-        'test_bytearray_bytearray',
-        'test_bytes_bytearray',
-        'test_class_bytearray',
-        'test_complex_bytearray',
-        'test_dict_bytearray',
-        'test_float_bytearray',
-        'test_frozenset_bytearray',
-        'test_int_bytearray',
-        'test_list_bytearray',
-        'test_None_bytearray',
-        'test_NotImplemented_bytearray',
-        'test_range_bytearray',
-        'test_set_bytearray',
-        'test_slice_bytearray',
-        'test_str_bytearray',
-        'test_tuple_bytearray',
-    ]

--- a/tests/builtins/test_max.py
+++ b/tests/builtins/test_max.py
@@ -72,7 +72,3 @@ class MaxTests(TranspileTestCase):
 
 class BuiltinMaxFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     functions = ["max"]
-
-    not_implemented = [
-        'test_bytearray',
-    ]

--- a/tests/builtins/test_min.py
+++ b/tests/builtins/test_min.py
@@ -76,6 +76,5 @@ class BuiltinMinFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     functions = ["min"]
 
     not_implemented = [
-        'test_bytearray',
         'test_tuple',
     ]

--- a/tests/builtins/test_reversed.py
+++ b/tests/builtins/test_reversed.py
@@ -1,8 +1,25 @@
-from .. utils import TranspileTestCase, BuiltinFunctionTestCase
+from .. utils import SAMPLE_DATA, TranspileTestCase, BuiltinFunctionTestCase
+
+
+def _iterate_test(datatype):
+
+    def test_func(self):
+        code = '\n'.join([
+            '\nfor x in {value}:\n    print(x)\n'.format(value=value)
+            for value in SAMPLE_DATA[datatype]
+        ])
+        self.assertCodeExecution(code)
+
+    return test_func
 
 
 class ReversedTests(TranspileTestCase):
-    pass
+    # test_iterate_bytearray = _iterate_test('bytearray')
+    test_iterate_bytes = _iterate_test('bytes')
+    test_iterate_list = _iterate_test('list')
+    test_iterate_range = _iterate_test('range')
+    test_iterate_str = _iterate_test('str')
+    test_iterate_tuple = _iterate_test('tuple')
 
 
 class BuiltinReversedFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):

--- a/tests/builtins/test_reversed.py
+++ b/tests/builtins/test_reversed.py
@@ -24,7 +24,3 @@ class ReversedTests(TranspileTestCase):
 
 class BuiltinReversedFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     functions = ["reversed"]
-
-    not_implemented = [
-        'test_range',
-    ]

--- a/tests/builtins/test_reversed.py
+++ b/tests/builtins/test_reversed.py
@@ -9,19 +9,5 @@ class BuiltinReversedFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     functions = ["reversed"]
 
     not_implemented = [
-        'test_bool',
-        'test_bytearray',
-        'test_bytes',
-        'test_class',
-        'test_complex',
-        'test_dict',
-        'test_float',
-        'test_frozenset',
-        'test_int',
-        'test_None',
-        'test_NotImplemented',
         'test_range',
-        'test_set',
-        'test_slice',
-        'test_str',
     ]

--- a/tests/builtins/test_reversed.py
+++ b/tests/builtins/test_reversed.py
@@ -18,12 +18,10 @@ class BuiltinReversedFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
         'test_float',
         'test_frozenset',
         'test_int',
-        'test_list',
         'test_None',
         'test_NotImplemented',
         'test_range',
         'test_set',
         'test_slice',
         'test_str',
-        'test_tuple',
     ]

--- a/tests/builtins/test_reversed.py
+++ b/tests/builtins/test_reversed.py
@@ -14,7 +14,7 @@ def _iterate_test(datatype):
 
 
 class ReversedTests(TranspileTestCase):
-    # test_iterate_bytearray = _iterate_test('bytearray')
+    test_iterate_bytearray = _iterate_test('bytearray')
     test_iterate_bytes = _iterate_test('bytes')
     test_iterate_list = _iterate_test('list')
     test_iterate_range = _iterate_test('range')

--- a/tests/builtins/test_set.py
+++ b/tests/builtins/test_set.py
@@ -9,7 +9,6 @@ class BuiltinSetFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     functions = ["set"]
 
     not_implemented = [
-        'test_bytearray',
         'test_bytes',
         'test_str',
         'test_tuple',

--- a/tests/builtins/test_sorted.py
+++ b/tests/builtins/test_sorted.py
@@ -26,6 +26,5 @@ class BuiltinSortedFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     functions = ["sorted"]
 
     not_implemented = [
-        'test_bytearray',
         'test_fozenset',
     ]

--- a/tests/builtins/test_sum.py
+++ b/tests/builtins/test_sum.py
@@ -29,6 +29,5 @@ class BuiltinSumFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     functions = ["sum"]
 
     not_implemented = [
-        'test_bytearray',
         'test_frozenzet',
     ]


### PR DESCRIPTION
* [x] Make the reversed builtin callable.
* [x] Implement generic reversed type on top of `__len__` and `__getitem__`.
* [x] Implement `__reversed__` on `list` to return a `list_reverseiterator`.
* [x] Implement `__reversed__` on `range` to return a `range_iterator`. [^a]
* [x] Add tests to `test_reversed.py::ReversedTests` to actually test running through the iterators.

[^a]: Reverse of a range is `range(start+(n-1)*step, start-step, -step)`, where `n` is the number of integers in the range. The principle is simple, but implementation can be very tedious to dive into.