### PR TITLE
transpiler needs to specify source file encoding

### DIFF
--- a/voc/transpiler.py
+++ b/voc/transpiler.py
@@ -14,7 +14,7 @@ def transpile(input, prefix='.', outdir=None, namespace='python', verbosity=0):
             if verbosity:
                 print("Compiling %s ..." % file_or_dir)
 
-            with open(file_or_dir) as source:
+            with open(file_or_dir, encoding='utf-8') as source:
                 ast_module = ast.parse(source.read(), mode='exec')
                 transpiler.transpile(file_or_dir, ast_module, prefix)
         elif os.path.isdir(file_or_dir):
@@ -24,7 +24,7 @@ def transpile(input, prefix='.', outdir=None, namespace='python', verbosity=0):
                         source_file = os.path.join(root, filename)
                         if verbosity:
                             print("Compiling %s ..." % source_file)
-                        with open(source_file) as source:
+                        with open(source_file, encoding='utf-8') as source:
                             ast_module = ast.parse(source.read(), mode='exec')
                             transpiler.transpile(source_file, ast_module, prefix)
         else:


### PR DESCRIPTION
When running 'ant java' on Windows, the shlex module from ouroboros
failed to build.  The module contains UTF-8 characters that need to be
accounted for in the transpiler.