### PR TITLE
Style fixes and ant checkstyle config change

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -55,7 +55,7 @@
 
     <!-- Checks for Size Violations.                    -->
     <!-- See http://checkstyle.sf.net/config_sizes.html -->
-    <module name="FileLength"/>
+    <!-- <module name="FileLength"/> -->
 
     <!-- Checks for whitespace                               -->
     <!-- See http://checkstyle.sf.net/config_whitespace.html -->

--- a/python/common/org/python/types/ByteArray.java
+++ b/python/common/org/python/types/ByteArray.java
@@ -725,9 +725,9 @@ public class ByteArray extends org.python.types.Object {
     }
 
     @org.python.Method(
-            __doc__ = "B.find(sub[, start[, end]]) -> int"+
-            "\n\nReturn the lowest index in B where subsection sub is found,"+
-            "\nsuch that sub is contained within B[start,end].  Optional"+
+            __doc__ = "B.find(sub[, start[, end]]) -> int" +
+            "\n\nReturn the lowest index in B where subsection sub is found," +
+            "\nsuch that sub is contained within B[start,end].  Optional" +
             "\narguments start and end are interpreted as in slice notation.\n\nReturn -1 on failure.",
             args = {"sub"},
             default_args = {"start", "end"}

--- a/python/common/org/python/types/Bytes.java
+++ b/python/common/org/python/types/Bytes.java
@@ -686,7 +686,7 @@ public class Bytes extends org.python.types.Object {
     public static byte[] _center(byte[] input, org.python.Object width, org.python.Object byteToFill) {
         byte[] fillByte;
         if (byteToFill instanceof org.python.types.Bytes || byteToFill instanceof org.python.types.ByteArray) {
-            if(byteToFill instanceof org.python.types.ByteArray){
+            if (byteToFill instanceof org.python.types.ByteArray) {
                 fillByte = ((org.python.types.ByteArray) byteToFill).value;
             } else {
                 fillByte = ((org.python.types.Bytes) byteToFill).value;
@@ -910,8 +910,8 @@ public class Bytes extends org.python.types.Object {
     }
 
     @org.python.Method(
-            __doc__ = "B.find(sub[, start[, end]]) -> int"+
-            "\n\nReturn the lowest index in B where substring sub is found,\nsuch that sub is contained within B[start:end].  Optional"+
+            __doc__ = "B.find(sub[, start[, end]]) -> int" +
+            "\n\nReturn the lowest index in B where substring sub is found,\nsuch that sub is contained within B[start:end].  Optional" +
             "\narguments start and end are interpreted as in slice notation.\n\nReturn -1 on failure.",
             args = {"sub"},
             default_args = {"start", "end"}
@@ -926,7 +926,7 @@ public class Bytes extends org.python.types.Object {
             _end = this.value.length;
         }
         byte[] _sub;
-        if(sub instanceof org.python.types.ByteArray){
+        if (sub instanceof org.python.types.ByteArray) {
             _sub = ((org.python.types.ByteArray) sub).value;
         } else {
             _sub = ((org.python.types.Bytes) sub).value;
@@ -1232,9 +1232,9 @@ public class Bytes extends org.python.types.Object {
         byte[] result = new byte[input.length];
         for (int idx = 0; idx < input.length; ++idx) {
             char lc = (char) input[idx];
-            if(Character.isUpperCase(lc)){
+            if (Character.isUpperCase(lc)) {
                 result[idx] = (byte) Character.toLowerCase(lc);
-            }else{
+            } else {
                 result[idx] = (byte) Character.toUpperCase(lc);
             }
         }

--- a/tests/datatypes/test_bytearray.py
+++ b/tests/datatypes/test_bytearray.py
@@ -127,6 +127,7 @@ class BytearrayTests(TranspileTestCase):
             print(bytearray(b"hElLO wOrLd").lower())
             print(bytearray(b"[Hello] World").lower())
             """)
+
     def test_count(self):
         self.assertCodeExecution("""
             print(bytearray(b'abcabca').count(97))


### PR DESCRIPTION
- Several minor style fixes in Bytes/ByteArray for Java and Python style
- Disable FileLength check in ant checkstyle config
    - It was erroring on Str.java because it was 2,374 lines, compared to the default max allowed of 2,000 lines. It doesn't seem productive to try and limit our not-organised-in-a-Java-way code that way.

The Java style issues may have snuck past CI due to #640.