### PR TITLE
GH-683: Support multiple if conditions in list comprehensions

### DIFF
--- a/tests/structures/test_list_comprehension.py
+++ b/tests/structures/test_list_comprehension.py
@@ -14,6 +14,7 @@ class ListComprehensionTests(TranspileTestCase):
         self.assertCodeExecution("""
             print([v for v in range(100) if v % 2 == 0])
             print([v for v in range(100) if v % 2 == 0 if v % 3 == 0])
+            print([v for v in range(100) if v % 2 == 0 if v % 3 == 0 if v > 10 if v < 80])
             """)
 
     def test_method(self):

--- a/tests/structures/test_list_comprehension.py
+++ b/tests/structures/test_list_comprehension.py
@@ -12,8 +12,8 @@ class ListComprehensionTests(TranspileTestCase):
 
     def test_list_comprehension_with_if_condition(self):
         self.assertCodeExecution("""
-            x = [1, 2, 3, 4, 5]
-            print([v**2 for v in x if v % 2 == 0])
+            print([v for v in range(100) if v % 2 == 0])
+            print([v for v in range(100) if v % 2 == 0 if v % 3 == 0])
             """)
 
     def test_method(self):

--- a/voc/python/ast.py
+++ b/voc/python/ast.py
@@ -1244,7 +1244,9 @@ class Visitor(ast.NodeVisitor):
                 self.visit(generator.target)
 
         if node.generators[0].ifs:
-            self.visit(node.generators[0].ifs[0])
+            self.visit(
+                ast.BoolOp(ast.And(), node.generators[0].ifs)
+            )
 
             self.context.add_opcodes(
                 IF([python.Object.as_boolean()], JavaOpcodes.IFEQ),


### PR DESCRIPTION
Refer to PR #686 which added support for a single if-condition. This PR is an extension of that, bringing support for multiple if-conditions in a list comprehension.

Resolves #683.