### PR TITLE
Stop using locale information in ctime

### DIFF
--- a/python/common/python/time.java
+++ b/python/common/python/time.java
@@ -107,7 +107,7 @@ public class time extends org.python.types.Module {
             }
             date = new java.util.Date(((org.python.types.Int) seconds.__int__()).value * 1000L);
         }
-        java.text.SimpleDateFormat ft = new java.text.SimpleDateFormat("E MMM dd HH:mm:ss yyyy");
+        java.text.SimpleDateFormat ft = new java.text.SimpleDateFormat("E MMM dd HH:mm:ss yyyy", java.util.Locale.ENGLISH);
         String padded_date = ft.format(date);
         if (Character.toString(padded_date.charAt(8)).equals("0")) {
             java.lang.StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
Python ctime does not use locale information (https://docs.python.org/3/library/time.html#time.ctime). This patch reproduces the same behavior on the Java implementation.

Test prior to change:
```
[gw3] linux -- Python 3.5.2 /home/debonzi/devel/personal/BeeWare/venv/bin/python3
self = <tests.stdlib.test_time.TimeModuleTests testMethod=test_ctime>

    def test_ctime(self):
        self.assertCodeExecution("""
                import time
                print(time.ctime()[:10], time.ctime()[-4:])
>               """)

tests/stdlib/test_time.py:113: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/utils.py:399: in assertCodeExecution
    self.assertEqual(java_out, py_out, context)
E   AssertionError: 'seg mai 14 2018\n===end of test===\n' != 'Mon May 14 2018\n===end of test===\n'
E   - seg mai 14 2018
E   + Mon May 14 2018
E     ===end of test===
E    : Global context
```

Test after change:
```
test_ctime (tests.stdlib.test_time.TimeModuleTests) ... ok
----------------------------------------------------------------------
Ran 1 test in 3.511s
OK
```

It also fixes some other tests.