### PR TITLE
Str.java - test.subscr.bool

### DIFF
--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -329,7 +329,7 @@ public class Str extends org.python.types.Object {
                     if (slice) {
                         if (this.value.length() < 2){
                             throw new org.python.exceptions.IndexError("string index out of range");
-                        } else {  
+                        } else {
                             sliced = this.value.substring(1, 2);
                            }
                     } else {

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -327,9 +327,9 @@ public class Str extends org.python.types.Object {
                     throw new org.python.exceptions.IndexError("string index out of range");
                 } else {
                     if (slice) {
-                        if (this.value.length() < 2)
+                        if (this.value.length() < 2){
                             throw new org.python.exceptions.IndexError("string index out of range");
-                        else
+                    } else  
                             sliced = this.value.substring(1, 2);
                     } else {
                         sliced = this.value.substring(0, 1);

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -329,7 +329,7 @@ public class Str extends org.python.types.Object {
                     if (slice) {
                         if (this.value.length() < 2){
                             throw new org.python.exceptions.IndexError("string index out of range");
-                    } else {  
+                        } else {  
                             sliced = this.value.substring(1, 2);
                            }
                     } else {

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -329,8 +329,9 @@ public class Str extends org.python.types.Object {
                     if (slice) {
                         if (this.value.length() < 2){
                             throw new org.python.exceptions.IndexError("string index out of range");
-                    } else  
+                    } else {  
                             sliced = this.value.substring(1, 2);
+                           }
                     } else {
                         sliced = this.value.substring(0, 1);
                     }

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -331,7 +331,7 @@ public class Str extends org.python.types.Object {
                             throw new org.python.exceptions.IndexError("string index out of range");
                         } else {
                             sliced = this.value.substring(1, 2);
-                           }
+                        }
                     } else {
                         sliced = this.value.substring(0, 1);
                     }

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -327,7 +327,10 @@ public class Str extends org.python.types.Object {
                     throw new org.python.exceptions.IndexError("string index out of range");
                 } else {
                     if (slice) {
-                        sliced = this.value.substring(1, 2);
+                        if (this.value.length() < 2)
+                            throw new org.python.exceptions.IndexError("string index out of range");
+                        else
+                            sliced = this.value.substring(1, 2);
                     } else {
                         sliced = this.value.substring(0, 1);
                     }

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -774,8 +774,6 @@ class BinaryStrOperationTests(BinaryOperationTestCase, TranspileTestCase):
 
     not_implemented = [
         'test_modulo_class',
-
-        'test_subscr_bool',
         'test_subscr_slice',
     ]
 


### PR DESCRIPTION
Implemented fix for placing bool objects as string subscripts.