### PR TITLE
Add str.zfill()

### DIFF
--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -1764,8 +1764,47 @@ public class Str extends org.python.types.Object {
     public org.python.Object upper() {
         return new org.python.types.Str(this.value.toUpperCase());
     }
-}
 
+    @org.python.Method(
+            __doc__ = "S.zfill() -> str\n" +
+                    "\n" +
+                    "Return a copy of the string left filled with ASCII '0' \n" +
+                    "digits to make a string of length width.\n",
+            args = {"width"}
+    )
+    public org.python.Object zfill(org.python.Object width) {
+
+
+        if (width instanceof org.python.types.Float) {
+            throw new org.python.exceptions.TypeError("integer argument expected, got float");
+        }
+        else if (!(width instanceof org.python.types.Int)) {
+            throw new org.python.exceptions.TypeError("'" + org.Python.typeName(width.getClass()) +
+                                                      "' object cannot be interpreted as an integer");
+        }
+
+        int w = (int) ((org.python.types.Int) width).value;
+
+        if (this.value.length() >= w) {
+            return new org.python.types.Str(this.value);
+        }
+
+        int fill = w - this.value.length();
+
+        java.lang.StringBuffer str = new java.lang.StringBuffer(w);
+
+        if (this.value.length() != 0 && (this.value.charAt(0) == '-' || this.value.charAt(0) == '+')) {
+            str.append(this.value.charAt(0));
+            this.value = this.value.substring(1);
+        }
+
+        for(int i = 0; i < fill; i++) {
+            str.append('0');
+        }
+
+        return new org.python.types.Str(str.toString() + this.value);
+    }
+}
 
 final class PythonFormatter {
 

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -778,6 +778,40 @@ class StrTests(TranspileTestCase):
         print(s1.splitlines(True))
         """)
 
+    def test_zfill(self):
+        self.assertCodeExecution("""
+            s = '42'
+            print(s.zfill(5))
+
+            try:
+                print(s.zfill('string'))
+            except TypeError as err:
+                print(err)
+
+            try:
+                print(s.zfill({}))
+            except TypeError as err:
+                print(err)
+
+            s = '-42'
+            print(s.zfill(5))
+
+            s = '+42'
+            print(s.zfill(5))
+
+            s = ''
+            print(s.zfill(5))
+
+            s = '-.-42'
+            print(s.zfill(6))
+        """)
+
+    @expectedFailure
+    def test_zfill_arg_handling():
+        self.assertCodeExecution("""
+            s = "42"
+            s.zfill()
+        """)
 
 class UnaryStrOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'str'


### PR DESCRIPTION
Hi, I have added `str.zfill()` to the builtin `str` type but I can't seem to figure out why my tests are failing.


Here is my log:
```
======================================================================
FAIL: test_zfill (tests.datatypes.test_str.StrTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/sanketdg/projects/voc/tests/datatypes/test_str.py", line 785, in test_zfill
    """)
  File "/home/sanketdg/projects/voc/tests/utils.py", line 399, in assertCodeExecution
    self.assertEqual(java_out, py_out, context)
AssertionError: '### EXCEPTION ###\nTypeError: zfill() tak[54 chars]:2\n' != '00042\n===end of test===\n'
+ 00042
+ ===end of test===
- ### EXCEPTION ###
- TypeError: zfill() takes 0 positional arguments but 1 was given
-     test.py:2
 : Global context

----------------------------------------------------------------------
Ran 1 test in 21.531s
```