### PR TITLE
[dict] Bugfix fromkeys (no ticket opened for this)

### DIFF
--- a/python/common/org/python/types/Dict.java
+++ b/python/common/org/python/types/Dict.java
@@ -362,7 +362,7 @@ public class Dict extends org.python.types.Object {
             args = {"iterable"},
             default_args = {"value"}
     )
-    public org.python.Object fromkeys(org.python.Object iterable, org.python.Object value) {
+    public static org.python.Object fromkeys(org.python.Object iterable, org.python.Object value) {
         org.python.types.Dict result = new org.python.types.Dict();
         try {
             org.python.Object iter = iterable.__iter__();

--- a/tests/datatypes/test_dict.py
+++ b/tests/datatypes/test_dict.py
@@ -256,7 +256,7 @@ class DictTests(TranspileTestCase):
     def test_fromkeys(self):
         self.assertCodeExecution("""
             keys = [1, 2]
-            print({}.fromkeys(keys))
+            print(dict.fromkeys(keys))
             """)
 
         # non-iterable error test
@@ -264,7 +264,7 @@ class DictTests(TranspileTestCase):
             keys = 1
             value = 2
             try:
-                print({}.fromkeys(keys, value))
+                print(dict.fromkeys(keys, value))
             except TypeError as err:
                 print(err)
             """)
@@ -282,7 +282,7 @@ class DictTests(TranspileTestCase):
         self.assertCodeExecution("""
             keys = [[1], 2]
             try:
-                print({}.fromkeys(keys))
+                print(dict.fromkeys(keys))
             except TypeError as err:
                 print(err)
             """)
@@ -291,7 +291,7 @@ class DictTests(TranspileTestCase):
     def test_fromkeys_missing_iterable(self):
         self.assertCodeExecution("""
             try:
-                print({}.fromkeys())
+                print(dict.fromkeys())
             except TypeError as err:
                 print(err)
             """)


### PR DESCRIPTION
[dict] Changing access permission of fromkeys method to allow it to be called without having to create a instance of dict (which was a bug). Also changed tests accordingly.
Does this look good enough?