### PR TITLE
Added generator send method

### DIFF
--- a/python/common/org/python/types/Generator.java
+++ b/python/common/org/python/types/Generator.java
@@ -39,8 +39,8 @@ public class Generator extends org.python.types.Object {
     }
 
     @org.python.Method(
-        __doc__ = "Implement send(message=None).",
-        args = {"message"}
+            __doc__ = "Implement send(message=None).",
+            args = {"message"}
     )
     public org.python.Object send(org.python.Object message) {
         if (just_started && !(message instanceof org.python.types.NoneType)) {

--- a/python/common/org/python/types/Generator.java
+++ b/python/common/org/python/types/Generator.java
@@ -6,6 +6,9 @@ public class Generator extends org.python.types.Object {
     public int yield_point;
     public java.util.Map<java.lang.String, org.python.Object> stack;
 
+    private boolean just_started = true;
+    public org.python.Object message;
+
     public int hashCode() {
         return this.expression.hashCode();
     }
@@ -23,6 +26,7 @@ public class Generator extends org.python.types.Object {
         this.expression = expression;
         this.yield_point = 0;
         this.stack = stack;
+        this.message = new org.python.types.NoneType();
     }
 
     public void yield(java.util.Map<java.lang.String, org.python.Object> stack, int yield_point) {
@@ -32,6 +36,22 @@ public class Generator extends org.python.types.Object {
         // }
         this.yield_point = yield_point;
         this.stack = stack;
+    }
+
+    @org.python.Method(
+        __doc__ = "Implement send(message=None).",
+        args = {"message"}
+    )
+    public org.python.Object send(org.python.Object message) {
+        if (just_started && !(message instanceof org.python.types.NoneType)) {
+            throw new org.python.exceptions.TypeError("can't send non-None value to a just-started generator");
+        }
+        this.message = message;
+        return this.__next__();
+    }
+
+    public void reset_message() {
+        this.message = org.python.types.NoneType.NONE;
     }
 
     @org.python.Method(
@@ -54,6 +74,7 @@ public class Generator extends org.python.types.Object {
     )
     public org.python.Object __next__() {
         try {
+            just_started = false;
             return (org.python.Object) this.expression.invoke(null, new java.lang.Object[]{this});
         } catch (java.lang.IllegalAccessException e) {
             throw new org.python.exceptions.RuntimeError("Illegal access to Java method " + this.expression);

--- a/tests/structures/test_generator.py
+++ b/tests/structures/test_generator.py
@@ -96,3 +96,64 @@ class GeneratorTests(TranspileTestCase):
             for i in using_yieldfrom():
                 print(i)
             """)
+            
+    def test_generator_send(self):
+        self.assertCodeExecution("""
+            def gen():
+                a = yield
+                print(a)
+                
+            g = gen()
+            next(g)
+            try:
+                g.send("Hello World")
+            except StopIteration:
+                pass
+            """)
+            
+    def test_generator_multi_send(self):
+        self.assertCodeExecution("""
+            def gen():
+                a = yield 1
+                print(a)
+                b = yield 2
+                print(b)
+                
+            g = gen()
+            next(g)
+            try:
+                print(g.send("a"))
+                print(g.send("b"))
+            except StopIteration:
+                pass
+            """)
+            
+    def test_generator_power_generator(self):
+        self.assertCodeExecution("""
+            def gen():
+                while True:
+                    x = yield 1
+                    yield x ** 2
+                
+            g = gen()
+            next(g)
+            print(g.send(6))
+            next(g)
+            print(g.send(-1))
+            """)
+            
+    def test_generator_send_loop(self):
+        self.assertCodeExecution("""
+            def gen():
+                for i in range(1, 5):
+                    a = yield i
+                    print("printing from generator " + str(a))
+            g = gen()
+            g.send(None)
+            try:
+                while True:
+                    b = g.send(1)
+                    print("printing from user " + str(b))
+            except StopIteration: 
+                pass
+            """)

--- a/tests/structures/test_generator.py
+++ b/tests/structures/test_generator.py
@@ -71,38 +71,38 @@ class GeneratorTests(TranspileTestCase):
             for i in myinterview.fizz_buzz():
                 print(i)
             """)
-    
+
     def test_yield_from_not_used(self):
         """Yield from is currently not implemented.
-        Unused yield from statements must not break 
+        Unused yield from statements must not break
         the program compilation, but only ensue a warning."""
         self.assertCodeExecution("""
-            
+
             def unused():
                 yield from range(5)
 
             print('Hello, world!')
             """)
-    
+
     @expectedFailure
     def test_yield_from_used(self):
         """Yield from is currently not implemented.
         Yield from statements become NotImplementedErrors at runtime."""
         self.assertCodeExecution("""
-            
+
             def using_yieldfrom():
                 yield from range(5)
-            
+
             for i in using_yieldfrom():
                 print(i)
             """)
-            
+
     def test_generator_send(self):
         self.assertCodeExecution("""
             def gen():
                 a = yield
                 print(a)
-                
+
             g = gen()
             next(g)
             try:
@@ -110,7 +110,7 @@ class GeneratorTests(TranspileTestCase):
             except StopIteration:
                 pass
             """)
-            
+
     def test_generator_multi_send(self):
         self.assertCodeExecution("""
             def gen():
@@ -118,7 +118,7 @@ class GeneratorTests(TranspileTestCase):
                 print(a)
                 b = yield 2
                 print(b)
-                
+
             g = gen()
             next(g)
             try:
@@ -127,35 +127,35 @@ class GeneratorTests(TranspileTestCase):
             except StopIteration:
                 pass
             """)
-            
+
     def test_generator_power_generator(self):
         self.assertCodeExecution("""
             def gen():
                 while True:
                     x = yield 1
                     yield x ** 2
-                
+
             g = gen()
             next(g)
             print(g.send(6))
             next(g)
             print(g.send(-1))
             """)
-            
+
     def test_generator_send_loop(self):
         self.assertCodeExecution("""
             def gen():
                 for i in range(1, 5):
                     a = yield i
                     print("printing from generator " + str(a))
-                    
+
             g = gen()
             g.send(None)
             try:
                 while True:
                     b = g.send(1)
                     print("printing from user " + str(b))
-            except StopIteration: 
+            except StopIteration:
                 pass
             """)
 
@@ -164,7 +164,7 @@ class GeneratorTests(TranspileTestCase):
             def gen():
                 while True:
                     x = print((yield))
-                
+
             g = gen()
             g.send(None)
             g.send("Hello World")
@@ -176,53 +176,53 @@ class GeneratorTests(TranspileTestCase):
                 while True:
                     x = -(yield)
                     yield x
-                
+
             g = gen()
             g.send(None)
             g.send(2)
             g.send(-1)
             """)
-            
+
     def test_generator_bool_op(self):
         self.assertCodeExecution("""
             def gen():
                 while True:
                     x = not (yield)
                     yield x
-                
+
             g = gen()
             g.send(None)
             g.send(True)
             g.send(False)
             """)
-            
+
     def test_generator_binary_op(self):
         self.assertCodeExecution("""
             def gen():
                 while True:
                     x = 2 + (yield)
                     yield x
-                    
+
             def gen2():
                 while True:
                     x = (yield) * 2
                     yield x
-                    
+
             def gen3():
                 while True:
                     x = (yield) ** 2
                     yield x
-                
+
             g = gen()
             g.send(None)
             g.send(2)
             g.send(-1)
-            
+
             g = gen2()
             g.send(None)
             g.send(100)
             g.send(20)
-            
+
             g = gen3()
             next(g)
             g.send(2)

--- a/tests/structures/test_generator.py
+++ b/tests/structures/test_generator.py
@@ -148,6 +148,7 @@ class GeneratorTests(TranspileTestCase):
                 for i in range(1, 5):
                     a = yield i
                     print("printing from generator " + str(a))
+                    
             g = gen()
             g.send(None)
             try:
@@ -156,4 +157,74 @@ class GeneratorTests(TranspileTestCase):
                     print("printing from user " + str(b))
             except StopIteration: 
                 pass
+            """)
+
+    def test_generator_yield_call(self):
+        self.assertCodeExecution("""
+            def gen():
+                while True:
+                    x = print((yield))
+                
+            g = gen()
+            g.send(None)
+            g.send("Hello World")
+            """)
+
+    def test_generator_unary_op(self):
+        self.assertCodeExecution("""
+            def gen():
+                while True:
+                    x = -(yield)
+                    yield x
+                
+            g = gen()
+            g.send(None)
+            g.send(2)
+            g.send(-1)
+            """)
+            
+    def test_generator_bool_op(self):
+        self.assertCodeExecution("""
+            def gen():
+                while True:
+                    x = not (yield)
+                    yield x
+                
+            g = gen()
+            g.send(None)
+            g.send(True)
+            g.send(False)
+            """)
+            
+    def test_generator_binary_op(self):
+        self.assertCodeExecution("""
+            def gen():
+                while True:
+                    x = 2 + (yield)
+                    yield x
+                    
+            def gen2():
+                while True:
+                    x = (yield) * 2
+                    yield x
+                    
+            def gen3():
+                while True:
+                    x = (yield) ** 2
+                    yield x
+                
+            g = gen()
+            g.send(None)
+            g.send(2)
+            g.send(-1)
+            
+            g = gen2()
+            g.send(None)
+            g.send(100)
+            g.send(20)
+            
+            g = gen3()
+            next(g)
+            g.send(2)
+            g.send(0)
             """)

--- a/voc/python/ast.py
+++ b/voc/python/ast.py
@@ -328,6 +328,23 @@ class Visitor(ast.NodeVisitor):
         # Evaluate the value
         self.visit(node.value)
 
+        if isinstance(node.value, ast.Yield):
+            self.context.load_name('<generator>')
+            self.context.add_opcodes(
+                JavaOpcodes.GETFIELD('org/python/types/Generator', 'message', 'Lorg/python/Object;')
+            )
+
+            # reset message to None after assignment
+            self.context.load_name('<generator>')
+            self.context.add_opcodes(
+                JavaOpcodes.INVOKEVIRTUAL(
+                    'org/python/types/Generator',
+                    'reset_message',
+                    args=[],
+                    returns='V'
+                )
+            )
+
         if len(node.targets) > 1:
             for target in node.targets:
                 # Assign the value to the target
@@ -1718,7 +1735,7 @@ class Visitor(ast.NodeVisitor):
             # Convert to a new value for return purposes
             JavaOpcodes.INVOKEINTERFACE('org/python/Object', 'byValue', args=[], returns='Lorg/python/Object;')
         )
-        # Save the current stack and yield inde
+        # Save the current stack and yield index
         self.context.load_name('<generator>')
         self.context.add_opcodes(
             ALOAD_name('#locals'),

--- a/voc/python/ast.py
+++ b/voc/python/ast.py
@@ -223,9 +223,9 @@ class Visitor(ast.NodeVisitor):
 
         for child in node.body:
             self.visit(child)
-                
+
         self.pop_context()
-        
+
     @node_visitor
     def visit_ClassDef(self, node):
         # Construct a class.


### PR DESCRIPTION
This PR enables `yield` keyword to be used in expression and introduces send method to generator in voc.

Some examples:
1.  Echoes what is sent
```
def gen():
    # echoes what is sent in
    while True:
        x = print((yield)) 

g = gen()
next(g)
g.send("Hi there!")
g.send("Sup")
```
Output:
```
Hi there!
Sup
```

2. Yield square of value sent
```
def gen():
    # yield square of value sent
    while True:
        x = yield("ready") 
        yield x ** 2

g = gen()
next(g)
print(g.send(2))
next(g)
print(g.send(-1))
```
Output:
```
4
1
```




Note:

- I'm currently working on augmented assignment with `yield`, hence the code below will not work at the moment:
```
def gen():
    k = 123
    k += yield
```

- Once this PR and #821 are confirmed stable, I will implement the same features to `yield from` keyword
