### PR TITLE
Add tests for two-arg version of round.

### DIFF
--- a/tests/builtins/test_round.py
+++ b/tests/builtins/test_round.py
@@ -1,4 +1,4 @@
-from .. utils import TranspileTestCase, BuiltinFunctionTestCase
+from .. utils import TranspileTestCase, BuiltinFunctionTestCase, BuiltinTwoargFunctionTestCase
 
 
 class RoundTests(TranspileTestCase):
@@ -20,3 +20,56 @@ class BuiltinRoundFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
         'test_set',
         'test_slice',
     ]
+
+
+class BuiltinRoundTwoargFunctionTests(BuiltinTwoargFunctionTestCase, TranspileTestCase):
+    functions = ["round"]
+    python_types = [
+        'None',
+        'NotImplemented',
+        'bool',
+        'bytearray',
+        'bytes',
+        'class',
+        'complex',
+        'dict',
+        'float',
+        'frozenset',
+        'int',
+        'list',
+        'range',
+        'set',
+        'slice',
+        'str',
+        'tuple',
+    ]
+
+    not_implemented_types = [
+        'test_bytearray',
+        'test_bytes',
+        'test_class',
+        'test_complex',
+        'test_dict',
+        'test_float',
+        'test_frozenset',
+        'test_NotImplemented',
+        'test_range',
+        'test_set',
+        'test_slice',
+    ]
+
+    not_implemented = [
+        'test_bool_bool',
+        'test_bool_int',
+        'test_int_bool',
+        'test_int_int',
+    ]
+
+    not_implemented_versions = {
+        'test_bool_None': (3.5, 3.6),
+        'test_int_None': (3.5, 3.6),
+    }
+
+    for not_implemented_type in not_implemented_types:
+        for python_type in python_types:
+            not_implemented.append('_'.join([not_implemented_type, python_type]))


### PR DESCRIPTION
`round` has both a single arg and a two-arg version. The two-arg version is not being tested yet, this adds those tests.

Makes this issue show up in tests
https://github.com/pybee/voc/issues/554