### PR TITLE
implement hashCode for complex datatype.

### DIFF
--- a/python/common/org/python/types/Complex.java
+++ b/python/common/org/python/types/Complex.java
@@ -23,6 +23,9 @@ public class Complex extends org.python.types.Object {
     }
 
     public int hashCode() {
+        // 0xf4243 is _PyHASH_MULTIPLIER macro defined in Cpython's Include/pyhash.h.
+        // Its just a prime number (happens to be multiplier) used in hashing.
+        // https://computinglife.wordpress.com/2008/11/20/why-do-hash-functions-use-prime-numbers/
         return this.real.hashCode() + 0xf4243 * this.imag.hashCode();
     }
 
@@ -163,7 +166,11 @@ public class Complex extends org.python.types.Object {
     )
     public org.python.Object __repr__() {
         if (this.real.value != 0.0 || this.real.isNegativeZero()) {
-            return new org.python.types.Str("(" + partToStr(this.real) + ((this.imag.value >= 0.0 && !this.imag.isNegativeZero()) ? "+" : "-") + partToStr(new org.python.types.Float(Math.abs(this.imag.value))) + "j)");
+            java.lang.String tempstr = new String("-");
+            if (this.imag.value >= 0.0 && !this.imag.isNegativeZero()){
+                tempstr = "+";
+            }
+            return new org.python.types.Str("(" + partToStr(this.real) + tempstr + partToStr(new org.python.types.Float(Math.abs(this.imag.value))) + "j)");
         } else {
             return new org.python.types.Str(partToStr(this.imag) + "j");
         }

--- a/python/common/org/python/types/Complex.java
+++ b/python/common/org/python/types/Complex.java
@@ -23,7 +23,7 @@ public class Complex extends org.python.types.Object {
     }
 
     public int hashCode() {
-        return this.hashCode();
+        return this.real.hashCode() + 0xf4243 * this.imag.hashCode();
     }
 
     public Complex(org.python.types.Float real_val, org.python.types.Float imag_val) {
@@ -162,31 +162,11 @@ public class Complex extends org.python.types.Object {
             __doc__ = "Return repr(self)."
     )
     public org.python.Object __repr__() {
-        java.lang.StringBuilder buffer = new java.lang.StringBuilder();
-        boolean real_present = true;
-        if (this.real.value != 0) {
-            buffer.append("(");
-            if (((org.python.types.Bool) ((this.real).__int__().__eq__(this.real))).value) {
-                buffer.append(((org.python.types.Str) this.real.__int__().__repr__()).value);
-            } else {
-                buffer.append(((org.python.types.Str) this.real.__repr__()).value);
-            }
+        if (this.real.value != 0.0 || this.real.isNegativeZero()) {
+            return new org.python.types.Str("(" + partToStr(this.real) + ((this.imag.value >= 0.0 && !this.imag.isNegativeZero()) ? "+" : "-") + partToStr(new org.python.types.Float(Math.abs(this.imag.value))) + "j)");
         } else {
-            real_present = false;
+            return new org.python.types.Str(partToStr(this.imag) + "j");
         }
-        if (this.real.value != 0 && this.imag.value >= 0) {
-            buffer.append("+");
-        }
-        if (((org.python.types.Bool) ((this.imag).__int__().__eq__(this.imag))).value) {
-            buffer.append(((org.python.types.Str) (this.imag).__int__().__repr__()).value);
-        } else {
-            buffer.append(((org.python.types.Str) (this.imag).__repr__()).value);
-        }
-        buffer.append("j");
-        if (real_present) {
-            buffer.append(")");
-        }
-        return new org.python.types.Str(buffer.toString());
     }
 
     @org.python.Method(
@@ -307,11 +287,7 @@ public class Complex extends org.python.types.Object {
             __doc__ = "Return str(self)."
     )
     public org.python.Object __str__() {
-        if (this.real.value != 0.0 || this.real.isNegativeZero()) {
-            return new org.python.types.Str("(" + partToStr(this.real) + ((this.imag.value >= 0.0 && !this.imag.isNegativeZero()) ? "+" : "-") + partToStr(new org.python.types.Float(Math.abs(this.imag.value))) + "j)");
-        } else {
-            return new org.python.types.Str(partToStr(this.imag) + "j");
-        }
+        return __repr__();
     }
 
     @org.python.Method(

--- a/tests/builtins/test_repr.py
+++ b/tests/builtins/test_repr.py
@@ -10,5 +10,4 @@ class BuiltinReprFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
 
     not_implemented = [
         'test_class',
-        'test_complex',
     ]

--- a/tests/builtins/test_set.py
+++ b/tests/builtins/test_set.py
@@ -11,9 +11,9 @@ class BuiltinSetFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     not_implemented = [
         'test_bytes',
         'test_str',
-        'test_tuple',
     ]
 
     is_flakey = [
         'test_dict',
+        'test_tuple'
     ]

--- a/tests/builtins/test_slice.py
+++ b/tests/builtins/test_slice.py
@@ -26,5 +26,4 @@ class BuiltinSliceFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
 
     not_implemented = [
         'test_class',
-        'test_complex',
     ]

--- a/tests/datatypes/test_dict.py
+++ b/tests/datatypes/test_dict.py
@@ -359,7 +359,6 @@ class BinaryDictOperationTests(BinaryOperationTestCase, TranspileTestCase):
 
         'test_subscr_bytearray',
         'test_subscr_class',
-        'test_subscr_complex',
         'test_subscr_slice',
     ]
 


### PR DESCRIPTION
1. Complex number hashing is taken from cpython's [hashing function](https://github.com/python/cpython/blob/master/Objects/complexobject.c#L408).

2. I made __repr__ and __str__ methods same for complex numbers, I am not exactly sure if it is the right thing but from here cypthon ```complexobject.c``` module both seem to have same underlining function.
Link to cpython's corressponding functions:
[```__repr__```](https://github.com/python/cpython/blob/master/Objects/complexobject.c#L1126) and [```__str__```](https://github.com/python/cpython/blob/master/Objects/complexobject.c#L1132).

Thank you.
