### PR TITLE
Implemented multiply-complex in Float.java

### DIFF
--- a/python/common/org/python/types/Float.java
+++ b/python/common/org/python/types/Float.java
@@ -313,6 +313,8 @@ public class Float extends org.python.types.Object {
             return new org.python.types.Float(((double) this.value) * ((org.python.types.Float) other).value);
         } else if (other instanceof org.python.types.Bool) {
             return new org.python.types.Float(this.value * (((org.python.types.Bool) other).value ? 1 : 0));
+        } else if (other instanceof org.python.types.Complex) {
+            return ((org.python.types.Complex) other).__mul__(this);
         } else if (other instanceof org.python.types.Dict) {
             throw new org.python.exceptions.TypeError("unsupported operand type(s) for *: 'float' and '" + other.typeName() + "'");
         } else if (other instanceof org.python.types.NoneType) {

--- a/tests/datatypes/test_bytearray.py
+++ b/tests/datatypes/test_bytearray.py
@@ -228,6 +228,7 @@ class BytearrayTests(TranspileTestCase):
             print(bytearray(b'').startswith(b''))
         """)
 
+
 class UnaryBytearrayOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'bytearray'
 

--- a/tests/datatypes/test_float.py
+++ b/tests/datatypes/test_float.py
@@ -112,7 +112,6 @@ class BinaryFloatOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_multiply_bytearray',
         'test_multiply_bytes',
         'test_multiply_class',
-        'test_multiply_complex',
         'test_multiply_NotImplemented',
         'test_multiply_range',
 
@@ -148,7 +147,6 @@ class InplaceFloatOperationTests(InplaceOperationTestCase, TranspileTestCase):
         'test_multiply_bytearray',
         'test_multiply_bytes',
         'test_multiply_class',
-        'test_multiply_complex',
         'test_multiply_list',
         'test_multiply_NotImplemented',
         'test_multiply_range',


### PR DESCRIPTION
Working on #36. I updated the ```__mul__``` method of ```Float.java``` to handle multiplication of a float with a complex number corresponding to the test ```test_multiply_complex``` in ```test_float.py```. For the following example script:
```
c = complex(1,2)
print(34.231234 * c)
c = complex(3,0)
print(3.231234 * c)
c = complex(0,3)
print(3.231234 * c)
```
Previously it was giving a ```NotImplementedError``` now it gives proper output similar to python 3 interpreter, that is, 
```
(34.231234+68.462468j)
(9.693702+0j)
9.693702j
```