### PR TITLE
Handle TypeError fixes backported to Python 3.5.4

### DIFF
--- a/python/common/org/python/types/ByteArray.java
+++ b/python/common/org/python/types/ByteArray.java
@@ -244,7 +244,7 @@ public class ByteArray extends org.python.types.Object {
             System.arraycopy(other_bytes, 0, new_bytes, this.value.length, other_bytes.length);
             return new ByteArray(new_bytes);
         }
-        if (org.Python.VERSION < 0x03060200) {
+        if (org.Python.VERSION < 0x03050400 || (org.Python.VERSION >= 0x03060000 && org.Python.VERSION < 0x03060200)) {
             throw new org.python.exceptions.TypeError("can't concat " + this.typeName() + " to " + other.typeName());
         } else {
             throw new org.python.exceptions.TypeError("can't concat " + other.typeName() + " to " + this.typeName());
@@ -259,7 +259,7 @@ public class ByteArray extends org.python.types.Object {
         try {
             return super.__iadd__(other);
         } catch (org.python.exceptions.TypeError ae) {
-            if (org.Python.VERSION < 0x03060200) {
+            if (org.Python.VERSION < 0x03050400 || (org.Python.VERSION >= 0x03060000 && org.Python.VERSION < 0x03060200)) {
                 throw new org.python.exceptions.TypeError("can't concat " + other.typeName() + " to " + this.typeName());
             } else {
                 throw ae;

--- a/python/common/org/python/types/Bytes.java
+++ b/python/common/org/python/types/Bytes.java
@@ -128,7 +128,7 @@ public class Bytes extends org.python.types.Object {
             System.arraycopy(other_bytes, 0, new_bytes, this.value.length, other_bytes.length);
             return new Bytes(new_bytes);
         }
-        if (org.Python.VERSION < 0x03060200) {
+        if (org.Python.VERSION < 0x03050400 || (org.Python.VERSION >= 0x03060000 && org.Python.VERSION < 0x03060200)) {
             throw new org.python.exceptions.TypeError("can't concat bytes to " + other.typeName());
         } else {
             throw new org.python.exceptions.TypeError("can't concat " + other.typeName() + " to bytes");


### PR DESCRIPTION
See #595 for the original problem.  As the fix done in Python 3.6.2 was
also backported to 3.5.4, extend the version checks made in #607.
See also python/cpython#724.