### PR TITLE
Adding support for deleting targets from lists and tuples

### DIFF
--- a/tests/structures/test_delete.py
+++ b/tests/structures/test_delete.py
@@ -131,3 +131,19 @@ class DeleteTests(TranspileTestCase):
 
             foo()
             """)
+
+    def test_delete_tuple(self):
+        self.assertCodeExecution("""
+            d = {"uno": 1, "due": 2, "tre": 3, "quattro": 4}
+            print("keys before delete: ", sorted(d))
+            del (d["uno"], d["quattro"])
+            print("keys after delete: ", sorted(d))
+            """)
+
+    def test_delete_list(self):
+        self.assertCodeExecution("""
+            d = {"uno": 1, "due": 2, "tre": 3, "quattro": 4}
+            print("keys before delete: ", sorted(d))
+            del [d["uno"], d["quattro"]]
+            print("keys after delete: ", sorted(d))
+            """)

--- a/voc/python/ast.py
+++ b/voc/python/ast.py
@@ -317,6 +317,8 @@ class Visitor(ast.NodeVisitor):
             elif isinstance(target, ast.Name):
                 # delete is performed by visit(target) with context Del
                 pass
+            elif isinstance(target, (ast.Tuple, ast.List)):
+                self.visit_Delete(ast.Delete(target.elts))
             else:
                 raise NotImplementedError('No handler for Delete of type %s' % target)
 


### PR DESCRIPTION
Hello!
I have fixed an issue that I noticed with the deletion of targets from lists and tuples. It would be great if you can have a look.

Thanks!