### PR TITLE
Implement list comprehensions with a single if condition

### DIFF
--- a/tests/structures/test_list_comprehension.py
+++ b/tests/structures/test_list_comprehension.py
@@ -6,11 +6,14 @@ class ListComprehensionTests(TranspileTestCase):
         self.assertCodeExecution("""
             x = [1, 2, 3, 4, 5]
             print([v**2 for v in x])
+
+            print([v for v in x])
             """)
 
+    def test_list_comprehension_with_if_condition(self):
         self.assertCodeExecution("""
             x = [1, 2, 3, 4, 5]
-            print([v for v in x])
+            print([v**2 for v in x if v % 2 == 0])
             """)
 
     def test_method(self):

--- a/voc/python/ast.py
+++ b/voc/python/ast.py
@@ -1243,6 +1243,13 @@ class Visitor(ast.NodeVisitor):
             if isinstance(generator, ast.comprehension):
                 self.visit(generator.target)
 
+        if node.generators[0].ifs:
+            self.visit(node.generators[0].ifs[0])
+
+            self.context.add_opcodes(
+                IF([python.Object.as_boolean()], JavaOpcodes.IFEQ),
+            )
+
         self.visit(node.elt)
 
         # And add it to the result list
@@ -1252,6 +1259,12 @@ class Visitor(ast.NodeVisitor):
                 JavaOpcodes.SWAP(),
                 python.List.append(),
         )
+
+        if node.generators[0].ifs:
+            self.context.add_opcodes(
+                END_IF()
+            )
+
         self.context.add_opcodes(
             END_LOOP(),
         )


### PR DESCRIPTION
Basic list comprehension with a single if condition.

**Next steps:**

- Implement multiple if conditions
- Implement the same for `set`, `dict`, `tuple`, etc.

Partially resolves the issue #683 .

Hat tip: @eliasdorneles 