### PR TITLE
Add zfill no argument handling printing the proper exception message.

### DIFF
--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -1788,12 +1788,12 @@ public class Str extends org.python.types.Object {
                     "\n" +
                     "Return a copy of the string left filled with ASCII '0' \n" +
                     "digits to make a string of length width.\n",
-            args = {"width"}
+            default_args = {"width"}
     )
     public org.python.Object zfill(org.python.Object width) {
-
-
-        if (width instanceof org.python.types.Float) {
+        if (width == null) {
+            throw new org.python.exceptions.TypeError("zfill() takes exactly 1 argument (0 given)");
+        } else if (width instanceof org.python.types.Float) {
             throw new org.python.exceptions.TypeError("integer argument expected, got float");
         } else if (!(width instanceof org.python.types.Int)) {
             throw new org.python.exceptions.TypeError("'" + org.Python.typeName(width.getClass()) +

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -814,7 +814,7 @@ class StrTests(TranspileTestCase):
         for test in tests:
             print(test.isprintable())
         """)
-    
+
     @expectedFailure
     def test_isprintable_surrogate_cases(self):
         self.assertCodeExecution(r"""
@@ -871,13 +871,12 @@ class StrTests(TranspileTestCase):
 
             s = '-.-42'
             print(s.zfill(6))
-        """)
 
-    @expectedFailure
-    def test_zfill_arg_handling(self):
-        self.assertCodeExecution("""
             s = "42"
-            s.zfill()
+            try:
+                s.zfill()
+            except TypeError as err:
+                print(err)
         """)
 
 


### PR DESCRIPTION
Implements missing code to expectedFailure test `zfill_arg_handling`