### PR TITLE
Fix str.title and str.istitle implementations

### DIFF
--- a/python/common/org/python/types/ByteArray.java
+++ b/python/common/org/python/types/ByteArray.java
@@ -788,8 +788,8 @@ public class ByteArray extends org.python.types.Object {
     @org.python.Method(
             __doc__ = "B.istitle() -> bool\n\nReturn True if B is a titlecased string and there is at least one\ncharacter in B, i.e. uppercase characters may only follow uncased\ncharacters and lowercase characters only cased ones. Return False\notherwise."
     )
-    public org.python.Object istitle(java.util.List<org.python.Object> args, java.util.Map<java.lang.String, org.python.Object> kwargs, java.util.List<org.python.Object> default_args, java.util.Map<java.lang.String, org.python.Object> default_kwargs) {
-        throw new org.python.exceptions.NotImplementedError("bytearray.istitle has not been implemented.");
+    public org.python.Object istitle() {
+        return new Bool(Bytes._istitle(this.value));
     }
 
     @org.python.Method(
@@ -928,8 +928,8 @@ public class ByteArray extends org.python.types.Object {
     @org.python.Method(
             __doc__ = "B.title() -> copy of B\n\nReturn a titlecased version of B, i.e. ASCII words start with uppercase\ncharacters, all remaining cased characters have lowercase."
     )
-    public org.python.Object title(java.util.List<org.python.Object> args, java.util.Map<java.lang.String, org.python.Object> kwargs, java.util.List<org.python.Object> default_args, java.util.Map<java.lang.String, org.python.Object> default_kwargs) {
-        throw new org.python.exceptions.NotImplementedError("bytearray.title has not been implemented.");
+    public org.python.Object title() {
+        return new ByteArray(Bytes._title(this.value));
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Bytes.java
+++ b/python/common/org/python/types/Bytes.java
@@ -1074,23 +1074,27 @@ public class Bytes extends org.python.types.Object {
         return new Bool(_isspace(this.value));
     }
 
-    @org.python.Method(
-            __doc__ = "B.istitle() -> bool\n\nReturn True if B is a titlecased string and there is at least one\ncharacter in B, i.e. uppercase characters may only follow uncased\ncharacters and lowercase characters only cased ones. Return False\notherwise."
-    )
-    public org.python.Object istitle() {
-        if (this.value.length == 0) {
-            return new org.python.types.Bool(false);
+    public static boolean _istitle(byte[] input) {
+        if (input.length == 0) {
+            return false;
         }
 
-        if (Arrays.equals(this.value, _title(this.value))) {
-            for (int idx = 0; idx < this.value.length; ++idx) {
-                if (_isalpha(this.value[idx])) {
-                    return new org.python.types.Bool(true);
+        if (Arrays.equals(input, _title(input))) {
+            for (int idx = 0; idx < input.length; ++idx) {
+                if (_isalpha(input[idx])) {
+                    return true;
                 }
             }
         }
 
-        return new org.python.types.Bool(false);
+        return false;
+    }
+
+    @org.python.Method(
+            __doc__ = "B.istitle() -> bool\n\nReturn True if B is a titlecased string and there is at least one\ncharacter in B, i.e. uppercase characters may only follow uncased\ncharacters and lowercase characters only cased ones. Return False\notherwise."
+    )
+    public org.python.Object istitle() {
+        return new org.python.types.Bool(_istitle(this.value));
     }
 
     public static boolean _isupper(byte[] input) {

--- a/python/common/org/python/types/Bytes.java
+++ b/python/common/org/python/types/Bytes.java
@@ -1082,11 +1082,11 @@ public class Bytes extends org.python.types.Object {
             return new org.python.types.Bool(false);
         }
 
-        boolean matches = Arrays.equals(this.value, _title(this.value));
-
-        for (int idx = 0; idx < this.value.length; ++idx) {
-            if (_isalpha(this.value[idx]) && matches) {
-                return new org.python.types.Bool(true);
+        if (Arrays.equals(this.value, _title(this.value))) {
+            for (int idx = 0; idx < this.value.length; ++idx) {
+                if (_isalpha(this.value[idx])) {
+                    return new org.python.types.Bool(true);
+                }
             }
         }
 

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -972,12 +972,15 @@ public class Str extends org.python.types.Object {
         if (this.value.isEmpty()) {
             return new org.python.types.Bool(false);
         }
-        for (int c = 1; c < this.value.length(); c++) {
-            if (this.value.charAt(c - 1) == ' ' && !(Character.isUpperCase(this.value.charAt(c)))) {
-                return new org.python.types.Bool(false);
+
+        boolean matches = this.value.equals(_title(this.value));
+
+        for (int idx = 0; idx < this.value.length(); idx++) {
+            if (Character.isLetter(this.value.charAt(idx)) && matches) {
+                return new org.python.types.Bool(true);
             }
         }
-        return new org.python.types.Bool(true);
+        return new org.python.types.Bool(false);
     }
 
     @org.python.Method(
@@ -1565,6 +1568,27 @@ public class Str extends org.python.types.Object {
         return new org.python.types.Str(swapcase.toString());
     }
 
+    public static String _title(String input) {
+        if (input.isEmpty()) {
+            return input;
+        }
+
+        java.lang.StringBuffer title = new java.lang.StringBuffer();
+        title.append(Character.toUpperCase(input.charAt(0)));
+        for (int c = 1; c < input.length(); c++) {
+            if (!(Character.isLetter(title.charAt(c - 1)))) {
+                title.append(Character.toUpperCase(input.charAt(c)));
+            } else if (Character.isUpperCase(input.charAt(c))) {
+                title.append(Character.toLowerCase(input.charAt(c)));
+            } else {
+                title.append(input.charAt(c));
+            }
+        }
+
+        return title.toString();
+    }
+
+
     @org.python.Method(
             __doc__ = "S.title() -> str\n" +
                     "\n" +
@@ -1572,21 +1596,7 @@ public class Str extends org.python.types.Object {
                     "characters, all remaining cased characters have lower case.\n"
     )
     public org.python.Object title() {
-        if (this.value.isEmpty()) {
-            return new org.python.types.Str(this.value);
-        }
-        java.lang.StringBuffer title = new java.lang.StringBuffer();
-        title.append(Character.toUpperCase(this.value.charAt(0)));
-        for (int c = 1; c < this.value.length(); c++) {
-            if (title.charAt(c - 1) == ' ') {
-                title.append(Character.toUpperCase(this.value.charAt(c)));
-            } else if (Character.isUpperCase(this.value.charAt(c))) {
-                title.append(Character.toLowerCase(this.value.charAt(c)));
-            } else {
-                title.append(this.value.charAt(c));
-            }
-        }
-        return new org.python.types.Str(title.toString());
+        return new org.python.types.Str(_title(this.value));
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -973,13 +973,14 @@ public class Str extends org.python.types.Object {
             return new org.python.types.Bool(false);
         }
 
-        boolean matches = this.value.equals(_title(this.value));
-
-        for (int idx = 0; idx < this.value.length(); idx++) {
-            if (Character.isLetter(this.value.charAt(idx)) && matches) {
-                return new org.python.types.Bool(true);
+        if (this.value.equals(_title(this.value))) {
+            for (int idx = 0; idx < this.value.length(); idx++) {
+                if (Character.isLetter(this.value.charAt(idx))) {
+                    return new org.python.types.Bool(true);
+                }
             }
         }
+
         return new org.python.types.Bool(false);
     }
 

--- a/tests/datatypes/test_bytearray.py
+++ b/tests/datatypes/test_bytearray.py
@@ -176,6 +176,30 @@ class BytearrayTests(TranspileTestCase):
             print(bytearray(b'pybee').center(True, bytearray(b'a')))
         """)
 
+    def test_title(self):
+        self.assertCodeExecution(r"""
+            print(bytearray(b"").title())
+            print(bytearray(b"abcd").title())
+            print(bytearray(b"NOT").title())
+            print(bytearray(b"coca cola").title())
+            print(bytearray(b"they are from UK, are they not?").title())
+            print(bytearray(b'/@.').title())
+            print(bytearray(b'\x46\x55\x43\x4B').title())
+            print(bytearray(b"py.bee").title())
+        """)
+
+    def test_istitle(self):
+        self.assertCodeExecution(r"""
+            print(bytearray(b"").istitle())
+            print(bytearray(b"abcd").istitle())
+            print(bytearray(b"NOT").istitle())
+            print(bytearray(b"coca cola").istitle())
+            print(bytearray(b"they are from UK, are they not?").istitle())
+            print(bytearray(b'/@.').istitle())
+            print(bytearray(b'\x46\x55\x43\x4B').istitle())
+            print(bytearray(b"py.bee").title())
+        """)
+
 
 class UnaryBytearrayOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'bytearray'

--- a/tests/datatypes/test_bytes.py
+++ b/tests/datatypes/test_bytes.py
@@ -445,6 +445,7 @@ class BytesTests(TranspileTestCase):
             print(b"they are from UK, are they not?".title())
             print(b'/@.'.title())
             print(b'\x46\x55\x43\x4B'.title())
+            print(b"py.bee".title())
         """)
 
     def test_istitle(self):
@@ -456,6 +457,7 @@ class BytesTests(TranspileTestCase):
             print(b"they are from UK, are they not?".istitle())
             print(b'/@.'.istitle())
             print(b'\x46\x55\x43\x4B'.istitle())
+            print(b"py.bee".title())
         """)
 
 

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -55,10 +55,17 @@ class StrTests(TranspileTestCase):
             """)
 
     def test_istitle(self):
-        self.assertCodeExecution("""
-            for s in ['Hello World', 'hello wORLd.', 'Hello world.', '']:
-                print(s.istitle())
-            """)
+        self.assertCodeExecution(r"""
+            print("".istitle())
+            print("abcd".istitle())
+            print("NOT".istitle())
+            print("coca cola".istitle())
+            print("they are from UK, are they not?".istitle())
+            print("/@.".istitle())
+            print("\u00c4".istitle())
+            print("\x41".istitle())
+            print("py.bee".istitle())
+        """)
 
     def test_join(self):
         self.assertCodeExecution("""
@@ -388,9 +395,16 @@ class StrTests(TranspileTestCase):
             """)
 
     def test_title(self):
-        self.assertCodeExecution("""
-            s = ' foo  bar    baz '
-            print(s.title())
+        self.assertCodeExecution(r"""
+            print("".title())
+            print("abcd".title())
+            print("NOT".title())
+            print("coca cola".title())
+            print("they are from UK, are they not?".title())
+            print("/@.".title())
+            print("\u00c4".title())
+            print("\x41".title())
+            print("py.bee".title())
         """)
 
     def test_len(self):


### PR DESCRIPTION
The tests are taken from `tests/datatypes/test_bytes.py`, and some of them were failing. I made small adjustments to the implementation of `str.title()`, while retaining the original logic; though my version of `bytes.title()` (see #680 and #681) takes a different approach.