### PR TITLE
implement bytearray isalnum() and isdigit() with tests Refs #36

### DIFF
--- a/python/common/org/python/types/ByteArray.java
+++ b/python/common/org/python/types/ByteArray.java
@@ -761,8 +761,16 @@ public class ByteArray extends org.python.types.Object {
     @org.python.Method(
             __doc__ = "B.isalnum() -> bool\n\nReturn True if all characters in B are alphanumeric\nand there is at least one character in B, False otherwise."
     )
-    public org.python.Object isalnum(java.util.List<org.python.Object> args, java.util.Map<java.lang.String, org.python.Object> kwargs, java.util.List<org.python.Object> default_args, java.util.Map<java.lang.String, org.python.Object> default_kwargs) {
-        throw new org.python.exceptions.NotImplementedError("bytearray.isalnum has not been implemented.");
+    public org.python.Object isalnum() {
+        if (this.value.length == 0) {
+            return new org.python.types.Bool(false);
+        }
+        for (byte ch: this.value) {
+            if (!Bytes._isalpha(ch) && !Bytes._isnum(ch)) {
+                return new org.python.types.Bool(false);
+            }
+        }
+        return new org.python.types.Bool(true);
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/ByteArray.java
+++ b/python/common/org/python/types/ByteArray.java
@@ -762,15 +762,7 @@ public class ByteArray extends org.python.types.Object {
             __doc__ = "B.isalnum() -> bool\n\nReturn True if all characters in B are alphanumeric\nand there is at least one character in B, False otherwise."
     )
     public org.python.Object isalnum() {
-        if (this.value.length == 0) {
-            return new org.python.types.Bool(false);
-        }
-        for (byte ch: this.value) {
-            if (!Bytes._isalpha(ch) && !Bytes._isnum(ch)) {
-                return new org.python.types.Bool(false);
-            }
-        }
-        return new org.python.types.Bool(true);
+        return (new Bytes(this.value)).isalnum();
     }
 
     @org.python.Method(
@@ -784,15 +776,7 @@ public class ByteArray extends org.python.types.Object {
             __doc__ = "B.isdigit() -> bool\n\nReturn True if all characters in B are digits\nand there is at least one character in B, False otherwise."
     )
     public org.python.Object isdigit() {
-        if (this.value.length == 0) {
-            return new org.python.types.Bool(false);
-        }
-        for (byte ch: this.value) {
-            if (!Bytes._isnum(ch)) {
-                return new org.python.types.Bool(false);
-            }
-        }
-        return new org.python.types.Bool(true);
+        return (new Bytes(this.value)).isdigit();
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/ByteArray.java
+++ b/python/common/org/python/types/ByteArray.java
@@ -783,8 +783,16 @@ public class ByteArray extends org.python.types.Object {
     @org.python.Method(
             __doc__ = "B.isdigit() -> bool\n\nReturn True if all characters in B are digits\nand there is at least one character in B, False otherwise."
     )
-    public org.python.Object isdigit(java.util.List<org.python.Object> args, java.util.Map<java.lang.String, org.python.Object> kwargs, java.util.List<org.python.Object> default_args, java.util.Map<java.lang.String, org.python.Object> default_kwargs) {
-        throw new org.python.exceptions.NotImplementedError("bytearray.isdigit has not been implemented.");
+    public org.python.Object isdigit() {
+        if (this.value.length == 0) {
+            return new org.python.types.Bool(false);
+        }
+        for (byte ch: this.value) {
+            if (!Bytes._isnum(ch)) {
+                return new org.python.types.Bool(false);
+            }
+        }
+        return new org.python.types.Bool(true);
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Bytes.java
+++ b/python/common/org/python/types/Bytes.java
@@ -1086,6 +1086,10 @@ public class Bytes extends org.python.types.Object {
         return new Bool(_isalpha(this.value));
     }
 
+    public static boolean _isnum(byte ch) {
+        return (ch >= '0' && ch <= '9');
+    }
+
     @org.python.Method(
             __doc__ = "B.isdigit() -> bool\n\nReturn True if all characters in B are digits\nand there is at least one character in B, False otherwise."
     )

--- a/tests/datatypes/test_bytearray.py
+++ b/tests/datatypes/test_bytearray.py
@@ -228,6 +228,33 @@ class BytearrayTests(TranspileTestCase):
             print(bytearray(b'').startswith(b''))
         """)
 
+    def test_isalnum(self):
+        self.assertCodeExecution("""
+            print(bytearray(b'0').isalnum())
+            print(bytearray(b'9').isalnum())
+            print(bytearray(b'1234567890').isalnum())
+            print(bytearray(b'89A23gM23z').isalnum())
+            print(bytearray(b':923').isalnum())
+            print(bytearray(b'\\923').isalnum())
+            print(bytearray(b' jdf fhd 33').isalnum())
+            print(bytearray(b'@#$%^&*').isalnum())
+            print(bytearray(b'"478\t47ads:').isalnum())
+            print(bytearray(b'AbZ').isalnum())
+        """)
+
+    def test_isdigit(self):
+        self.assertCodeExecution("""
+            print(bytearray(b'0').isdigit())
+            print(bytearray(b'9').isdigit())
+            print(bytearray(b'1234567890').isdigit())
+            print(bytearray(b'8923g23823').isdigit())
+            print(bytearray(b'923').isdigit())
+            print(bytearray(b'\\923').isdigit())
+            print(bytearray(b'000').isdigit())
+            print(bytearray(b'@#$%^&*').isdigit())
+            print(bytearray(b'"478\t47ads:').isdigit())
+            print(bytearray(b'AbZ').isdigit())
+        """)
 
 class UnaryBytearrayOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'bytearray'


### PR DESCRIPTION
A helper method Bytes._isnum() is created to keep code cleaner and exploit existing Bytes._isalpha(). Both are then used in ByteArray.isalnum()