### PR TITLE
Implemented rjust method in Bytes with suitable test cases.

### DIFF
--- a/python/common/org/python/types/Bytes.java
+++ b/python/common/org/python/types/Bytes.java
@@ -1369,10 +1369,63 @@ public class Bytes extends org.python.types.Object {
     }
 
     @org.python.Method(
-            __doc__ = "B.rjust(width[, fillchar]) -> copy of B\n\nReturn B right justified in a string of length width. Padding is\ndone using the specified fill character (default is a space)"
+            __doc__ = "B.rjust(width[, fillchar]) -> copy of B\n\nReturn B right justified in a string of length width. Padding is\ndone using the specified fill character (default is a space).",
+            args = {"width"},
+            default_args = {"fillingChar"}
     )
-    public org.python.Object rjust(java.util.List<org.python.Object> args, java.util.Map<java.lang.String, org.python.Object> kwargs, java.util.List<org.python.Object> default_args, java.util.Map<java.lang.String, org.python.Object> default_kwargs) {
-        throw new org.python.exceptions.NotImplementedError("bytes.rjust has not been implemented.");
+    public org.python.Object rjust(org.python.Object width, org.python.Object fillingChar) {
+        return new org.python.types.Bytes(_rjust(this.value, width, fillingChar));
+    }
+
+    public static byte[] _rjust(byte[] input, org.python.Object width, org.python.Object fillingChar) {
+        byte[] fillChar;
+        if (fillingChar instanceof org.python.types.Bytes || fillingChar instanceof org.python.types.ByteArray) {
+            if (fillingChar instanceof org.python.types.ByteArray) {
+                fillChar = ((org.python.types.ByteArray) fillingChar).value;
+            } else {
+                fillChar = ((org.python.types.Bytes) fillingChar).value;
+            }
+            if (fillChar.length != 1) {
+                if (org.Python.VERSION < 0x030502F0) {
+                    throw new org.python.exceptions.TypeError("must be a byte string of length 1, not bytes");
+                } else {
+                    throw new org.python.exceptions.TypeError("rjust() argument 2 must be a byte string of length 1, not bytes");
+                }
+            }
+        } else if (fillingChar == null) {
+            fillChar = " ".getBytes();
+        } else {
+            if (org.Python.VERSION < 0x030502F0) {
+                throw new org.python.exceptions.TypeError("must be a byte string of length 1, not " + fillingChar.typeName());
+            } else {
+                throw new org.python.exceptions.TypeError("rjust() argument 2 must be a byte string of length 1, not " + fillingChar.typeName());
+            }
+        }
+
+        if (width instanceof org.python.types.Int) {
+            int iwidth = (int) ((org.python.types.Int) width).value;
+            if (input.length >= iwidth) {
+                return input;
+            } else {
+                int diff = iwidth - input.length;
+
+                byte[] returnBytes;
+                returnBytes = new byte[iwidth];
+
+                for (int i = 0; i < diff; i++) {
+                    returnBytes[i] = fillChar[0];
+                }
+                for (int i = diff; i < iwidth; i++) {
+                    returnBytes[i] = input[i - diff];
+                }
+                return returnBytes;
+            }
+        } else if (width instanceof org.python.types.Bool) {
+            return input;
+        } else {
+            throw new org.python.exceptions.TypeError("'" + width.typeName() +
+                "'" + " object cannot be interpreted as an integer");
+        }
     }
 
     @org.python.Method(

--- a/tests/datatypes/test_bytes.py
+++ b/tests/datatypes/test_bytes.py
@@ -375,6 +375,32 @@ class BytesTests(TranspileTestCase):
                 print(str(e))
         """)
 
+    def test_rjust(self):
+        self.assertCodeExecution("""
+            print(b'testMoreThanWidth'.rjust(5))
+            print(b'testEqualWidth'.rjust(14))
+            print(b'testLessThanWidth'.rjust(20))
+            print(b'testMoreWithFill'.rjust(2, b'x'))
+            print(b'testEqualWithFill'.rjust(17, b'x'))
+            print(b'testLessWithFill'.rjust(25, b'x'))
+            print(b'testNegative'.rjust(-20))
+            print(b''.rjust(5))
+            print(b'testNoChangeWidthOne'.rjust(True, b'x'))
+            print(b'testBArraySecondArg'.rjust(True, bytearray(b'x')))
+            try:
+                print(b'testStrArgError'.rjust('5'))
+            except Exception as e:
+                print(str(e))
+            try:
+                print(b'testMoreLengthError'.rjust(12, b'as'))
+            except Exception as e:
+                print(str(e))
+            try:
+                print(b'testStrFillingChar'.rjust(12, 'a'))
+            except Exception as e:
+                print(str(e))
+        """)
+
     def test_lower(self):
         self.assertCodeExecution("""
             print(b"abc".lower())


### PR DESCRIPTION
The method *rjust* inside the Bytes.java file from python/common/org/python/types has been implemented with suitable test cases inside tests/datatypes/test_bytes.py
This method aligns the bytes in right justified manner iff width is more than the length of the byte [] provided, which also accepts custom filling character if specified, defaulted to " ".