### PR TITLE
Implemented expandtabs method in Bytes with suitable test cases.

### DIFF
--- a/python/common/org/python/types/Bytes.java
+++ b/python/common/org/python/types/Bytes.java
@@ -971,10 +971,44 @@ public class Bytes extends org.python.types.Object {
     }
 
     @org.python.Method(
-            __doc__ = "B.expandtabs(tabsize=8) -> copy of B\n\nReturn a copy of B where all tab characters are expanded using spaces.\nIf tabsize is not given, a tab size of 8 characters is assumed."
+            __doc__ = "B.expandtabs(tabsize=8) -> copy of B\n\nReturn a copy of B where all tab characters are expanded using spaces.\nIf tabsize is not given, a tab size of 8 characters is assumed.",
+            args = {},
+            default_args = {"tabsize"}
     )
-    public org.python.Object expandtabs(java.util.List<org.python.Object> args, java.util.Map<java.lang.String, org.python.Object> kwargs, java.util.List<org.python.Object> default_args, java.util.Map<java.lang.String, org.python.Object> default_kwargs) {
-        throw new org.python.exceptions.NotImplementedError("bytes.expandtabs has not been implemented.");
+    public org.python.Object expandtabs(org.python.Object tabsize) {
+        return new org.python.types.Bytes(_expandtabs(this.value, tabsize));
+    }
+
+    public static byte[] _expandtabs(byte[] input, org.python.Object tabsize) {
+        int itabsize;
+        byte[] space;
+        space = " ".getBytes();
+        if (tabsize == null) {
+            itabsize = 8;
+        } else if (tabsize instanceof org.python.types.Int) {
+            itabsize = (int) ((org.python.types.Int) tabsize).value;
+        } else {
+            throw new org.python.exceptions.TypeError("an integer is required (got type " + tabsize.typeName() + ")");
+        }
+        byte[] returnBytes;
+        returnBytes = new byte[input.length * 2];
+        int times = 0;
+        int pos = 0;
+        for (int i = 0; i < input.length; i++) {
+            if (input[i] == '\t') {
+                times = itabsize - pos % itabsize;
+                while (times-- > 0) {
+                    returnBytes[pos] = space[0];
+                    pos++;
+                }
+                continue;
+            } else {
+                returnBytes[pos] = input[i];
+                pos++;
+            }
+        }
+        return Arrays.copyOfRange(returnBytes, 0, pos);
+
     }
 
     @org.python.Method(

--- a/tests/datatypes/test_bytes.py
+++ b/tests/datatypes/test_bytes.py
@@ -401,6 +401,30 @@ class BytesTests(TranspileTestCase):
                 print(str(e))
         """)
 
+    def test_expandtabs(self):
+        self.assertCodeExecution("""
+            print(b'testNoTabs'.expandtabs())
+            print(b'test\t'.expandtabs())
+            print(b'testDoubleTab\t\t'.expandtabs())
+            print(b'testTab\tandText'.expandtabs())
+            print(b'testTab\t'.expandtabs(4))
+            print(b'testTab\t\t'.expandtabs(4))
+            print(b'test\t\t'.expandtabs(-4))
+            print(b''.expandtabs(5))
+            try:
+                print(b'testErrorChar\t'.expandtabs('a'))
+            except Exception as e:
+                print(str(e))
+            try:
+                print(b'testErrorChars\t'.expandtabs('as'))
+            except Exception as e:
+                print(str(e))
+            try:
+                print(b'testErrorCharNum\t'.expandtabs('1'))
+            except Exception as e:
+                print(str(e))
+        """)
+
     def test_lower(self):
         self.assertCodeExecution("""
             print(b"abc".lower())


### PR DESCRIPTION
The method expandtabs inside the Bytes.java file from python/common/org/python/types has been implemented with suitable test cases inside tests/datatypes/test_bytes.py
This method expands the tabs according to the tabsize(default=8) with spaces.
It is to be noted that this method does not replace the tabs with space as many times the tab character ('\t') is encountered but replaces with position parameter for spaces with the input length.
eg
 b'test\t'.expandtabs() will **not be** b'test&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' but instead will be b'test&nbsp;&nbsp;&nbsp;'

All test cases run properly, and further details can be noted through the test_bytes.py file. 