### PR TITLE
Test mul frozenset float

### DIFF
--- a/python/common/org/python/exceptions/Exception.java
+++ b/python/common/org/python/exceptions/Exception.java
@@ -9,7 +9,7 @@ public class Exception extends org.python.exceptions.BaseException {
         super(msg);
     }
 
-    @org.python.Method(__doc__="", varargs="args")
+    @org.python.Method(__doc__ = "", varargs = "args")
     public Exception(org.python.Object[] args, java.util.Map<java.lang.String, org.python.Object> kwargs) {
         super(args, kwargs);
     }

--- a/python/common/org/python/types/Bytes.java
+++ b/python/common/org/python/types/Bytes.java
@@ -1251,11 +1251,10 @@ public class Bytes extends org.python.types.Object {
             result.value.add(this);
             result.value.add(new Bytes(""));
             result.value.add(new Bytes(""));
-        }
-        else {
+        } else {
             result.value.add(new Bytes(Arrays.copyOfRange(this.value, 0, pos)));
             result.value.add(sep);
-            result.value.add(new Bytes(Arrays.copyOfRange(this.value, pos + ((Bytes)sep).value.length, this.value.length)));
+            result.value.add(new Bytes(Arrays.copyOfRange(this.value, pos + ((Bytes) sep).value.length, this.value.length)));
         }
         return result;
     }

--- a/python/common/org/python/types/Dict.java
+++ b/python/common/org/python/types/Dict.java
@@ -524,7 +524,7 @@ public class Dict extends org.python.types.Object {
 
                     if (pair.size() != 2) {
                         throw new org.python.exceptions.ValueError(
-                        "dictionary update sequence element #" + size + " has length " + pair.size() +"; 2 is required");
+                        "dictionary update sequence element #" + size + " has length " + pair.size() + "; 2 is required");
                     }
                     org.python.Object key = pair.get(0);
                     org.python.Object value = pair.get(1);

--- a/python/common/org/python/types/Float.java
+++ b/python/common/org/python/types/Float.java
@@ -319,6 +319,8 @@ public class Float extends org.python.types.Object {
             throw new org.python.exceptions.TypeError("unsupported operand type(s) for *: 'float' and '" + other.typeName() + "'");
         } else if (other instanceof org.python.types.Set) {
             throw new org.python.exceptions.TypeError("unsupported operand type(s) for *: 'float' and '" + other.typeName() + "'");
+        } else if (other instanceof org.python.types.FrozenSet) {
+            throw new org.python.exceptions.TypeError("unsupported operand type(s) for *: 'float' and '" + other.typeName() + "'");
         } else if (other instanceof org.python.types.List) {
             throw new org.python.exceptions.TypeError("can't multiply sequence by non-int of type 'float'");
         } else if (other instanceof org.python.types.Tuple) {

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -1777,8 +1777,7 @@ public class Str extends org.python.types.Object {
 
         if (width instanceof org.python.types.Float) {
             throw new org.python.exceptions.TypeError("integer argument expected, got float");
-        }
-        else if (!(width instanceof org.python.types.Int)) {
+        } else if (!(width instanceof org.python.types.Int)) {
             throw new org.python.exceptions.TypeError("'" + org.Python.typeName(width.getClass()) +
                                                       "' object cannot be interpreted as an integer");
         }
@@ -1798,7 +1797,7 @@ public class Str extends org.python.types.Object {
             this.value = this.value.substring(1);
         }
 
-        for(int i = 0; i < fill; i++) {
+        for (int i = 0; i < fill; i++) {
             str.append('0');
         }
 

--- a/python/common/python/platform.java
+++ b/python/common/python/platform.java
@@ -26,8 +26,8 @@ public class platform extends org.python.types.Module {
         } else if (vendor.equals("The Android Project")) {
             platform_class_name = "python._platform.AndroidPlatform";
         } else if (vendor.equals("Azul Systems, Inc.")) {
-	    platform_class_name = "python._platform.JavaPlatform";
-	} else {
+            platform_class_name = "python._platform.JavaPlatform";
+        } else {
             throw new org.python.exceptions.RuntimeError("Unknown platform vendor '" + vendor + "'");
         }
 

--- a/tests/datatypes/test_bytes.py
+++ b/tests/datatypes/test_bytes.py
@@ -503,6 +503,7 @@ class BytesTests(TranspileTestCase):
             print(b''.split(maxsplit='5'))
             """, exits_early=True)
 
+
 class UnaryBytesOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'bytes'
 

--- a/tests/datatypes/test_float.py
+++ b/tests/datatypes/test_float.py
@@ -149,7 +149,6 @@ class InplaceFloatOperationTests(InplaceOperationTestCase, TranspileTestCase):
         'test_multiply_bytes',
         'test_multiply_class',
         'test_multiply_complex',
-        'test_multiply_frozenset',
         'test_multiply_list',
         'test_multiply_NotImplemented',
         'test_multiply_range',

--- a/tests/datatypes/test_float.py
+++ b/tests/datatypes/test_float.py
@@ -113,7 +113,6 @@ class BinaryFloatOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_multiply_bytes',
         'test_multiply_class',
         'test_multiply_complex',
-        'test_multiply_frozenset',
         'test_multiply_NotImplemented',
         'test_multiply_range',
 

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -713,9 +713,10 @@ class StrTests(TranspileTestCase):
             except TypeError as err:
                 print(err)
             """)
+
     def test_rsplit(self):
         self.assertCodeExecution(r"""
-           for s in ['This is for rsplit', ' eeed d ded  eded   ', 'átomo', '',' t e s t i n g   r s p l i t ', 'a b c']:
+           for s in ['This is for rsplit',' eeed d ded  eded   ','átomo','',' t e s t i n g   r s p l i t ','a b c']:
                 print(s.rsplit())
                 print(s.rsplit("e"))
                 print(s.rsplit(maxsplit=2))
@@ -807,11 +808,12 @@ class StrTests(TranspileTestCase):
         """)
 
     @expectedFailure
-    def test_zfill_arg_handling():
+    def test_zfill_arg_handling(self):
         self.assertCodeExecution("""
             s = "42"
             s.zfill()
         """)
+
 
 class UnaryStrOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'str'


### PR DESCRIPTION
I am working on #36. I updated ```__mul__``` function in ```python/common/org/python/types/Float.java``` corresponding to ```test_float.java``` for the test ```test_multiply_frozenset```. I wrote an example script with the following code:
```
c = frozenset({1,2,3,4,1,5})
c = 2.435 * c
print(c)
```
Previously running this script using voc was giving error ```NotImplementedError: float.__mul__() has not been implemented.```
Now it gives the error ```TypeError: unsupported operand type(s) for *: 'float' and 'frozenset'``` which is the error given by python 3 interpreter. Also fixed some style errors.