### PR TITLE
Refs #36 removes unnecessary setValue calls on Inplace operators

### DIFF
--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -813,8 +813,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
     )
     public org.python.Object __imul__(org.python.Object other) {
         try {
-            this.setValue(this.__mul__(other));
-            return this;
+            return this.__mul__(other);
         } catch (org.python.exceptions.TypeError e) {
             throw new org.python.exceptions.TypeError("unsupported operand type(s) for *=: '" + this.typeName() + "' and '" + other.typeName() + "'");
         }
@@ -826,8 +825,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
     )
     public org.python.Object __itruediv__(org.python.Object other) {
         try {
-            this.setValue(this.__truediv__(other));
-            return this;
+            return this.__truediv__(other);
         } catch (org.python.exceptions.TypeError e) {
             throw new org.python.exceptions.TypeError("unsupported operand type(s) for /=: '" + this.typeName() + "' and '" + other.typeName() + "'");
         }
@@ -839,8 +837,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
     )
     public org.python.Object __ifloordiv__(org.python.Object other) {
         try {
-            this.setValue(this.__floordiv__(other));
-            return this;
+            return this.__floordiv__(other);
         } catch (org.python.exceptions.TypeError e) {
             if (other instanceof org.python.types.Complex) {
                 throw new org.python.exceptions.TypeError("can't take floor of complex number.");
@@ -885,8 +882,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
             args = {"other"}
     )
     public org.python.Object __ipow__(org.python.Object other) {
-        this.setValue(this.__pow__(other, null));
-        return this;
+        return this.__pow__(other, null);
     }
 
     @org.python.Method(
@@ -933,8 +929,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
     )
     public org.python.Object __ixor__(org.python.Object other) {
         try {
-            this.setValue(this.__xor__(other));
-            return this;
+            return this.__xor__(other);
         } catch (org.python.exceptions.TypeError e) {
             throw new org.python.exceptions.TypeError("unsupported operand type(s) for ^=: '" + this.typeName() + "' and '" + other.typeName() + "'");
         }

--- a/tests/datatypes/test_bool.py
+++ b/tests/datatypes/test_bool.py
@@ -40,33 +40,7 @@ class InplaceBoolOperationTests(InplaceOperationTestCase, TranspileTestCase):
     data_type = 'bool'
 
     not_implemented = [
-        'test_floor_divide_bool',
-        'test_floor_divide_float',
-        'test_floor_divide_int',
-
         'test_modulo_bool',
         'test_modulo_float',
         'test_modulo_int',
-
-        'test_multiply_bool',
-        'test_multiply_bytearray',
-        'test_multiply_bytes',
-        'test_multiply_complex',
-        'test_multiply_float',
-        'test_multiply_int',
-        'test_multiply_list',
-        'test_multiply_str',
-        'test_multiply_tuple',
-
-        'test_power_bool',
-        'test_power_complex',
-        'test_power_float',
-        'test_power_int',
-
-        'test_true_divide_bool',
-        'test_true_divide_complex',
-        'test_true_divide_float',
-        'test_true_divide_int',
-
-        'test_xor_int',
     ]

--- a/tests/datatypes/test_complex.py
+++ b/tests/datatypes/test_complex.py
@@ -205,12 +205,8 @@ class InplaceComplexOperationTests(InplaceOperationTestCase, TranspileTestCase):
         'test_modulo_str',
         'test_modulo_tuple',
 
-        'test_multiply_bool',
         'test_multiply_bytearray',
         'test_multiply_bytes',
-        'test_multiply_complex',
-        'test_multiply_float',
-        'test_multiply_int',
         'test_multiply_list',
         'test_multiply_none',
         'test_multiply_str',
@@ -235,10 +231,7 @@ class InplaceComplexOperationTests(InplaceOperationTestCase, TranspileTestCase):
         'test_ne_str',
         'test_ne_tuple',
 
-        'test_power_bool',
         'test_power_complex',
-        'test_power_float',
-        'test_power_int',
         'test_power_none',
 
         'test_rshift_none',
@@ -262,9 +255,5 @@ class InplaceComplexOperationTests(InplaceOperationTestCase, TranspileTestCase):
         'test_subscr_str',
         'test_subscr_tuple',
 
-        'test_true_divide_bool',
-        'test_true_divide_complex',
-        'test_true_divide_float',
-        'test_true_divide_int',
         'test_true_divide_none',
     ]


### PR DESCRIPTION
Fixing most of the Inplace Boolean Operations Tests