### PR TITLE
Add project urls to the setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,5 +46,11 @@ setup(
         'Topic :: Software Development',
         'Topic :: Utilities',
     ],
-    test_suite='tests'
+    test_suite='tests',
+    package_urls={
+        'Funding': 'https://pybee.org/contributing/membership/',
+        'Documentation': 'https://voc.readthedocs.io/en/latest/',
+        'Tracker': 'https://github.com/pybee/voc/issues',
+        'Source': 'https://github.com/pybee/voc',
+    },
 )


### PR DESCRIPTION
setup.py now defines a spec for project urls, which results in a more
informative pypi page and helps downstream consumers of project information.