### PR TITLE
Fix bugs in args attribute of exception objects

### DIFF
--- a/python/common/org/python/exceptions/BaseException.java
+++ b/python/common/org/python/exceptions/BaseException.java
@@ -17,15 +17,8 @@ public class BaseException extends org.python.types.Object {
     }
 
     public BaseException(org.python.Object[] args, java.util.Map<java.lang.String, org.python.Object> kwargs) {
-        super(buildMessage(buildTuple(args)));
+        super();
         this.args = buildTuple(args);
-    }
-
-    private static String buildMessage(org.python.types.Tuple tupArgs) {
-        if (tupArgs.value.size() == 0) {
-            return "";
-        }
-        return tupArgs.toString();
     }
 
     private static org.python.types.Tuple buildTuple(org.python.Object[] args) {
@@ -36,14 +29,16 @@ public class BaseException extends org.python.types.Object {
             __doc__ = "Return repr(self)."
     )
     public org.python.Object __repr__() {
-        return new org.python.types.Str(this.getClass().getSimpleName() + "(\"" + this.getMessage() + "\",)");
+        return new org.python.types.Str(this.getClass().getSimpleName() + this.args.toString());
     }
 
     @org.python.Method(
             __doc__ = "Return str(self)."
     )
     public org.python.Object __str__() {
-        if (this.args.value.size() == 1) {
+        if (this.args.value.size() == 0) {
+            return new org.python.types.Str("");
+        } else if (this.args.value.size() == 1) {
             return this.args.value.get(0).__str__();
         }
         return this.args.__str__();
@@ -51,5 +46,9 @@ public class BaseException extends org.python.types.Object {
 
     public java.lang.String toString() {
         return this.getClass().getSimpleName() + ": " + this.getMessage();
+    }
+
+    public java.lang.String getMessage() {
+        return this.__str__().toString();
     }
 }

--- a/python/common/org/python/exceptions/BaseException.java
+++ b/python/common/org/python/exceptions/BaseException.java
@@ -5,7 +5,7 @@ package org.python.exceptions;
 )
 public class BaseException extends org.python.types.Object {
     @org.python.Attribute()
-    org.python.types.Tuple args = new org.python.types.Tuple();
+    public org.python.types.Tuple args = new org.python.types.Tuple();
 
     public BaseException() {
         super();

--- a/python/common/org/python/exceptions/KeyError.java
+++ b/python/common/org/python/exceptions/KeyError.java
@@ -16,6 +16,6 @@ public class KeyError extends org.python.exceptions.LookupError {
     }
 
     public KeyError(org.python.Object key) {
-        super(key.__repr__().toString());
+        super(new org.python.Object[] {key}, null);
     }
 }

--- a/python/common/org/python/exceptions/KeyError.java
+++ b/python/common/org/python/exceptions/KeyError.java
@@ -1,27 +1,18 @@
 package org.python.exceptions;
 
 public class KeyError extends org.python.exceptions.LookupError {
-    private String customMessage = null;
     public KeyError(org.python.Object[] args, java.util.Map<java.lang.String, org.python.Object> kwargs) {
-        super(convertToReprIfOneArgument(args), kwargs);
-        if (args.length == 1) {
-            customMessage = args[0].__repr__().toString();
-        }
+        super(args, kwargs);
     }
 
-    @Override
-    public String getMessage() {
-        if (customMessage != null) {
-            return customMessage;
+    @org.python.Method(
+            __doc__ = "Return str(self)."
+    )
+    public org.python.Object __str__() {
+        if (this.args.value.size() == 1) {
+            return this.args.value.get(0).__repr__();
         }
-        return super.getMessage();
-    }
-
-    private static org.python.Object[] convertToReprIfOneArgument(org.python.Object[] args) {
-        if (args.length == 1) {
-            return new org.python.Object[] { args[0].__repr__() };
-        }
-        return args;
+        return this.args.__str__();
     }
 
     public KeyError(org.python.Object key) {

--- a/tests/structures/test_exception.py
+++ b/tests/structures/test_exception.py
@@ -85,7 +85,7 @@ class ExceptionTests(TranspileTestCase):
                 try:
                     raise exc("one")
                 except Exception as e:
-                    print(e, e.args)
+                    print(e, e.args, str(e), repr(e))
                 try:
                     raise exc("one", 2)
                 except Exception as e:

--- a/tests/structures/test_exception.py
+++ b/tests/structures/test_exception.py
@@ -85,11 +85,11 @@ class ExceptionTests(TranspileTestCase):
                 try:
                     raise exc("one")
                 except Exception as e:
-                    print(e)
+                    print(e, e.args)
                 try:
                     raise exc("one", 2)
                 except Exception as e:
-                    print(e)
+                    print(e, e.args)
         """)
 
     @expectedFailure


### PR DESCRIPTION
- Fix a sneaky bug introduced in #702 
- Fix string representation of `BaseException` and `KeyError` objects. Did some small cleanups.

Hat tip @eliasdorneles !