### PR TITLE
Refs #36 Implement binary slice comparison operations

### DIFF
--- a/python/common/org/python/types/Slice.java
+++ b/python/common/org/python/types/Slice.java
@@ -177,7 +177,9 @@ public class Slice extends org.python.types.Object {
             org.python.types.Tuple thisSliceAsTuple = convertSliceToTuple(this);
             return thisSliceAsTuple.__ge__(otherSliceAsTuple);
         }
-        else return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
+        else {
+            return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
+        }
     }
 
     @org.python.Method(
@@ -191,7 +193,9 @@ public class Slice extends org.python.types.Object {
             org.python.types.Tuple thisSliceAsTuple = convertSliceToTuple(this);
             return thisSliceAsTuple.__gt__(otherSliceAsTuple);
         }
-        else return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
+        else {
+            return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
+        }
     }
 
     @org.python.Method(
@@ -205,7 +209,9 @@ public class Slice extends org.python.types.Object {
             org.python.types.Tuple thisSliceAsTuple = convertSliceToTuple(this);
             return thisSliceAsTuple.__eq__(otherSliceAsTuple);
         }
-        else return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
+        else {
+            return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
+        }
     }
 
     @org.python.Method(
@@ -219,7 +225,9 @@ public class Slice extends org.python.types.Object {
             org.python.types.Tuple thisSliceAsTuple = convertSliceToTuple(this);
             return thisSliceAsTuple.__lt__(otherSliceAsTuple);
         }
-        else return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
+        else {
+            return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
+        }
     }
 
     @org.python.Method(
@@ -233,6 +241,8 @@ public class Slice extends org.python.types.Object {
             org.python.types.Tuple thisSliceAsTuple = convertSliceToTuple(this);
             return thisSliceAsTuple.__le__(otherSliceAsTuple);
         }
-        else return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
+        else {
+            return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
+        }
     }
 }

--- a/python/common/org/python/types/Slice.java
+++ b/python/common/org/python/types/Slice.java
@@ -158,12 +158,26 @@ public class Slice extends org.python.types.Object {
             this.step.__repr__()));
     }
 
+    private org.python.types.Tuple convertSliceToTuple(org.python.types.Slice slice) {
+        org.python.types.Tuple tupleFromSlice = new org.python.types.Tuple();
+        tupleFromSlice.value.add(slice.start);
+        tupleFromSlice.value.add(slice.stop);
+        tupleFromSlice.value.add(slice.step);
+        return tupleFromSlice;
+    }
+
     @org.python.Method(
             __doc__ = "Return self>=value.",
             args = {"other"}
     )
     public org.python.Object __ge__(org.python.Object other) {
-        return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
+
+        if (other instanceof org.python.types.Slice) {
+            org.python.types.Tuple otherSliceAsTuple = convertSliceToTuple((org.python.types.Slice) other);
+            org.python.types.Tuple thisSliceAsTuple = convertSliceToTuple(this);
+            return thisSliceAsTuple.__ge__(otherSliceAsTuple);
+        }
+        else return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
 
     @org.python.Method(
@@ -171,7 +185,13 @@ public class Slice extends org.python.types.Object {
             args = {"other"}
     )
     public org.python.Object __gt__(org.python.Object other) {
-        return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
+
+        if (other instanceof org.python.types.Slice) {
+            org.python.types.Tuple otherSliceAsTuple = convertSliceToTuple((org.python.types.Slice) other);
+            org.python.types.Tuple thisSliceAsTuple = convertSliceToTuple(this);
+            return thisSliceAsTuple.__gt__(otherSliceAsTuple);
+        }
+        else return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
 
     @org.python.Method(
@@ -179,7 +199,13 @@ public class Slice extends org.python.types.Object {
             args = {"other"}
     )
     public org.python.Object __eq__(org.python.Object other) {
-        return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
+
+        if (other instanceof org.python.types.Slice) {
+            org.python.types.Tuple otherSliceAsTuple = convertSliceToTuple((org.python.types.Slice) other);
+            org.python.types.Tuple thisSliceAsTuple = convertSliceToTuple(this);
+            return thisSliceAsTuple.__eq__(otherSliceAsTuple);
+        }
+        else return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
 
     @org.python.Method(
@@ -187,7 +213,13 @@ public class Slice extends org.python.types.Object {
             args = {"other"}
     )
     public org.python.Object __lt__(org.python.Object other) {
-        return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
+
+        if (other instanceof org.python.types.Slice) {
+            org.python.types.Tuple otherSliceAsTuple = convertSliceToTuple((org.python.types.Slice) other);
+            org.python.types.Tuple thisSliceAsTuple = convertSliceToTuple(this);
+            return thisSliceAsTuple.__lt__(otherSliceAsTuple);
+        }
+        else return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
 
     @org.python.Method(
@@ -195,6 +227,12 @@ public class Slice extends org.python.types.Object {
             args = {"other"}
     )
     public org.python.Object __le__(org.python.Object other) {
-        return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
+
+        if (other instanceof org.python.types.Slice) {
+            org.python.types.Tuple otherSliceAsTuple = convertSliceToTuple((org.python.types.Slice) other);
+            org.python.types.Tuple thisSliceAsTuple = convertSliceToTuple(this);
+            return thisSliceAsTuple.__le__(otherSliceAsTuple);
+        }
+        else return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
 }

--- a/tests/datatypes/test_slice.py
+++ b/tests/datatypes/test_slice.py
@@ -234,26 +234,11 @@ class BinarySliceOperationTests(BinaryOperationTestCase, TranspileTestCase):
     data_type = 'slice'
 
     not_implemented = [
-        'test_direct_eq_slice',
-        'test_direct_ge_slice',
-        'test_direct_gt_slice',
-        'test_direct_le_slice',
-        'test_direct_lt_slice',
-        'test_direct_ne_slice',
-
-        'test_eq_slice',
-        'test_ge_slice',
-        'test_gt_slice',
-        'test_le_slice',
-        'test_lt_slice',
-
         'test_multiply_bytearray',
         'test_multiply_bytes',
         'test_multiply_list',
         'test_multiply_str',
         'test_multiply_tuple',
-
-        'test_ne_slice',
 
         'test_subscr_bool',
         'test_subscr_bytearray',


### PR DESCRIPTION
This change implements the following binary slice comparison operations:

```
__eq__
__gt__
__ge__
__lt__
__le__
```

`__ne__` is also implemented as a byproduct, as it uses the inverse of `__eq__`.

In Python3 `__cmp__()` is eliminated and all comparisons are now rich comparisons, so this change covers the corresponding `direct` (rich comparison) binary operations as well.

I'm a first time contributor to this project, feedback is very much appreciated!