### PR TITLE
Implement join() in Bytes and ByteArray

### DIFF
--- a/python/common/org/python/types/ByteArray.java
+++ b/python/common/org/python/types/ByteArray.java
@@ -808,10 +808,13 @@ public class ByteArray extends org.python.types.Object {
     }
 
     @org.python.Method(
-            __doc__ = "B.join(iterable_of_bytes) -> bytearray\n\nConcatenate any number of bytes/bytearray objects, with B\nin between each pair, and return the result as a new bytearray."
+            __doc__ = "B.join(iterable_of_bytes) -> bytearray\n\nConcatenate any number of bytes/bytearray objects, with B\nin between each pair, and return the result as a new bytearray.",
+            args = {"iterable"}
     )
-    public org.python.Object join(java.util.List<org.python.Object> args, java.util.Map<java.lang.String, org.python.Object> kwargs, java.util.List<org.python.Object> default_args, java.util.Map<java.lang.String, org.python.Object> default_kwargs) {
-        throw new org.python.exceptions.NotImplementedError("bytearray.join has not been implemented.");
+    public org.python.Object join(org.python.Object iterable) {
+        org.python.types.Bytes temp = new org.python.types.Bytes(this.value);
+        org.python.types.Bytes res = (org.python.types.Bytes) temp.join(iterable);
+        return new ByteArray(res.value);
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Bytes.java
+++ b/python/common/org/python/types/Bytes.java
@@ -1221,7 +1221,7 @@ public class Bytes extends org.python.types.Object {
                 item = new Bytes(((org.python.types.ByteArray) item).value);
 
             } else {
-                throw new org.python.exceptions.TypeError("sequence item "+i+": expected bytes-like object, "+item.typeName()+" found");
+                throw new org.python.exceptions.TypeError("sequence item " + i + ": expected bytes-like object, " + item.typeName() + " found");
             }
             if (i == 0) {
                 joinedBytes = (org.python.types.Bytes) item;

--- a/python/common/org/python/types/Bytes.java
+++ b/python/common/org/python/types/Bytes.java
@@ -1191,7 +1191,8 @@ public class Bytes extends org.python.types.Object {
     }
 
     @org.python.Method(
-            __doc__ = "B.join(iterable_of_bytes) -> bytes\n\nConcatenate any number of bytes objects, with B in between each pair.\nExample: b'.'.join([b'ab', b'pq', b'rs']) -> b'ab.pq.rs'."
+            __doc__ = "B.join(iterable_of_bytes) -> bytes\n\nConcatenate any number of bytes objects, with B in between each pair.\nExample: b'.'.join([b'ab', b'pq', b'rs']) -> b'ab.pq.rs'.",
+            args = {"iterable"}
     )
     public org.python.Object join(org.python.Object iterable) {
         // Check if other is an iterable
@@ -1217,8 +1218,11 @@ public class Bytes extends org.python.types.Object {
             if (item instanceof org.python.types.Bytes) {
                 item = (org.python.types.Bytes) item;
             } else if (item instanceof org.python.types.ByteArray) {
-                item = (org.python.types.ByteArray) item;
-            } else throw new org.python.exceptions.TypeError("sequence item "+i+": expected bytes-like object, "+item.typeName()+" found");
+                item = new Bytes(((org.python.types.ByteArray) item).value);
+
+            } else {
+                throw new org.python.exceptions.TypeError("sequence item "+i+": expected bytes-like object, "+item.typeName()+" found");
+            }
             if (i == 0) {
                 joinedBytes = (org.python.types.Bytes) item;
             } else {

--- a/python/common/org/python/types/Bytes.java
+++ b/python/common/org/python/types/Bytes.java
@@ -1193,8 +1193,40 @@ public class Bytes extends org.python.types.Object {
     @org.python.Method(
             __doc__ = "B.join(iterable_of_bytes) -> bytes\n\nConcatenate any number of bytes objects, with B in between each pair.\nExample: b'.'.join([b'ab', b'pq', b'rs']) -> b'ab.pq.rs'."
     )
-    public org.python.Object join(java.util.List<org.python.Object> args, java.util.Map<java.lang.String, org.python.Object> kwargs, java.util.List<org.python.Object> default_args, java.util.Map<java.lang.String, org.python.Object> default_kwargs) {
-        throw new org.python.exceptions.NotImplementedError("bytes.join has not been implemented.");
+    public org.python.Object join(org.python.Object iterable) {
+        // Check if other is an iterable
+        java.util.List<org.python.Object> temp_list = new java.util.ArrayList<org.python.Object>();
+        org.python.Object iter = null;
+        try {
+            iter = org.Python.iter(iterable);
+        } catch (org.python.exceptions.TypeError e) {
+            throw new org.python.exceptions.TypeError("can only join an iterable");
+        }
+        // Save elements in a known list for iterating later
+        try {
+            while (true) {
+                org.python.Object item = iter.__next__();
+                temp_list.add(item);
+            }
+        } catch (org.python.exceptions.StopIteration e) {
+        }
+        // perform join
+        org.python.Object joinedBytes = null;
+        int i = 0;
+        for (org.python.Object item : temp_list) {
+            if (item instanceof org.python.types.Bytes) {
+                item = (org.python.types.Bytes) item;
+            } else if (item instanceof org.python.types.ByteArray) {
+                item = (org.python.types.ByteArray) item;
+            } else throw new org.python.exceptions.TypeError("sequence item "+i+": expected bytes-like object, "+item.typeName()+" found");
+            if (i == 0) {
+                joinedBytes = (org.python.types.Bytes) item;
+            } else {
+                joinedBytes = joinedBytes.__add__(__add__(item));
+            }
+            i++;
+        }
+        return joinedBytes;
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Bytes.java
+++ b/python/common/org/python/types/Bytes.java
@@ -1196,39 +1196,34 @@ public class Bytes extends org.python.types.Object {
     )
     public org.python.Object join(org.python.Object iterable) {
         // Check if other is an iterable
-        java.util.List<org.python.Object> temp_list = new java.util.ArrayList<org.python.Object>();
         org.python.Object iter = null;
         try {
             iter = org.Python.iter(iterable);
         } catch (org.python.exceptions.TypeError e) {
             throw new org.python.exceptions.TypeError("can only join an iterable");
         }
-        // Save elements in a known list for iterating later
+        // iterate and perform join
+        org.python.Object joinedBytes = null;
+        int i = 0;
         try {
             while (true) {
                 org.python.Object item = iter.__next__();
-                temp_list.add(item);
+                if (item instanceof org.python.types.Bytes) {
+                    item = (org.python.types.Bytes) item;
+                } else if (item instanceof org.python.types.ByteArray) {
+                    item = new Bytes(((org.python.types.ByteArray) item).value);
+
+                } else {
+                    throw new org.python.exceptions.TypeError("sequence item " + i + ": expected bytes-like object, " + item.typeName() + " found");
+                }
+                if (i == 0) {
+                    joinedBytes = (org.python.types.Bytes) item;
+                } else {
+                    joinedBytes = joinedBytes.__add__(__add__(item));
+                }
+                i++;
             }
         } catch (org.python.exceptions.StopIteration e) {
-        }
-        // perform join
-        org.python.Object joinedBytes = null;
-        int i = 0;
-        for (org.python.Object item : temp_list) {
-            if (item instanceof org.python.types.Bytes) {
-                item = (org.python.types.Bytes) item;
-            } else if (item instanceof org.python.types.ByteArray) {
-                item = new Bytes(((org.python.types.ByteArray) item).value);
-
-            } else {
-                throw new org.python.exceptions.TypeError("sequence item " + i + ": expected bytes-like object, " + item.typeName() + " found");
-            }
-            if (i == 0) {
-                joinedBytes = (org.python.types.Bytes) item;
-            } else {
-                joinedBytes = joinedBytes.__add__(__add__(item));
-            }
-            i++;
         }
         return joinedBytes;
     }

--- a/tests/datatypes/test_bytearray.py
+++ b/tests/datatypes/test_bytearray.py
@@ -256,6 +256,21 @@ class BytearrayTests(TranspileTestCase):
             print(bytearray(b'AbZ').isdigit())
         """)
 
+    def test_join(self):
+        self.assertCodeExecution("""
+            b = bytearray(b'.')
+            print(b.join([b'12', b'dh']))
+            print(b.join([bytearray(b'12'), bytearray(b'dh')]))
+            b = bytearray(b' ')
+            print(b.join([b'd', bytearray(b'l22-'), b'=ej*']))
+            print(b.join([bytearray(b'31'), b'`', b'^']))
+            print(b.join([bytearray(b'dh')]))
+            b = bytearray(b'%#@!')
+            print(b.join([b'1',b'd',b'<']))
+            print(b.join([b'12']))
+        """)
+
+
 class UnaryBytearrayOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'bytearray'
 

--- a/tests/datatypes/test_bytes.py
+++ b/tests/datatypes/test_bytes.py
@@ -277,7 +277,7 @@ class BytesTests(TranspileTestCase):
 
     def test_isalnum(self):
         self.assertCodeExecution("""
-            print(b'w1thnumb3r2'.isalnum('jk'))
+            print(b'w1thnumb3r2'.isalnum())
             print(b'withoutnumber'.isalnum())
             print(b'with spaces'.isalnum())
             print(b'666'.isalnum())

--- a/tests/datatypes/test_bytes.py
+++ b/tests/datatypes/test_bytes.py
@@ -277,7 +277,7 @@ class BytesTests(TranspileTestCase):
 
     def test_isalnum(self):
         self.assertCodeExecution("""
-            print(b'w1thnumb3r2'.isalnum())
+            print(b'w1thnumb3r2'.isalnum('jk'))
             print(b'withoutnumber'.isalnum())
             print(b'with spaces'.isalnum())
             print(b'666'.isalnum())
@@ -502,6 +502,20 @@ class BytesTests(TranspileTestCase):
         self.assertCodeExecution("""
             print(b''.split(maxsplit='5'))
             """, exits_early=True)
+
+    def test_join(self):
+        self.assertCodeExecution("""
+            b = bytes(b'.')
+            print(b.join([b'12', b'dh']))
+            print(b.join([bytearray(b'12'), bytearray(b'dh')]))
+            b = bytes(b' ')
+            print(b.join([b'd', bytearray(b'l22-'), b'=ej*']))
+            print(b.join([bytearray(b'31'), b'`', b'^']))
+            print(b.join([bytearray(b'dh')]))
+            b = bytes(b'%#@!')
+            print(b.join([b'1',b'd',b'<']))
+            print(b.join([b'12']))
+        """)
 
 
 class UnaryBytesOperationTests(UnaryOperationTestCase, TranspileTestCase):


### PR DESCRIPTION
join method is implemented for Bytes. The same is called in ByteArray.join() but the result here is casted to ByteArray as per python3 behaviour. Refs #38 