### PR TITLE
Added support for Yield from statement

### DIFF
--- a/tests/structures/test_generator.py
+++ b/tests/structures/test_generator.py
@@ -72,24 +72,48 @@ class GeneratorTests(TranspileTestCase):
                 print(i)
             """)
     
-    def test_yield_from_not_used(self):
-        """Yield from is currently not implemented.
-        Unused yield from statements must not break 
-        the program compilation, but only ensue a warning."""
+    def test_simplest_yieldfrom(self):
         self.assertCodeExecution("""
-            
-            def unused():
-                yield from range(5)
+            def gen1():
+                yield 1
+                yield 2
+                yield 3
+                
+            def gen2():
+                yield from gen1()
+                
+            for i in gen2():
+                print(i)
+        """)
 
-            print('Hello, world!')
-            """)
-    
-    @expectedFailure
-    def test_yield_from_used(self):
-        """Yield from is currently not implemented.
-        Yield from statements become NotImplementedErrors at runtime."""
+    def test_yieldfrom_list(self):
         self.assertCodeExecution("""
-            
+            def gen():
+                yield from [1, 2, 3]
+                
+            for i in gen():
+                print(i)
+        """)
+
+    def test_chainning_yieldfrom(self):
+        self.assertCodeExecution("""
+            def gen1():
+                yield 'a'
+                yield 'b'
+                
+            def gen2():
+                yield from gen1()
+                yield 'gen2'
+                
+            def gen3():
+                yield from gen2()
+                
+            for i in gen3():
+                print(i)
+        """)
+    
+    def test_yield_from_used(self):
+        self.assertCodeExecution("""
             def using_yieldfrom():
                 yield from range(5)
             

--- a/tests/structures/test_generator.py
+++ b/tests/structures/test_generator.py
@@ -95,7 +95,7 @@ class GeneratorTests(TranspileTestCase):
                 print(i)
         """)
 
-    def test_chainning_yieldfrom(self):
+    def test_chaining_yieldfrom(self):
         self.assertCodeExecution("""
             def gen1():
                 yield 'a'
@@ -111,12 +111,3 @@ class GeneratorTests(TranspileTestCase):
             for i in gen3():
                 print(i)
         """)
-    
-    def test_yield_from_used(self):
-        self.assertCodeExecution("""
-            def using_yieldfrom():
-                yield from range(5)
-            
-            for i in using_yieldfrom():
-                print(i)
-            """)

--- a/voc/python/ast.py
+++ b/voc/python/ast.py
@@ -1712,7 +1712,7 @@ class Visitor(ast.NodeVisitor):
 
     @node_visitor
     def visit_Yield(self, node):
-        if node.value:
+        if hasattr(node, "lineno"):
             self.visit(node.value)
         yield_point = len(self.context.yield_points) + 1
         self.context.add_opcodes(

--- a/voc/python/ast.py
+++ b/voc/python/ast.py
@@ -1713,6 +1713,10 @@ class Visitor(ast.NodeVisitor):
     @node_visitor
     def visit_Yield(self, node):
         if hasattr(node, "lineno"):
+            # Check for programmatically defined yield node.
+            # A programmatically defined yield node does not has the attribute `lineno`
+            # Example: visit_YieldFrom function defined ast.Yield(None) after pushing value
+            # obtained from iterator onto stack, hence no need to visit node.value here
             self.visit(node.value)
         yield_point = len(self.context.yield_points) + 1
         self.context.add_opcodes(

--- a/voc/python/ast.py
+++ b/voc/python/ast.py
@@ -1757,22 +1757,14 @@ class Visitor(ast.NodeVisitor):
         loop = START_LOOP()
         self.context.add_opcodes(
             loop,
-        )
-        self.context.add_opcodes(
             TRY(),
         )
         self.context.load_name('#yield-iter-%x' % id(node))
         self.context.add_opcodes(
             python.Iterable.next(),
-        )
-        self.context.add_opcodes(
             CATCH('org/python/exceptions/StopIteration'),
-        )
-        self.context.add_opcodes(
             JavaOpcodes.POP(),
             jump(JavaOpcodes.GOTO(0), self.context, loop, OpcodePosition.NEXT),
-        )
-        self.context.add_opcodes(
             END_TRY(),
         )
         self.visit(ast.Yield(None))


### PR DESCRIPTION
This commit only added support for `yield from x` or `yield from foo()` by itself (see samples in test),
the assignment statement x = yield from foo() is currently not supported as generator.send() is currently WIP