### PR TITLE
Improvements to stdlib compiling and report scripts

### DIFF
--- a/tools/compile_stdlib.py
+++ b/tools/compile_stdlib.py
@@ -211,9 +211,7 @@ def update_repo():
 
 
 def write_file(path, content):
-    dir_path = os.path.dirname(path)
-    if not os.path.isdir(dir_path):
-        os.mkdir(dir_path)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
     with open(path, 'w') as f:
         f.write(content)
 


### PR DESCRIPTION
This fixes directory creation (it was failing when `build/java/python` directory didn't exist yet) and improves the output for the cases of test failures (previous output was just concatenating stderr and stdout files).

Looks good?