### PR TITLE
Adjust whitespace character set for strings

### DIFF
--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -953,7 +953,7 @@ public class Str extends org.python.types.Object {
             return new org.python.types.Bool(false);
         }
         for (char ch : this.value.toCharArray()) {
-            if (!Character.isWhitespace(ch)) {
+            if (!isWhitespace(ch)) {
                 return new org.python.types.Bool(false);
             }
         }
@@ -1090,7 +1090,7 @@ public class Str extends org.python.types.Object {
         int start = 0;
         int end = this.value.length();
         if (chars == null || chars instanceof org.python.types.NoneType) {
-            while (start < end && java.lang.Character.isWhitespace(this.value.charAt(start))) {
+            while (start < end && isWhitespace(this.value.charAt(start))) {
                 start++;
             }
         } else if (chars instanceof org.python.types.Str) {
@@ -1357,7 +1357,7 @@ public class Str extends org.python.types.Object {
         int start = 0;
         int end = this.value.length();
         if (chars == null || chars instanceof org.python.types.NoneType) {
-            while (end > start && java.lang.Character.isWhitespace(this.value.charAt(end - 1))) {
+            while (end > start && isWhitespace(this.value.charAt(end - 1))) {
                 end--;
             }
         } else if (chars instanceof org.python.types.Str) {
@@ -1440,6 +1440,26 @@ public class Str extends org.python.types.Object {
             case '\u0085':
             case '\u2028':
             case '\u2029':
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static boolean isWhitespace(char character) {
+        // Compared to Java, Python does not consider U+180E as whitespace,
+        // but it does U+0085, U+00A0, U+2007, and U+202F.
+        if (character == '\u180E') {
+            return false;
+        }
+        if (Character.isWhitespace(character)) {
+            return true;
+        }
+        switch (character) {
+            case '\u0085':
+            case '\u00A0':
+            case '\u2007':
+            case '\u202F':
                 return true;
             default:
                 return false;

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -29,7 +29,8 @@ class StrTests(TranspileTestCase):
 
     def test_isspace(self):
         self.assertCodeExecution(r"""
-            for s in ['\x1f \v \f \n \t \r', ' ', '\t\tnope\t\t', '']:
+            for s in ['\x1f \v \f \n \t \r', ' ', '\x85\xa0', '\u2007', '\u202f',
+            '\u180e', '\t\tnope\t\t', '']:
                 print(s.isspace())
             """)
 
@@ -487,6 +488,13 @@ class StrTests(TranspileTestCase):
             print(str.lstrip('ab'))
             """)
 
+        self.assertCodeExecution(r"""
+            str="\u180eabc"
+            print(str.lstrip())
+            str="\x85abc"
+            print(str.lstrip())
+            """)
+
     def test_rstrip(self):
         self.assertCodeExecution("""
             str = " fooggg\t\t   "
@@ -509,6 +517,13 @@ class StrTests(TranspileTestCase):
             str=""
             print(str.rstrip())
             print(str.rstrip('ab'))
+            """)
+
+        self.assertCodeExecution(r"""
+            str="abc\u180e"
+            print(str.rstrip())
+            str="abc\x85"
+            print(str.rstrip())
             """)
 
     def test_rfind(self):


### PR DESCRIPTION
The set of characters that Java considers whitespace differs from Python.
Create a private isWhitespace that handles the adjustments.