### PR TITLE
Prevent crashing when trying to compile vars(variable)

### DIFF
--- a/docs/background/releases.rst
+++ b/docs/background/releases.rst
@@ -4,23 +4,23 @@ Release History
 0.1.5
 -----
 
-Added support for if conditions in list comprehensions
-Added support for printf-style formatting
-Several fixes for arguments handling and operations with numbers
-Many bugfixes and improvements to docs, tests and error messages
-Added implementations for many builtin functions and type methods
-VOC jar library now ships with the stdlib modules that it already compiles
+* Added support for if conditions in list comprehensions
+* Added support for printf-style formatting
+* Several fixes for arguments handling and operations with numbers
+* Many bugfixes and improvements to docs, tests and error messages
+* Added implementations for many builtin functions and type methods
+* VOC jar library now ships with the stdlib modules that it already compiles
 
 
 0.1.4
 -----
 
-Added support for self-assignment for attributes and subscript
-Added support for multiple comparison
-Improved support for slices
-Many bugfixes and improvements to docs and tests
-Added implementations for many builtin functions and type methods
-VOC is now tested in Python 3.6, and uses BeeKeeper for CI
+* Added support for self-assignment for attributes and subscript
+* Added support for multiple comparison
+* Improved support for slices
+* Many bugfixes and improvements to docs and tests
+* Added implementations for many builtin functions and type methods
+* VOC is now tested in Python 3.6, and uses BeeKeeper for CI
 
 0.1.3
 -----

--- a/docs/how-to/release_process.rst
+++ b/docs/how-to/release_process.rst
@@ -53,7 +53,7 @@ others can benefit from the changes that have been made recently.
     $ twine upload dist/voc-0.1.2*
 
 10. Check that you have AWS credentials in a file named  ``.env`` file in the
-    root directory of your project checkout
+    root directory of your project checkout::
 
     AWS_ACCESS_KEY_ID=...
     AWS_SECRET_ACCESS_KEY=...

--- a/voc/python/ast.py
+++ b/voc/python/ast.py
@@ -1911,9 +1911,9 @@ class Visitor(ast.NodeVisitor):
                 )
             elif node.args:
                 self.context.add_opcodes(
-                    java.New('org/python/exceptions/TypeError'),
-                    JavaOpcodes.LDC_W(node.func.id + "() takes no arguments (" + len(node.args) + " given)"),
-                    java.Init('org/python/exceptions/TypeError', 'Ljava/lang/String;'),
+                    java.New('org/python/exceptions/NotImplementedError'),
+                    JavaOpcodes.LDC_W(node.func.id + "(object) not yet implemented"),
+                    java.Init('org/python/exceptions/NotImplementedError', 'Ljava/lang/String;'),
                     JavaOpcodes.ATHROW()
                 )
             else:


### PR DESCRIPTION
This prevents VOC from crashing when trying to compile something like `vars({})` (this is causing VOC to crash when trying to compile some stdlib modules) and changed the exception to `NotImplementedError` (because `vars(something)` is missing implementation).

I'm also sneaking some minor fixes in the docs (I messed up the syntax the other day, sorry!).

Does this look good?