### PR TITLE
Fixes exception raising (fixes #352)

### DIFF
--- a/python/common/org/python/exceptions/BaseException.java
+++ b/python/common/org/python/exceptions/BaseException.java
@@ -17,8 +17,15 @@ public class BaseException extends org.python.types.Object {
     }
 
     public BaseException(org.python.Object[] args, java.util.Map<java.lang.String, org.python.Object> kwargs) {
-        super(buildTuple(args).toString());
+        super(buildMessage(buildTuple(args)));
         this.args = buildTuple(args);
+    }
+
+    private static String buildMessage(org.python.types.Tuple tupArgs) {
+        if (tupArgs.value.size() == 0) {
+            return "";
+        }
+        return tupArgs.toString();
     }
 
     private static org.python.types.Tuple buildTuple(org.python.Object[] args) {

--- a/python/common/org/python/exceptions/BaseException.java
+++ b/python/common/org/python/exceptions/BaseException.java
@@ -4,18 +4,25 @@ package org.python.exceptions;
         __doc__ = "Common base class for all exceptions"
 )
 public class BaseException extends org.python.types.Object {
+    @org.python.Attribute()
+    org.python.types.Tuple args = new org.python.types.Tuple();
+
     public BaseException() {
         super();
-        // System.out.println("EX: " + this);
     }
 
     public BaseException(String msg) {
         super(msg);
-        // System.out.println("EX: " + this);
+        this.args.value.add(new org.python.types.Str(msg));
     }
 
     public BaseException(org.python.Object[] args, java.util.Map<java.lang.String, org.python.Object> kwargs) {
-        super(args[0].toString());
+        super(buildTuple(args).toString());
+        this.args = buildTuple(args);
+    }
+
+    private static org.python.types.Tuple buildTuple(org.python.Object[] args) {
+        return new org.python.types.Tuple(java.util.Arrays.asList(args));
     }
 
     @org.python.Method(
@@ -29,7 +36,10 @@ public class BaseException extends org.python.types.Object {
             __doc__ = "Return str(self)."
     )
     public org.python.Object __str__() {
-        return new org.python.types.Str(this.getMessage());
+        if (this.args.value.size() == 1) {
+            return this.args.value.get(0).__str__();
+        }
+        return this.args.__str__();
     }
 
     public java.lang.String toString() {

--- a/python/common/org/python/exceptions/Exception.java
+++ b/python/common/org/python/exceptions/Exception.java
@@ -9,6 +9,7 @@ public class Exception extends org.python.exceptions.BaseException {
         super(msg);
     }
 
+    @org.python.Method(__doc__="", varargs="args")
     public Exception(org.python.Object[] args, java.util.Map<java.lang.String, org.python.Object> kwargs) {
         super(args, kwargs);
     }

--- a/python/common/org/python/exceptions/KeyError.java
+++ b/python/common/org/python/exceptions/KeyError.java
@@ -1,8 +1,20 @@
 package org.python.exceptions;
 
 public class KeyError extends org.python.exceptions.LookupError {
+    private String customMessage = null;
     public KeyError(org.python.Object[] args, java.util.Map<java.lang.String, org.python.Object> kwargs) {
         super(convertToReprIfOneArgument(args), kwargs);
+        if (args.length == 1) {
+            customMessage = args[0].__repr__().toString();
+        }
+    }
+
+    @Override
+    public String getMessage() {
+        if (customMessage != null) {
+            return customMessage;
+        }
+        return super.getMessage();
     }
 
     private static org.python.Object[] convertToReprIfOneArgument(org.python.Object[] args) {

--- a/python/common/org/python/exceptions/KeyError.java
+++ b/python/common/org/python/exceptions/KeyError.java
@@ -2,7 +2,14 @@ package org.python.exceptions;
 
 public class KeyError extends org.python.exceptions.LookupError {
     public KeyError(org.python.Object[] args, java.util.Map<java.lang.String, org.python.Object> kwargs) {
-        super(args[0].__repr__().toString());
+        super(convertToReprIfOneArgument(args), kwargs);
+    }
+
+    private static org.python.Object[] convertToReprIfOneArgument(org.python.Object[] args) {
+        if (args.length == 1) {
+            return new org.python.Object[] { args[0].__repr__() };
+        }
+        return args;
     }
 
     public KeyError(org.python.Object key) {

--- a/python/common/org/python/exceptions/StopIteration.java
+++ b/python/common/org/python/exceptions/StopIteration.java
@@ -13,6 +13,6 @@ public class StopIteration extends org.python.exceptions.Exception {
     }
 
     public StopIteration(org.python.Object[] args, java.util.Map<java.lang.String, org.python.Object> kwargs) {
-        this(args[0]);
+        super(args, kwargs);
     }
 }

--- a/tests/structures/test_exception.py
+++ b/tests/structures/test_exception.py
@@ -79,6 +79,19 @@ class ExceptionTests(TranspileTestCase):
             print('Done.')
             """)
 
+    def test_raising_exceptions_multiple_args(self):
+        self.assertCodeExecution("""
+            for exc in [KeyError, ValueError, TypeError]:
+                try:
+                    raise exc("one")
+                except Exception as e:
+                    print(e)
+                try:
+                    raise exc("one", 2)
+                except Exception as e:
+                    print(e)
+        """)
+
     @expectedFailure
     def test_raise_custom_exception_import_from(self):
         self.assertCodeExecution(

--- a/voc/python/ast.py
+++ b/voc/python/ast.py
@@ -614,7 +614,15 @@ class Visitor(ast.NodeVisitor):
                 ALOAD_name(self.current_exc_name[-1]),
             )
         else:
-            self.visit(node.exc)
+            if isinstance(node.exc, ast.Name):
+                # handle "raise ValueError" as if "raise ValueError()"
+                exception = self.full_classref(node.exc.id, default_prefix='org.python.exceptions')
+                self.context.add_opcodes(
+                    java.New(exception),
+                    java.Init(exception)
+                )
+            else:
+                self.visit(node.exc)
 
         self.context.add_opcodes(
             JavaOpcodes.CHECKCAST('java/lang/Throwable'),

--- a/voc/python/ast.py
+++ b/voc/python/ast.py
@@ -614,26 +614,10 @@ class Visitor(ast.NodeVisitor):
                 ALOAD_name(self.current_exc_name[-1]),
             )
         else:
-            if getattr(node.exc, 'func', None) is not None:
-                name = node.exc.func.id
-                args = node.exc.args
-            else:
-                name = node.exc.id
-                args = []
-
-            exception = self.full_classref(name, default_prefix='org.python.exceptions')
-            self.context.add_opcodes(
-                java.New(exception),
-            )
-
-            for arg in args:
-                self.visit(arg)
-
-            self.context.add_opcodes(
-                java.Init(exception, *(['Lorg/python/Object;'] * len(args)))
-            )
+            self.visit(node.exc)
 
         self.context.add_opcodes(
+            JavaOpcodes.CHECKCAST('java/lang/Throwable'),
             JavaOpcodes.ATHROW(),
         )
 


### PR DESCRIPTION
This PR contains some fixes on the behavior for exceptions: notably VOC doesn't crash anymore with `raise some_module.SomeException` (used in a few modules of the standard library).

It also introduces the `.args` attribute (a python tuple, mirroring CPython behavior) that contains the exception arguments and fixes behavior for multiple arguments.

There is some special behavior for KeyError as well (which prints messages differently).

Does this look good?