### PR TITLE
Python inheritance chain

### DIFF
--- a/python/common/org/Python.java
+++ b/python/common/org/Python.java
@@ -22,7 +22,6 @@ public class Python {
         builtins.put("False", org.python.types.Bool.FALSE);
 
         // Primitives, which are both functions and types.
-        builtins.put("bool", org.python.types.Type.pythonType(org.python.types.Bool.class));
         builtins.put("bytearray", org.python.types.Type.pythonType(org.python.types.ByteArray.class));
         builtins.put("bytes", org.python.types.Type.pythonType(org.python.types.Bytes.class));
         builtins.put("complex", org.python.types.Type.pythonType(org.python.types.Complex.class));
@@ -36,101 +35,120 @@ public class Python {
         builtins.put("str", org.python.types.Type.pythonType(org.python.types.Str.class));
         builtins.put("tuple", org.python.types.Type.pythonType(org.python.types.Tuple.class));
 
+        // subclasses of int
+        java.lang.Class base = org.python.types.Int.class;
+        builtins.put("bool", org.python.types.Type.pythonType(org.python.types.Bool.class, base));
+
         // Add all the builtin exceptions
         builtins.put("BaseException", org.python.types.Type.pythonType(org.python.exceptions.BaseException.class));
 
-        builtins.put("SystemExit", org.python.types.Type.pythonType(org.python.exceptions.SystemExit.class));
-        builtins.put("KeyboardInterrupt", org.python.types.Type.pythonType(org.python.exceptions.KeyboardInterrupt.class));
-        builtins.put("GeneratorExit", org.python.types.Type.pythonType(org.python.exceptions.GeneratorExit.class));
-        builtins.put("Exception", org.python.types.Type.pythonType(org.python.exceptions.Exception.class));
+        base = org.python.exceptions.BaseException.class;
+        builtins.put("SystemExit", org.python.types.Type.pythonType(org.python.exceptions.SystemExit.class, base));
+        builtins.put("KeyboardInterrupt", org.python.types.Type.pythonType(org.python.exceptions.KeyboardInterrupt.class, base));
+        builtins.put("GeneratorExit", org.python.types.Type.pythonType(org.python.exceptions.GeneratorExit.class, base));
+        builtins.put("Exception", org.python.types.Type.pythonType(org.python.exceptions.Exception.class, base));
 
         // subclasses of Exception
-        builtins.put("StopIteration", org.python.types.Type.pythonType(org.python.exceptions.StopIteration.class));
-        // New in Python 3.5: builtins.put("StopAsyncIteration", org.python.types.Type.pythonType(org.python.exceptions.StopAsyncIteration.class));
-        builtins.put("ArithmeticError", org.python.types.Type.pythonType(org.python.exceptions.ArithmeticError.class));
-        builtins.put("AssertionError", org.python.types.Type.pythonType(org.python.exceptions.AssertionError.class));
-        builtins.put("AttributeError", org.python.types.Type.pythonType(org.python.exceptions.AttributeError.class));
-        builtins.put("BufferError", org.python.types.Type.pythonType(org.python.exceptions.BufferError.class));
-        builtins.put("EOFError", org.python.types.Type.pythonType(org.python.exceptions.EOFError.class));
-        builtins.put("ImportError", org.python.types.Type.pythonType(org.python.exceptions.ImportError.class));
-        builtins.put("LookupError", org.python.types.Type.pythonType(org.python.exceptions.LookupError.class));
-        builtins.put("MemoryError", org.python.types.Type.pythonType(org.python.exceptions.MemoryError.class));
-        builtins.put("NameError", org.python.types.Type.pythonType(org.python.exceptions.NameError.class));
-        builtins.put("OSError", org.python.types.Type.pythonType(org.python.exceptions.OSError.class));
-        builtins.put("ReferenceError", org.python.types.Type.pythonType(org.python.exceptions.ReferenceError.class));
-        builtins.put("RuntimeError", org.python.types.Type.pythonType(org.python.exceptions.RuntimeError.class));
-        builtins.put("SyntaxError", org.python.types.Type.pythonType(org.python.exceptions.SyntaxError.class));
-        builtins.put("SystemError", org.python.types.Type.pythonType(org.python.exceptions.SystemError.class));
-        builtins.put("TypeError", org.python.types.Type.pythonType(org.python.exceptions.TypeError.class));
-        builtins.put("ValueError", org.python.types.Type.pythonType(org.python.exceptions.ValueError.class));
-        builtins.put("Warning", org.python.types.Type.pythonType(org.python.exceptions.Warning.class));
+        base = org.python.exceptions.Exception.class;
+        builtins.put("StopIteration", org.python.types.Type.pythonType(org.python.exceptions.StopIteration.class, base));
+        // New in Python 3.5: builtins.put("StopAsyncIteration", org.python.types.Type.pythonType(org.python.exceptions.StopAsyncIteration.class, base));
+        builtins.put("ArithmeticError", org.python.types.Type.pythonType(org.python.exceptions.ArithmeticError.class, base));
+        builtins.put("AssertionError", org.python.types.Type.pythonType(org.python.exceptions.AssertionError.class, base));
+        builtins.put("AttributeError", org.python.types.Type.pythonType(org.python.exceptions.AttributeError.class, base));
+        builtins.put("BufferError", org.python.types.Type.pythonType(org.python.exceptions.BufferError.class, base));
+        builtins.put("EOFError", org.python.types.Type.pythonType(org.python.exceptions.EOFError.class, base));
+        builtins.put("ImportError", org.python.types.Type.pythonType(org.python.exceptions.ImportError.class, base));
+        builtins.put("LookupError", org.python.types.Type.pythonType(org.python.exceptions.LookupError.class, base));
+        builtins.put("MemoryError", org.python.types.Type.pythonType(org.python.exceptions.MemoryError.class, base));
+        builtins.put("NameError", org.python.types.Type.pythonType(org.python.exceptions.NameError.class, base));
+        builtins.put("OSError", org.python.types.Type.pythonType(org.python.exceptions.OSError.class, base));
+        builtins.put("ReferenceError", org.python.types.Type.pythonType(org.python.exceptions.ReferenceError.class, base));
+        builtins.put("RuntimeError", org.python.types.Type.pythonType(org.python.exceptions.RuntimeError.class, base));
+        builtins.put("SyntaxError", org.python.types.Type.pythonType(org.python.exceptions.SyntaxError.class, base));
+        builtins.put("SystemError", org.python.types.Type.pythonType(org.python.exceptions.SystemError.class, base));
+        builtins.put("TypeError", org.python.types.Type.pythonType(org.python.exceptions.TypeError.class, base));
+        builtins.put("ValueError", org.python.types.Type.pythonType(org.python.exceptions.ValueError.class, base));
+        builtins.put("Warning", org.python.types.Type.pythonType(org.python.exceptions.Warning.class, base));
 
         // subclasses of ArithmeticError
-        builtins.put("FloatingPointError", org.python.types.Type.pythonType(org.python.exceptions.FloatingPointError.class));
-        builtins.put("OverflowError", org.python.types.Type.pythonType(org.python.exceptions.OverflowError.class));
-        builtins.put("ZeroDivisionError", org.python.types.Type.pythonType(org.python.exceptions.ZeroDivisionError.class));
+        base = org.python.exceptions.ArithmeticError.class;
+        builtins.put("FloatingPointError", org.python.types.Type.pythonType(org.python.exceptions.FloatingPointError.class, base));
+        builtins.put("OverflowError", org.python.types.Type.pythonType(org.python.exceptions.OverflowError.class, base));
+        builtins.put("ZeroDivisionError", org.python.types.Type.pythonType(org.python.exceptions.ZeroDivisionError.class, base));
 
         // subclasses of ImportError
-        // New in 3.6: builtins.put("ModuleNotFoundError", org.python.types.Type.pythonType(org.python.exceptions.ModuleNotFoundError.class));
+        // base = org.python.exceptions.ImportError.class;
+        // New in 3.6: builtins.put("ModuleNotFoundError", org.python.types.Type.pythonType(org.python.exceptions.ModuleNotFoundError.class, base));
 
         // subclasses of LookupError
-        builtins.put("IndexError", org.python.types.Type.pythonType(org.python.exceptions.IndexError.class));
-        builtins.put("KeyError", org.python.types.Type.pythonType(org.python.exceptions.KeyError.class));
+        base = org.python.exceptions.LookupError.class;
+        builtins.put("IndexError", org.python.types.Type.pythonType(org.python.exceptions.IndexError.class, base));
+        builtins.put("KeyError", org.python.types.Type.pythonType(org.python.exceptions.KeyError.class, base));
 
         // subclasses of NameError
-        builtins.put("UnboundLocalError", org.python.types.Type.pythonType(org.python.exceptions.UnboundLocalError.class));
+        base = org.python.exceptions.NameError.class;
+        builtins.put("UnboundLocalError", org.python.types.Type.pythonType(org.python.exceptions.UnboundLocalError.class, base));
 
         // subclasses of OSError
-        builtins.put("BlockingIOError", org.python.types.Type.pythonType(org.python.exceptions.BlockingIOError.class));
-        builtins.put("ChildProcessError", org.python.types.Type.pythonType(org.python.exceptions.ChildProcessError.class));
-        builtins.put("ConnectionError", org.python.types.Type.pythonType(org.python.exceptions.ConnectionError.class));
-        builtins.put("FileExistsError", org.python.types.Type.pythonType(org.python.exceptions.FileExistsError.class));
-        builtins.put("FileNotFoundError", org.python.types.Type.pythonType(org.python.exceptions.FileNotFoundError.class));
-        builtins.put("InterruptedError", org.python.types.Type.pythonType(org.python.exceptions.InterruptedError.class));
-        builtins.put("IsADirectoryError", org.python.types.Type.pythonType(org.python.exceptions.IsADirectoryError.class));
-        builtins.put("NotADirectoryError", org.python.types.Type.pythonType(org.python.exceptions.NotADirectoryError.class));
-        builtins.put("PermissionError", org.python.types.Type.pythonType(org.python.exceptions.PermissionError.class));
-        builtins.put("ProcessLookupError", org.python.types.Type.pythonType(org.python.exceptions.ProcessLookupError.class));
-        builtins.put("TimeoutError", org.python.types.Type.pythonType(org.python.exceptions.TimeoutError.class));
+        base = org.python.exceptions.OSError.class;
+        builtins.put("BlockingIOError", org.python.types.Type.pythonType(org.python.exceptions.BlockingIOError.class, base));
+        builtins.put("ChildProcessError", org.python.types.Type.pythonType(org.python.exceptions.ChildProcessError.class, base));
+        builtins.put("ConnectionError", org.python.types.Type.pythonType(org.python.exceptions.ConnectionError.class, base));
+        builtins.put("FileExistsError", org.python.types.Type.pythonType(org.python.exceptions.FileExistsError.class, base));
+        builtins.put("FileNotFoundError", org.python.types.Type.pythonType(org.python.exceptions.FileNotFoundError.class, base));
+        builtins.put("InterruptedError", org.python.types.Type.pythonType(org.python.exceptions.InterruptedError.class, base));
+        builtins.put("IsADirectoryError", org.python.types.Type.pythonType(org.python.exceptions.IsADirectoryError.class, base));
+        builtins.put("NotADirectoryError", org.python.types.Type.pythonType(org.python.exceptions.NotADirectoryError.class, base));
+        builtins.put("PermissionError", org.python.types.Type.pythonType(org.python.exceptions.PermissionError.class, base));
+        builtins.put("ProcessLookupError", org.python.types.Type.pythonType(org.python.exceptions.ProcessLookupError.class, base));
+        builtins.put("TimeoutError", org.python.types.Type.pythonType(org.python.exceptions.TimeoutError.class, base));
 
-        builtins.put("IOError", org.python.types.Type.pythonType(org.python.exceptions.OSError.class));
-        builtins.put("EnvironmentError", org.python.types.Type.pythonType(org.python.exceptions.OSError.class));
+        base = org.python.exceptions.Exception.class;
+        builtins.put("IOError", org.python.types.Type.pythonType(org.python.exceptions.OSError.class, base));
+        builtins.put("EnvironmentError", org.python.types.Type.pythonType(org.python.exceptions.OSError.class, base));
 
         // subclasses of ConnectionError
-        builtins.put("BrokenPipeError", org.python.types.Type.pythonType(org.python.exceptions.BrokenPipeError.class));
-        builtins.put("ConnectionAbortedError", org.python.types.Type.pythonType(org.python.exceptions.ConnectionAbortedError.class));
-        builtins.put("ConnectionRefusedError", org.python.types.Type.pythonType(org.python.exceptions.ConnectionRefusedError.class));
-        builtins.put("ConnectionResetError", org.python.types.Type.pythonType(org.python.exceptions.ConnectionResetError.class));
+        base = org.python.exceptions.ConnectionError.class;
+        builtins.put("BrokenPipeError", org.python.types.Type.pythonType(org.python.exceptions.BrokenPipeError.class, base));
+        builtins.put("ConnectionAbortedError", org.python.types.Type.pythonType(org.python.exceptions.ConnectionAbortedError.class, base));
+        builtins.put("ConnectionRefusedError", org.python.types.Type.pythonType(org.python.exceptions.ConnectionRefusedError.class, base));
+        builtins.put("ConnectionResetError", org.python.types.Type.pythonType(org.python.exceptions.ConnectionResetError.class, base));
 
         // subclasses of RuntimeError
-        builtins.put("NotImplementedError", org.python.types.Type.pythonType(org.python.exceptions.NotImplementedError.class));
-        // new in Python 3.5: builtins.put("RecursionError", org.python.types.Type.pythonType(org.python.exceptions.RecursionError.class));
+        base = org.python.exceptions.RuntimeError.class;
+        builtins.put("NotImplementedError", org.python.types.Type.pythonType(org.python.exceptions.NotImplementedError.class, base));
+        // new in Python 3.5: builtins.put("RecursionError", org.python.types.Type.pythonType(org.python.exceptions.RecursionError.class, base));
 
         // subclasses of SyntaxError
-        builtins.put("IndentationError", org.python.types.Type.pythonType(org.python.exceptions.IndentationError.class));
+        base = org.python.exceptions.SyntaxError.class;
+        builtins.put("IndentationError", org.python.types.Type.pythonType(org.python.exceptions.IndentationError.class, base));
 
         // subclasses of IndentationError
-        builtins.put("TabError", org.python.types.Type.pythonType(org.python.exceptions.TabError.class));
+        base = org.python.exceptions.IndentationError.class;
+        builtins.put("TabError", org.python.types.Type.pythonType(org.python.exceptions.TabError.class, base));
 
         // subclasses of ValueError
-        builtins.put("UnicodeError", org.python.types.Type.pythonType(org.python.exceptions.UnicodeError.class));
+        base = org.python.exceptions.ValueError.class;
+        builtins.put("UnicodeError", org.python.types.Type.pythonType(org.python.exceptions.UnicodeError.class, base));
 
         // subclasses of UnicodeError
-        builtins.put("UnicodeDecodeError", org.python.types.Type.pythonType(org.python.exceptions.UnicodeDecodeError.class));
-        builtins.put("UnicodeEncodeError", org.python.types.Type.pythonType(org.python.exceptions.UnicodeEncodeError.class));
-        builtins.put("UnicodeTranslateError", org.python.types.Type.pythonType(org.python.exceptions.UnicodeTranslateError.class));
+        base = org.python.exceptions.UnicodeError.class;
+        builtins.put("UnicodeDecodeError", org.python.types.Type.pythonType(org.python.exceptions.UnicodeDecodeError.class, base));
+        builtins.put("UnicodeEncodeError", org.python.types.Type.pythonType(org.python.exceptions.UnicodeEncodeError.class, base));
+        builtins.put("UnicodeTranslateError", org.python.types.Type.pythonType(org.python.exceptions.UnicodeTranslateError.class, base));
 
         // subclasses of Warning
-        builtins.put("DeprecationWarning", org.python.types.Type.pythonType(org.python.exceptions.DeprecationWarning.class));
-        builtins.put("PendingDeprecationWarning", org.python.types.Type.pythonType(org.python.exceptions.PendingDeprecationWarning.class));
-        builtins.put("RuntimeWarning", org.python.types.Type.pythonType(org.python.exceptions.RuntimeWarning.class));
-        builtins.put("SyntaxWarning", org.python.types.Type.pythonType(org.python.exceptions.SyntaxWarning.class));
-        builtins.put("UserWarning", org.python.types.Type.pythonType(org.python.exceptions.UserWarning.class));
-        builtins.put("FutureWarning", org.python.types.Type.pythonType(org.python.exceptions.FutureWarning.class));
-        builtins.put("ImportWarning", org.python.types.Type.pythonType(org.python.exceptions.ImportWarning.class));
-        builtins.put("UnicodeWarning", org.python.types.Type.pythonType(org.python.exceptions.UnicodeWarning.class));
-        builtins.put("BytesWarning", org.python.types.Type.pythonType(org.python.exceptions.BytesWarning.class));
-        builtins.put("ResourceWarning", org.python.types.Type.pythonType(org.python.exceptions.ResourceWarning.class));
+        base = org.python.exceptions.Warning.class;
+        builtins.put("DeprecationWarning", org.python.types.Type.pythonType(org.python.exceptions.DeprecationWarning.class, base));
+        builtins.put("PendingDeprecationWarning", org.python.types.Type.pythonType(org.python.exceptions.PendingDeprecationWarning.class, base));
+        builtins.put("RuntimeWarning", org.python.types.Type.pythonType(org.python.exceptions.RuntimeWarning.class, base));
+        builtins.put("SyntaxWarning", org.python.types.Type.pythonType(org.python.exceptions.SyntaxWarning.class, base));
+        builtins.put("UserWarning", org.python.types.Type.pythonType(org.python.exceptions.UserWarning.class, base));
+        builtins.put("FutureWarning", org.python.types.Type.pythonType(org.python.exceptions.FutureWarning.class, base));
+        builtins.put("ImportWarning", org.python.types.Type.pythonType(org.python.exceptions.ImportWarning.class, base));
+        builtins.put("UnicodeWarning", org.python.types.Type.pythonType(org.python.exceptions.UnicodeWarning.class, base));
+        builtins.put("BytesWarning", org.python.types.Type.pythonType(org.python.exceptions.BytesWarning.class, base));
+        builtins.put("ResourceWarning", org.python.types.Type.pythonType(org.python.exceptions.ResourceWarning.class, base));
 
         org.Python.initializeModule(org.Python.class, builtins);
     }

--- a/python/common/org/python/types/Type.java
+++ b/python/common/org/python/types/Type.java
@@ -61,6 +61,20 @@ public class Type extends org.python.types.Object implements org.python.Callable
         }
     }
 
+    public static org.python.types.Type pythonType(java.lang.Class java_class, java.lang.Class base_java_class) {
+        org.python.types.Type python_type = pythonType(java_class);
+
+        if (base_java_class != null) {
+            org.python.types.Type base_python_type = known_types.get(base_java_class);
+            java.util.List<org.python.Object> bases = new java.util.ArrayList<org.python.Object>();
+            bases.add(base_python_type);
+            python_type.__dict__.put("__base__", base_python_type);
+            python_type.__dict__.put("__bases__", new org.python.types.Tuple(bases));
+        }
+
+        return python_type;
+    }
+
     public static org.python.types.Type declarePythonType(
             org.python.Object name,
             org.python.Object bases,

--- a/python/common/org/python/types/Type.java
+++ b/python/common/org/python/types/Type.java
@@ -28,7 +28,7 @@ public class Type extends org.python.types.Object implements org.python.Callable
 
             // Declare the type, and install it the known types list
             // (Replacing any placeholders)
-            python_type = declarePythonType(java_class);
+            python_type = declarePythonType(java_class, null, null, null);
 
             // Since we have a freshly created type, resolve
             // any placeholders that referenced this type.
@@ -78,20 +78,6 @@ public class Type extends org.python.types.Object implements org.python.Callable
                 ((org.python.types.Tuple) bases).value,
                 to_dict
         );
-    }
-
-    public static org.python.types.Type declarePythonType(
-            java.lang.String name,
-            java.util.List<org.python.Object> bases,
-            java.util.Map<java.lang.String, org.python.Object> dict
-    ) {
-        return org.python.types.Type.declarePythonType(org.python.types.Object.class, name, bases, dict);
-    }
-
-    public static org.python.types.Type declarePythonType(
-            java.lang.Class java_class
-    ) {
-        return org.python.types.Type.declarePythonType(java_class, null, null, null);
     }
 
     public static org.python.types.Type declarePythonType(

--- a/tests/builtins/test_issubclass.py
+++ b/tests/builtins/test_issubclass.py
@@ -88,6 +88,15 @@ class IssubclassTests(TranspileTestCase):
             print(issubclass(MyClass3, MyClass1))
             """, run_in_function=False)
 
+    def test_builtins(self):
+        self.assertCodeExecution("""
+            builtin_classes = (object, bytearray, bytes, complex, dict, int,
+                float, frozenset, list, memoryview, set, str, tuple, bool)
+            for base in builtin_classes:
+                for sub in builtin_classes:
+                    print(sub, base, issubclass(sub, base))
+            """, run_in_function=False)
+
 
 class BuiltinIssubclassFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     functions = ["issubclass"]


### PR DESCRIPTION
In #486, @deep110 notes that bool should extend from int, and @freakboy3742 points out that there needs to be a *python* inheritance chain, which may be distinct from any *java* inheritance chain.  This series of patches sets up the *python* inheritance chain for named builtin types, so that isinstance and issubclass work better with builtin types.  It also makes sure that object is the default base type.