### PR TITLE
Add upper for bytes type

### DIFF
--- a/python/common/org/python/types/Bytes.java
+++ b/python/common/org/python/types/Bytes.java
@@ -1114,8 +1114,13 @@ public class Bytes extends org.python.types.Object {
     @org.python.Method(
             __doc__ = "B.upper() -> copy of B\n\nReturn a copy of B with all ASCII characters converted to uppercase."
     )
-    public org.python.Object upper(java.util.List<org.python.Object> args, java.util.Map<java.lang.String, org.python.Object> kwargs, java.util.List<org.python.Object> default_args, java.util.Map<java.lang.String, org.python.Object> default_kwargs) {
-        throw new org.python.exceptions.NotImplementedError("bytes.upper has not been implemented.");
+    public org.python.Object upper() {
+        byte[] result = new byte[this.value.length];
+        for (int idx = 0; idx < this.value.length; ++idx) {
+            char lc = (char) this.value[idx];
+            result[idx] = (byte) Character.toUpperCase(lc);
+        }
+        return new Bytes(result);
     }
 
     @org.python.Method(

--- a/tests/datatypes/test_bytes.py
+++ b/tests/datatypes/test_bytes.py
@@ -268,18 +268,31 @@ class BytesTests(TranspileTestCase):
             print(b'pybee'.center(-5))
             print(b''.center(5))
             print(b'pybee'.center(True, b'a'))
-            """)
+        """)
         self.assertCodeExecution("""
             print(b'pybee'.center('5'))
-            """, exits_early=True)
+        """, exits_early=True)
         self.assertCodeExecution("""
             print(b'pybee'.center(12, b'as'))
-            """, exits_early=True)
+        """, exits_early=True)
         self.assertCodeExecution("""
             print(b'pybee'.center(12, 'a'))
-            """, exits_early=True)
+        """, exits_early=True)
 
-        
+    def test_upper(self):
+        self.assertCodeExecution("""
+            print(b'testupper'.upper())
+            print(b'TestUpper'.upper())
+            print(b'test upper'.upper())
+            print(b'666'.upper())
+            print(b' '.upper())
+            print(b''.upper())
+            print(b'/@. test'.upper())
+            print(b'\x46\x55\x43\x4B'.upper())
+        """)
+
+
+
 class UnaryBytesOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'bytes'
 


### PR DESCRIPTION
Implementation of "upper()" builtin method for bytes type with 8 tests cases on "test_bytes.py".