### PR TITLE
Update java install instructions.

### DIFF
--- a/docs/background/install.rst
+++ b/docs/background/install.rst
@@ -25,7 +25,7 @@ To check if you have the JDK installed, run ``javac -version``
     $ javac -version
     javac 1.7.0_101
 
-If you do not have a Java 7 or Java 8 JDK `install Java <http://www.oracle.com/technetwork/java/javase/downloads/index.html>`_ in one of those versions and check again.
+If you do not have at least Java 7 `install Java <http://www.oracle.com/technetwork/java/javase/downloads/index.html>`_ and check again.
 
 To check if Apache ANT is installed, run ``ant -version``
 

--- a/docs/background/install.rst
+++ b/docs/background/install.rst
@@ -25,7 +25,7 @@ To check if you have the JDK installed, run ``javac -version``
     $ javac -version
     javac 1.7.0_101
 
-If you do not have at least Java 7 `install Java <http://www.oracle.com/technetwork/java/javase/downloads/index.html>`_ and check again.
+If you do not have a Java 7 or Java 8 JDK `install Java <http://www.oracle.com/technetwork/java/javase/downloads/index.html>`_ in one of those versions and check again.
 
 To check if Apache ANT is installed, run ``ant -version``
 

--- a/docs/how-to/contribute.rst
+++ b/docs/how-to/contribute.rst
@@ -22,7 +22,7 @@ instead of using the official PyBee repository, you'll be using your own
 Github fork.
 
 As with the getting started guide, these instructions will assume that you
-have Python 3.4+, a Java 7 or Java 8 JDK, and Apache ANT installed.
+have Python 3.4+, a Java >=7 JDK, and Apache ANT installed.
 
 **Note:** If you are on Linux, you will need to install an extra package to be able to run the test suite.
  * **Ubuntu** 12.04 and 14.04: ``libpython3.4-testsuite`` This can be done by running ``apt-get install libpython3.4-testsuite``.


### PR DESCRIPTION
The documentation at https://voc.readthedocs.io/en/latest/how-to/contribute.html states that you need `a Java 7 or Java 8 JDK` but the install instructions states `at least 7` which can lead people to install Java 10 JDK.