### PR TITLE
Fix error messages for NotImplemented operations

### DIFF
--- a/python/common/org/python/types/NotImplementedType.java
+++ b/python/common/org/python/types/NotImplementedType.java
@@ -117,12 +117,12 @@ public class NotImplementedType extends org.python.types.Object {
             return this.__mul__(other);
         } catch (org.python.exceptions.TypeError e) {
             if (other instanceof org.python.types.Str || other instanceof org.python.types.List || other instanceof org.python.types.Tuple || other instanceof org.python.types.Bytes || other instanceof org.python.types.ByteArray) {
-              throw new org.python.exceptions.TypeError("can't multiply sequence by non-int of type 'NotImplementedType'");
+                throw new org.python.exceptions.TypeError("can't multiply sequence by non-int of type 'NotImplementedType'");
             } else {
-              throw new org.python.exceptions.TypeError(
-                String.format("unsupported operand type(s) for *=: 'NotImplementedType' and '%s'",
-                      other.typeName())
-              );
+                throw new org.python.exceptions.TypeError(
+                        String.format("unsupported operand type(s) for *=: 'NotImplementedType' and '%s'",
+                                other.typeName())
+                );
             }
         }
     }

--- a/python/common/org/python/types/NotImplementedType.java
+++ b/python/common/org/python/types/NotImplementedType.java
@@ -98,13 +98,32 @@ public class NotImplementedType extends org.python.types.Object {
             args = {"other"}
     )
     public org.python.Object __mul__(org.python.Object other) {
-        if (other instanceof org.python.types.Str || other instanceof org.python.types.List || other instanceof org.python.types.Tuple) {
+        if (other instanceof org.python.types.Str || other instanceof org.python.types.List || other instanceof org.python.types.Tuple || other instanceof org.python.types.Bytes || other instanceof org.python.types.ByteArray) {
             throw new org.python.exceptions.TypeError("can't multiply sequence by non-int of type 'NotImplementedType'");
         } else {
             throw new org.python.exceptions.TypeError(
                     String.format("unsupported operand type(s) for *: 'NotImplementedType' and '%s'",
                             other.typeName())
             );
+        }
+    }
+
+    @org.python.Method(
+            __doc__ = "",
+            args = {"other"}
+    )
+    public org.python.Object __imul__(org.python.Object other) {
+        try {
+            return this.__mul__(other);
+        } catch (org.python.exceptions.TypeError e) {
+            if (other instanceof org.python.types.Str || other instanceof org.python.types.List || other instanceof org.python.types.Tuple || other instanceof org.python.types.Bytes || other instanceof org.python.types.ByteArray) {
+              throw new org.python.exceptions.TypeError("can't multiply sequence by non-int of type 'NotImplementedType'");
+            } else {
+              throw new org.python.exceptions.TypeError(
+                String.format("unsupported operand type(s) for *=: 'NotImplementedType' and '%s'",
+                      other.typeName())
+              );
+            }
         }
     }
 

--- a/tests/datatypes/test_NotImplemented.py
+++ b/tests/datatypes/test_NotImplemented.py
@@ -16,55 +16,6 @@ class UnaryNotImplementedOperationTests(UnaryOperationTestCase, TranspileTestCas
 class BinaryNotImplementedOperationTests(BinaryOperationTestCase, TranspileTestCase):
     data_type = 'NotImplemented'
 
-    not_implemented = [
-        'test_multiply_bytes',
-        'test_multiply_bytearray',
-    ]
-
 
 class InplaceNotImplementedOperationTests(InplaceOperationTestCase, TranspileTestCase):
     data_type = 'NotImplemented'
-
-    not_implemented = [
-        'test_eq_bytearray',
-        'test_eq_class',
-        'test_eq_complex',
-        'test_eq_frozenset',
-
-        'test_ge_bytearray',
-        'test_ge_class',
-        'test_ge_complex',
-        'test_ge_frozenset',
-
-        'test_gt_bytearray',
-        'test_gt_class',
-        'test_gt_complex',
-        'test_gt_frozenset',
-
-        'test_le_bytearray',
-        'test_le_class',
-        'test_le_complex',
-        'test_le_frozenset',
-
-        'test_lt_bytearray',
-        'test_lt_class',
-        'test_lt_complex',
-        'test_lt_frozenset',
-
-        'test_multiply_bytes',
-        'test_multiply_bytearray',
-        'test_multiply_list',
-        'test_multiply_str',
-        'test_multiply_tuple',
-
-        'test_ne_bytearray',
-        'test_ne_class',
-        'test_ne_complex',
-        'test_ne_frozenset',
-
-        'test_subscr_bytearray',
-        'test_subscr_bytes',
-        'test_subscr_class',
-        'test_subscr_complex',
-        'test_subscr_frozenset',
-    ]


### PR DESCRIPTION
- Add special error messages for Bytes/ByteArray/Str/Tuple/List types
- Remove comparison test cases that aren't failures