### PR TITLE
Fixes issue #627

### DIFF
--- a/voc/transpiler.py
+++ b/voc/transpiler.py
@@ -47,7 +47,7 @@ class Transpiler:
             basedir = []
 
         for namespace, class_name, javaclassfile in self.classfiles:
-            dirname = os.path.join(*(basedir + namespace.split('.')))
+            dirname = os.path.join(*(basedir))
             classfilename = os.path.join(dirname, '%s.class' % class_name)
 
             try:


### PR DESCRIPTION
Actually, problem was  that the output class file was created in  destination address within a python 
sub-folder.
It was due to the initial value of namespace  i.e  python . Which further joins the python sub-folder in 
`dirname` address  . 

