### PR TITLE
Add List.extend for datatype bytes, bytearray, range, str

### DIFF
--- a/python/common/org/python/types/List.java
+++ b/python/common/org/python/types/List.java
@@ -671,13 +671,30 @@ public class List extends org.python.types.Object {
             this.value.addAll(((org.python.types.Tuple) other).value);
         } else if (other instanceof org.python.types.Dict) {
             this.value.addAll(((org.python.types.Dict) other).value.keySet());
-        } else if (other instanceof org.python.types.Iterator) {
-            try {
-                while (true) {
-                    org.python.Object next = other.__next__();
-                    this.value.add(next);
+        } else if (
+            (other instanceof org.python.types.Str) ||
+            (other instanceof org.python.types.Range) ||
+            (other instanceof org.python.types.Bytes) ||
+            (other instanceof org.python.types.ByteArray) ||
+            (other instanceof org.python.types.Iterator)) {
+            org.python.Object iter = null;
+            if (other instanceof org.python.types.Str) {
+                iter = ((org.python.types.Str)other).__iter__();
+            } else if (other instanceof org.python.types.Range) {
+                iter = ((org.python.types.Range)other).__iter__();
+            } else if (other instanceof org.python.types.Bytes) {
+                iter = ((org.python.types.Bytes)other).__iter__();
+            } else if (other instanceof org.python.types.ByteArray) {
+                iter = ((org.python.types.ByteArray)other).__iter__();
+            } else if (other instanceof org.python.types.Iterator) {
+                iter = other;
+            }
+            while (true) {
+                try {
+                    this.value.add(iter.__next__());
+                } catch (org.python.exceptions.StopIteration si) {
+                    break;
                 }
-            } catch (org.python.exceptions.StopIteration si) {
             }
         } else {
             throw new org.python.exceptions.TypeError("'" + other.typeName() + "' object is not iterable");

--- a/python/common/org/python/types/List.java
+++ b/python/common/org/python/types/List.java
@@ -672,11 +672,11 @@ public class List extends org.python.types.Object {
         } else if (other instanceof org.python.types.Dict) {
             this.value.addAll(((org.python.types.Dict) other).value.keySet());
         } else if (
-            (other instanceof org.python.types.Str) ||
-            (other instanceof org.python.types.Range) ||
-            (other instanceof org.python.types.Bytes) ||
-            (other instanceof org.python.types.ByteArray) ||
-            (other instanceof org.python.types.Iterator)) {
+                (other instanceof org.python.types.Str) ||
+                (other instanceof org.python.types.Range) ||
+                (other instanceof org.python.types.Bytes) ||
+                (other instanceof org.python.types.ByteArray) ||
+                (other instanceof org.python.types.Iterator)) {
             org.python.Object iter = null;
             if (other instanceof org.python.types.Str) {
                 iter = ((org.python.types.Str)other).__iter__();

--- a/tests/datatypes/test_list.py
+++ b/tests/datatypes/test_list.py
@@ -193,7 +193,35 @@ class ListTests(TranspileTestCase):
             print(x)
             """)
 
-        # # extend non-iterable
+        # extend bytearray
+        self.assertCodeExecution("""
+            x = [1, 2, 3]
+            x.extend(bytearray(b'abc'))
+            print(x)
+            """)
+
+        # extend byte
+        self.assertCodeExecution("""
+            x = [1, 2, 3]
+            x.extend(b'def')
+            print(x)
+            """)
+
+        # extend str
+        self.assertCodeExecution("""
+            x = [1, 2, 3]
+            x.extend(b'string')
+            print(x)
+            """)
+
+        # extend range
+        self.assertCodeExecution("""
+            x = [1, 2, 3]
+            x.extend(range(5))
+            print(x)
+            """)
+
+        # extend non-iterable
         self.assertCodeExecution("""
             x = [1, 2, 3]
             try:


### PR DESCRIPTION
Those were missing from the implementation.

## Additions:
- List.extend for bytes, bytearray, range, and string