### PR TITLE
Fix in-place modulo operations for bools.

### DIFF
--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -856,8 +856,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
     )
     public org.python.Object __imod__(org.python.Object other) {
         try {
-            this.setValue(this.__mod__(other));
-            return this;
+            return this.__mod__(other);
         } catch (org.python.exceptions.TypeError e) {
             if (other instanceof org.python.types.Complex) {
                 throw new org.python.exceptions.TypeError("can't mod complex numbers.");

--- a/tests/datatypes/test_bool.py
+++ b/tests/datatypes/test_bool.py
@@ -44,10 +44,6 @@ class InplaceBoolOperationTests(InplaceOperationTestCase, TranspileTestCase):
         'test_floor_divide_float',
         'test_floor_divide_int',
 
-        'test_modulo_bool',
-        'test_modulo_float',
-        'test_modulo_int',
-
         'test_multiply_bool',
         'test_multiply_bytearray',
         'test_multiply_bytes',


### PR DESCRIPTION
A modulo operation with a bool may return an int, which cannot be then cast to a bool in `Bool.setValue`.

Not calling `setValue`, and instead returning the new value, allows the tests to pass.