### PR TITLE
Boolean preallocation optimization

### DIFF
--- a/python/common/org/Python.java
+++ b/python/common/org/Python.java
@@ -384,12 +384,12 @@ public class Python {
             while (true) {
                 org.python.Object next = iter.__next__();
                 if (!next.toBoolean()) {
-                    return new org.python.types.Bool(false);
+                    return org.python.types.Bool.getBool(false);
                 }
             }
         } catch (org.python.exceptions.StopIteration si) {
         }
-        return new org.python.types.Bool(true);
+        return org.python.types.Bool.getBool(true);
     }
 
     @org.python.Method(
@@ -405,12 +405,12 @@ public class Python {
             while (true) {
                 org.python.Object next = iter.__next__();
                 if (next.toBoolean()) {
-                    return new org.python.types.Bool(true);
+                    return org.python.types.Bool.getBool(true);
                 }
             }
         } catch (org.python.exceptions.StopIteration si) {
         }
-        return new org.python.types.Bool(false);
+        return org.python.types.Bool.getBool(false);
     }
 
     @org.python.Method(
@@ -462,7 +462,7 @@ public class Python {
             args = {"object"}
     )
     public static org.python.types.Bool callable(org.python.Object object) {
-        return new org.python.types.Bool(org.python.Callable.class.isAssignableFrom(object.getClass()));
+        return org.python.types.Bool.getBool(org.python.Callable.class.isAssignableFrom(object.getClass()));
     }
 
     @org.python.Method(
@@ -777,9 +777,9 @@ public class Python {
         }
         try {
             object.__getattribute__(name);
-            return new org.python.types.Bool(true);
+            return org.python.types.Bool.getBool(true);
         } catch (org.python.exceptions.AttributeError ae) {
-            return new org.python.types.Bool(false);
+            return org.python.types.Bool.getBool(false);
         } catch (org.python.exceptions.TypeError te) {
             throw new org.python.exceptions.TypeError(te.getMessage().replace("__hasattribute__", "hasattr"));
         }
@@ -909,22 +909,22 @@ public class Python {
             java.util.List<org.python.Object> target_classes = ((org.python.types.Tuple) classinfo_or_tuple).value;
             for (org.python.Object target_klass: target_classes) {
                 if (org.Python.issubclass(klass, target_klass).toBoolean()) {
-                    return new org.python.types.Bool(true);
+                    return org.python.types.Bool.getBool(true);
                 }
             }
-            return new org.python.types.Bool(false);
+            return org.python.types.Bool.getBool(false);
         } else if (classinfo_or_tuple instanceof org.python.types.Type) {
             org.python.types.Type klass_obj = (org.python.types.Type) klass;
             if (klass == classinfo_or_tuple) {
-                return new org.python.types.Bool(true);
+                return org.python.types.Bool.getBool(true);
             } else if (klass_obj.__dict__.get("__bases__") != null) {
                 for (org.python.Object base: ((org.python.types.Tuple) klass_obj.__dict__.get("__bases__")).value) {
                     if (base == classinfo_or_tuple || org.Python.issubclass(base, classinfo_or_tuple).value) {
-                        return new org.python.types.Bool(true);
+                        return org.python.types.Bool.getBool(true);
                     }
                 }
             }
-            return new org.python.types.Bool(false);
+            return org.python.types.Bool.getBool(false);
         } else {
             throw new org.python.exceptions.TypeError("issubclass() arg 2 must be a class or tuple of classes");
         }
@@ -1617,7 +1617,7 @@ public class Python {
             return new org.python.types.List();
         } else {
             if (reverse == null) {
-                reverse = new org.python.types.Bool(false);
+                reverse = org.python.types.Bool.getBool(false);
             }
             org.python.Object iterator = org.Python.iter(iterable);
             java.util.List<org.python.Object> generated = new java.util.ArrayList<org.python.Object>();

--- a/python/common/org/Python.java
+++ b/python/common/org/Python.java
@@ -384,12 +384,12 @@ public class Python {
             while (true) {
                 org.python.Object next = iter.__next__();
                 if (!next.toBoolean()) {
-                    return org.python.types.Bool.getBool(false);
+                    return org.python.types.Bool.FALSE;
                 }
             }
         } catch (org.python.exceptions.StopIteration si) {
         }
-        return org.python.types.Bool.getBool(true);
+        return org.python.types.Bool.TRUE;
     }
 
     @org.python.Method(
@@ -405,12 +405,12 @@ public class Python {
             while (true) {
                 org.python.Object next = iter.__next__();
                 if (next.toBoolean()) {
-                    return org.python.types.Bool.getBool(true);
+                    return org.python.types.Bool.TRUE;
                 }
             }
         } catch (org.python.exceptions.StopIteration si) {
         }
-        return org.python.types.Bool.getBool(false);
+        return org.python.types.Bool.FALSE;
     }
 
     @org.python.Method(
@@ -777,9 +777,9 @@ public class Python {
         }
         try {
             object.__getattribute__(name);
-            return org.python.types.Bool.getBool(true);
+            return org.python.types.Bool.TRUE;
         } catch (org.python.exceptions.AttributeError ae) {
-            return org.python.types.Bool.getBool(false);
+            return org.python.types.Bool.FALSE;
         } catch (org.python.exceptions.TypeError te) {
             throw new org.python.exceptions.TypeError(te.getMessage().replace("__hasattribute__", "hasattr"));
         }
@@ -909,22 +909,22 @@ public class Python {
             java.util.List<org.python.Object> target_classes = ((org.python.types.Tuple) classinfo_or_tuple).value;
             for (org.python.Object target_klass: target_classes) {
                 if (org.Python.issubclass(klass, target_klass).toBoolean()) {
-                    return org.python.types.Bool.getBool(true);
+                    return org.python.types.Bool.TRUE;
                 }
             }
-            return org.python.types.Bool.getBool(false);
+            return org.python.types.Bool.FALSE;
         } else if (classinfo_or_tuple instanceof org.python.types.Type) {
             org.python.types.Type klass_obj = (org.python.types.Type) klass;
             if (klass == classinfo_or_tuple) {
-                return org.python.types.Bool.getBool(true);
+                return org.python.types.Bool.TRUE;
             } else if (klass_obj.__dict__.get("__bases__") != null) {
                 for (org.python.Object base: ((org.python.types.Tuple) klass_obj.__dict__.get("__bases__")).value) {
                     if (base == classinfo_or_tuple || org.Python.issubclass(base, classinfo_or_tuple).value) {
-                        return org.python.types.Bool.getBool(true);
+                        return org.python.types.Bool.TRUE;
                     }
                 }
             }
-            return org.python.types.Bool.getBool(false);
+            return org.python.types.Bool.FALSE;
         } else {
             throw new org.python.exceptions.TypeError("issubclass() arg 2 must be a class or tuple of classes");
         }
@@ -1617,7 +1617,7 @@ public class Python {
             return new org.python.types.List();
         } else {
             if (reverse == null) {
-                reverse = org.python.types.Bool.getBool(false);
+                reverse = org.python.types.Bool.FALSE;
             }
             org.python.Object iterator = org.Python.iter(iterable);
             java.util.List<org.python.Object> generated = new java.util.ArrayList<org.python.Object>();

--- a/python/common/org/python/java/Function.java
+++ b/python/common/org/python/java/Function.java
@@ -465,7 +465,7 @@ public class Function extends org.python.types.Object implements org.python.Call
             __doc__ = ""
     )
     public org.python.Object __bool__() {
-        return new org.python.types.Bool(true);
+        return org.python.types.Bool.getBool(true);
     }
 
     public org.python.Object invoke(org.python.Object[] args, java.util.Map<java.lang.String, org.python.Object> kwargs) {

--- a/python/common/org/python/java/Function.java
+++ b/python/common/org/python/java/Function.java
@@ -465,7 +465,7 @@ public class Function extends org.python.types.Object implements org.python.Call
             __doc__ = ""
     )
     public org.python.Object __bool__() {
-        return org.python.types.Bool.getBool(true);
+        return org.python.types.Bool.TRUE;
     }
 
     public org.python.Object invoke(org.python.Object[] args, java.util.Map<java.lang.String, org.python.Object> kwargs) {

--- a/python/common/org/python/java/Method.java
+++ b/python/common/org/python/java/Method.java
@@ -37,6 +37,6 @@ public class Method extends org.python.types.Object implements org.python.Callab
             __doc__ = ""
     )
     public org.python.Object __bool__() {
-        return new org.python.types.Bool(true);
+        return org.python.types.Bool.getBool(true);
     }
 }

--- a/python/common/org/python/java/Method.java
+++ b/python/common/org/python/java/Method.java
@@ -37,6 +37,6 @@ public class Method extends org.python.types.Object implements org.python.Callab
             __doc__ = ""
     )
     public org.python.Object __bool__() {
-        return org.python.types.Bool.getBool(true);
+        return org.python.types.Bool.TRUE;
     }
 }

--- a/python/common/org/python/types/Bool.java
+++ b/python/common/org/python/types/Bool.java
@@ -7,16 +7,16 @@ public class Bool extends org.python.types.Object {
 
     public static org.python.types.Bool getBool(boolean bool) {
         if (bool) {
-            return TRUE;
+            return org.python.types.Bool.TRUE;
         }
-        return FALSE;
+        return org.python.types.Bool.FALSE;
     }
 
     public static org.python.types.Bool getBool(long int_val) {
         if (int_val != 0) {
-            return TRUE;
+            return org.python.types.Bool.TRUE;
         }
-        return FALSE;
+        return org.python.types.Bool.FALSE;
     }
 
     /**
@@ -128,7 +128,7 @@ public class Bool extends org.python.types.Object {
         if (other instanceof org.python.types.Int) {
             return org.python.types.Bool.getBool((((org.python.types.Bool) this).value ? 1 : 0) == ((org.python.types.Int) other).value);
         } else if (other instanceof org.python.types.Bool) {
-            return org.python.types.Bool.getBool((((org.python.types.Bool) this).value ? 1 : 0) == (((org.python.types.Bool) other).value ? 1 : 0));
+            return org.python.types.Bool.getBool(((org.python.types.Bool) this).value == ((org.python.types.Bool) other).value);
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -311,7 +311,7 @@ public class Bool extends org.python.types.Object {
                 return new org.python.types.Int(0);
             } else {
                 if (org.Python.VERSION < 0x03060000) {
-                    return (org.python.types.Bool) FALSE;
+                    return org.python.types.Bool.FALSE;
                 } else {
                     return new org.python.types.Int(0);
                 }
@@ -324,7 +324,7 @@ public class Bool extends org.python.types.Object {
 
             if (!this.value) {
                 if (org.Python.VERSION < 0x03060000) {
-                    return (org.python.types.Bool) FALSE;
+                    return org.python.types.Bool.FALSE;
                 } else {
                     return new org.python.types.Int(0);
                 }
@@ -435,7 +435,7 @@ public class Bool extends org.python.types.Object {
     )
     public org.python.Object __xor__(org.python.Object other) {
         if (other instanceof org.python.types.Bool) {
-            return org.python.types.Bool.getBool((((org.python.types.Bool) this).value ? 1 : 0) ^ (((org.python.types.Bool) other).value ? 1 : 0));
+            return org.python.types.Bool.getBool(((org.python.types.Bool) this).value ^ ((org.python.types.Bool) other).value);
         } else if (other instanceof org.python.types.Int) {
             long operand1 = this.value ? 1L : 0L;
             long operand2 = ((org.python.types.Int) other).value;
@@ -450,7 +450,7 @@ public class Bool extends org.python.types.Object {
     )
     public org.python.Object __or__(org.python.Object other) {
         if (other instanceof org.python.types.Bool) {
-            return org.python.types.Bool.getBool((((org.python.types.Bool) this).value ? 1 : 0) | (((org.python.types.Bool) other).value ? 1 : 0));
+            return org.python.types.Bool.getBool(((org.python.types.Bool) this).value | ((org.python.types.Bool) other).value);
         }
         if (other instanceof org.python.types.Int) {
             return new org.python.types.Int((((org.python.types.Bool) this).value ? 1 : 0) | ((org.python.types.Int) other).value);

--- a/python/common/org/python/types/Bool.java
+++ b/python/common/org/python/types/Bool.java
@@ -6,17 +6,17 @@ public class Bool extends org.python.types.Object {
     public static org.python.types.Bool FALSE = new org.python.types.Bool(false);
 
     public static org.python.types.Bool getBool(boolean bool) {
-      if (bool) {
-        return TRUE;
-      }
-      return FALSE;
+        if (bool) {
+            return TRUE;
+        }
+        return FALSE;
     }
 
     public static org.python.types.Bool getBool(long int_val) {
-      if (int_val != 0) {
-        return TRUE;
-      }
-      return FALSE;
+        if (int_val != 0) {
+            return TRUE;
+        }
+        return FALSE;
     }
 
     /**

--- a/python/common/org/python/types/Bool.java
+++ b/python/common/org/python/types/Bool.java
@@ -5,6 +5,20 @@ public class Bool extends org.python.types.Object {
     public static org.python.Object TRUE = new org.python.types.Bool(true);
     public static org.python.Object FALSE = new org.python.types.Bool(false);
 
+    public static org.python.types.Bool getBool(boolean bool) {
+      if (bool) {
+        return (org.python.types.Bool) TRUE;
+      }
+      return (org.python.types.Bool) FALSE;
+    }
+
+    public static org.python.types.Bool getBool(long int_val) {
+      if (int_val != 0) {
+        return (org.python.types.Bool) TRUE;
+      }
+      return (org.python.types.Bool) FALSE;
+    }
+
     /**
      * A utility method to update the internal value of this object.
      *
@@ -20,23 +34,18 @@ public class Bool extends org.python.types.Object {
     }
 
     public org.python.Object byValue() {
-        return new org.python.types.Bool(this.value);
+        return org.python.types.Bool.getBool(this.value);
     }
 
     public int hashCode() {
         return new java.lang.Boolean(this.value).hashCode();
     }
 
-    public Bool(boolean bool) {
+    private Bool(boolean bool) {
         super();
         this.value = bool;
     }
-
-    public Bool(long int_val) {
-        super();
-        this.value = int_val != 0;
-    }
-
+    
     @org.python.Method(
             __doc__ = "bool(x) -> bool" +
                     "\n" +
@@ -91,9 +100,9 @@ public class Bool extends org.python.types.Object {
     )
     public org.python.Object __lt__(org.python.Object other) {
         if (other instanceof org.python.types.Int) {
-            return new org.python.types.Bool((((org.python.types.Bool) this).value ? 1 : 0) < ((org.python.types.Int) other).value);
+            return org.python.types.Bool.getBool((((org.python.types.Bool) this).value ? 1 : 0) < ((org.python.types.Int) other).value);
         } else if (other instanceof org.python.types.Bool) {
-            return new org.python.types.Bool((((org.python.types.Bool) this).value ? 1 : 0) < (((org.python.types.Bool) other).value ? 1 : 0));
+            return org.python.types.Bool.getBool((((org.python.types.Bool) this).value ? 1 : 0) < (((org.python.types.Bool) other).value ? 1 : 0));
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -104,9 +113,9 @@ public class Bool extends org.python.types.Object {
     )
     public org.python.Object __le__(org.python.Object other) {
         if (other instanceof org.python.types.Int) {
-            return new org.python.types.Bool((((org.python.types.Bool) this).value ? 1 : 0) <= ((org.python.types.Int) other).value);
+            return org.python.types.Bool.getBool((((org.python.types.Bool) this).value ? 1 : 0) <= ((org.python.types.Int) other).value);
         } else if (other instanceof org.python.types.Bool) {
-            return new org.python.types.Bool((((org.python.types.Bool) this).value ? 1 : 0) <= (((org.python.types.Bool) other).value ? 1 : 0));
+            return org.python.types.Bool.getBool((((org.python.types.Bool) this).value ? 1 : 0) <= (((org.python.types.Bool) other).value ? 1 : 0));
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -117,9 +126,9 @@ public class Bool extends org.python.types.Object {
     )
     public org.python.Object __eq__(org.python.Object other) {
         if (other instanceof org.python.types.Int) {
-            return new org.python.types.Bool((((org.python.types.Bool) this).value ? 1 : 0) == ((org.python.types.Int) other).value);
+            return org.python.types.Bool.getBool((((org.python.types.Bool) this).value ? 1 : 0) == ((org.python.types.Int) other).value);
         } else if (other instanceof org.python.types.Bool) {
-            return new org.python.types.Bool((((org.python.types.Bool) this).value ? 1 : 0) == (((org.python.types.Bool) other).value ? 1 : 0));
+            return org.python.types.Bool.getBool((((org.python.types.Bool) this).value ? 1 : 0) == (((org.python.types.Bool) other).value ? 1 : 0));
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -130,9 +139,9 @@ public class Bool extends org.python.types.Object {
     )
     public org.python.Object __gt__(org.python.Object other) {
         if (other instanceof org.python.types.Int) {
-            return new org.python.types.Bool((((org.python.types.Bool) this).value ? 1 : 0) > ((org.python.types.Int) other).value);
+            return org.python.types.Bool.getBool((((org.python.types.Bool) this).value ? 1 : 0) > ((org.python.types.Int) other).value);
         } else if (other instanceof org.python.types.Bool) {
-            return new org.python.types.Bool((((org.python.types.Bool) this).value ? 1 : 0) > (((org.python.types.Bool) other).value ? 1 : 0));
+            return org.python.types.Bool.getBool((((org.python.types.Bool) this).value ? 1 : 0) > (((org.python.types.Bool) other).value ? 1 : 0));
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -143,9 +152,9 @@ public class Bool extends org.python.types.Object {
     )
     public org.python.Object __ge__(org.python.Object other) {
         if (other instanceof org.python.types.Int) {
-            return new org.python.types.Bool((((org.python.types.Bool) this).value ? 1 : 0) >= ((org.python.types.Int) other).value);
+            return org.python.types.Bool.getBool((((org.python.types.Bool) this).value ? 1 : 0) >= ((org.python.types.Int) other).value);
         } else if (other instanceof org.python.types.Bool) {
-            return new org.python.types.Bool((((org.python.types.Bool) this).value ? 1 : 0) >= (((org.python.types.Bool) other).value ? 1 : 0));
+            return org.python.types.Bool.getBool((((org.python.types.Bool) this).value ? 1 : 0) >= (((org.python.types.Bool) other).value ? 1 : 0));
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -154,7 +163,7 @@ public class Bool extends org.python.types.Object {
             __doc__ = "self != 0"
     )
     public org.python.types.Bool __bool__() {
-        return new org.python.types.Bool(this.value);
+        return org.python.types.Bool.getBool(this.value);
     }
 
     public boolean __setattr_null(java.lang.String name, org.python.Object value) {
@@ -302,7 +311,7 @@ public class Bool extends org.python.types.Object {
                 return new org.python.types.Int(0);
             } else {
                 if (org.Python.VERSION < 0x03060000) {
-                    return new org.python.types.Bool(false);
+                    return (org.python.types.Bool) FALSE;
                 } else {
                     return new org.python.types.Int(0);
                 }
@@ -315,13 +324,13 @@ public class Bool extends org.python.types.Object {
 
             if (!this.value) {
                 if (org.Python.VERSION < 0x03060000) {
-                    return new org.python.types.Bool(false);
+                    return (org.python.types.Bool) FALSE;
                 } else {
                     return new org.python.types.Int(0);
                 }
             } else if (other_val > 1) {
                 if (org.Python.VERSION < 0x03060000) {
-                    return new org.python.types.Bool(this.value);
+                    return org.python.types.Bool.getBool(this.value);
                 } else {
                     return new org.python.types.Int(1);
                 }
@@ -404,7 +413,7 @@ public class Bool extends org.python.types.Object {
     )
     public org.python.Object __and__(org.python.Object other) {
         if (other instanceof org.python.types.Bool) {
-            return new org.python.types.Bool(
+            return org.python.types.Bool.getBool(
                     (((org.python.types.Bool) this).value ? 1 : 0) &
                             (((org.python.types.Bool) other).value ? 1 : 0)
             );
@@ -426,7 +435,7 @@ public class Bool extends org.python.types.Object {
     )
     public org.python.Object __xor__(org.python.Object other) {
         if (other instanceof org.python.types.Bool) {
-            return new org.python.types.Bool((((org.python.types.Bool) this).value ? 1 : 0) ^ (((org.python.types.Bool) other).value ? 1 : 0));
+            return org.python.types.Bool.getBool((((org.python.types.Bool) this).value ? 1 : 0) ^ (((org.python.types.Bool) other).value ? 1 : 0));
         } else if (other instanceof org.python.types.Int) {
             long operand1 = this.value ? 1L : 0L;
             long operand2 = ((org.python.types.Int) other).value;
@@ -441,7 +450,7 @@ public class Bool extends org.python.types.Object {
     )
     public org.python.Object __or__(org.python.Object other) {
         if (other instanceof org.python.types.Bool) {
-            return new org.python.types.Bool((((org.python.types.Bool) this).value ? 1 : 0) | (((org.python.types.Bool) other).value ? 1 : 0));
+            return org.python.types.Bool.getBool((((org.python.types.Bool) this).value ? 1 : 0) | (((org.python.types.Bool) other).value ? 1 : 0));
         }
         if (other instanceof org.python.types.Int) {
             return new org.python.types.Int((((org.python.types.Bool) this).value ? 1 : 0) | ((org.python.types.Int) other).value);

--- a/python/common/org/python/types/Bool.java
+++ b/python/common/org/python/types/Bool.java
@@ -2,21 +2,21 @@ package org.python.types;
 
 public class Bool extends org.python.types.Object {
     public boolean value;
-    public static org.python.Object TRUE = new org.python.types.Bool(true);
-    public static org.python.Object FALSE = new org.python.types.Bool(false);
+    public static org.python.types.Bool TRUE = new org.python.types.Bool(true);
+    public static org.python.types.Bool FALSE = new org.python.types.Bool(false);
 
     public static org.python.types.Bool getBool(boolean bool) {
       if (bool) {
-        return (org.python.types.Bool) TRUE;
+        return TRUE;
       }
-      return (org.python.types.Bool) FALSE;
+      return FALSE;
     }
 
     public static org.python.types.Bool getBool(long int_val) {
       if (int_val != 0) {
-        return (org.python.types.Bool) TRUE;
+        return TRUE;
       }
-      return (org.python.types.Bool) FALSE;
+      return FALSE;
     }
 
     /**
@@ -45,7 +45,7 @@ public class Bool extends org.python.types.Object {
         super();
         this.value = bool;
     }
-    
+
     @org.python.Method(
             __doc__ = "bool(x) -> bool" +
                     "\n" +

--- a/python/common/org/python/types/ByteArray.java
+++ b/python/common/org/python/types/ByteArray.java
@@ -413,33 +413,33 @@ public class ByteArray extends org.python.types.Object {
             byte[] other_bytes = (byte[]) ((org.python.types.Bytes) other).value;
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] > other_bytes[i]) {
-                    return org.python.types.Bool.getBool(1);
+                    return org.python.types.Bool.TRUE;
                 }
                 if (this.value[i] < other_bytes[i]) {
-                    return org.python.types.Bool.getBool(0);
+                    return org.python.types.Bool.FALSE;
                 }
             }
             if (this.value.length < other_bytes.length) {
-                return org.python.types.Bool.getBool(0);
+                return org.python.types.Bool.FALSE;
             }
-            return org.python.types.Bool.getBool(1);
+            return org.python.types.Bool.TRUE;
         } else if (other instanceof org.python.types.ByteArray) {
             byte[] other_bytes = (byte[]) ((org.python.types.ByteArray) other).value;
             if (other_bytes == null) {
-                return org.python.types.Bool.getBool(1);
+                return org.python.types.Bool.TRUE;
             }
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] > other_bytes[i]) {
-                    return org.python.types.Bool.getBool(1);
+                    return org.python.types.Bool.TRUE;
                 }
                 if (this.value[i] < other_bytes[i]) {
-                    return org.python.types.Bool.getBool(0);
+                    return org.python.types.Bool.FALSE;
                 }
             }
             if (this.value.length < other_bytes.length) {
-                return org.python.types.Bool.getBool(0);
+                return org.python.types.Bool.FALSE;
             }
-            return org.python.types.Bool.getBool(1);
+            return org.python.types.Bool.TRUE;
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -453,16 +453,16 @@ public class ByteArray extends org.python.types.Object {
             byte[] other_bytes = (byte[]) ((org.python.types.Bytes) other).value;
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] > other_bytes[i]) {
-                    return org.python.types.Bool.getBool(1);
+                    return org.python.types.Bool.TRUE;
                 }
                 if (this.value[i] < other_bytes[i]) {
-                    return org.python.types.Bool.getBool(0);
+                    return org.python.types.Bool.FALSE;
                 }
             }
             if (this.value.length <= other_bytes.length) {
-                return org.python.types.Bool.getBool(0);
+                return org.python.types.Bool.FALSE;
             }
-            return org.python.types.Bool.getBool(1);
+            return org.python.types.Bool.TRUE;
         } else if (other instanceof org.python.types.ByteArray) {
             byte[] other_bytes = (byte[]) ((org.python.types.ByteArray) other).value;
             if (other_bytes == null) {
@@ -470,16 +470,16 @@ public class ByteArray extends org.python.types.Object {
             }
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] > other_bytes[i]) {
-                    return org.python.types.Bool.getBool(1);
+                    return org.python.types.Bool.TRUE;
                 }
                 if (this.value[i] < other_bytes[i]) {
-                    return org.python.types.Bool.getBool(0);
+                    return org.python.types.Bool.FALSE;
                 }
             }
             if (this.value.length <= other_bytes.length) {
-                return org.python.types.Bool.getBool(0);
+                return org.python.types.Bool.FALSE;
             }
-            return org.python.types.Bool.getBool(1);
+            return org.python.types.Bool.TRUE;
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -493,16 +493,16 @@ public class ByteArray extends org.python.types.Object {
             byte[] other_bytes = (byte[]) ((org.python.types.Bytes) other).value;
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] < other_bytes[i]) {
-                    return org.python.types.Bool.getBool(1);
+                    return org.python.types.Bool.TRUE;
                 }
                 if (this.value[i] > other_bytes[i]) {
-                    return org.python.types.Bool.getBool(0);
+                    return org.python.types.Bool.FALSE;
                 }
             }
             if (this.value.length <= other_bytes.length) {
-                return org.python.types.Bool.getBool(1);
+                return org.python.types.Bool.TRUE;
             }
-            return org.python.types.Bool.getBool(0);
+            return org.python.types.Bool.FALSE;
         } else if (other instanceof org.python.types.ByteArray) {
             byte[] other_bytes = (byte[]) ((org.python.types.ByteArray) other).value;
             if (other_bytes == null) {
@@ -510,16 +510,16 @@ public class ByteArray extends org.python.types.Object {
             }
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] < other_bytes[i]) {
-                    return org.python.types.Bool.getBool(1);
+                    return org.python.types.Bool.TRUE;
                 }
                 if (this.value[i] > other_bytes[i]) {
-                    return org.python.types.Bool.getBool(0);
+                    return org.python.types.Bool.FALSE;
                 }
             }
             if (this.value.length <= other_bytes.length) {
-                return org.python.types.Bool.getBool(1);
+                return org.python.types.Bool.TRUE;
             }
-            return org.python.types.Bool.getBool(0);
+            return org.python.types.Bool.FALSE;
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -533,33 +533,33 @@ public class ByteArray extends org.python.types.Object {
             byte[] other_bytes = (byte[]) ((org.python.types.Bytes) other).value;
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] < other_bytes[i]) {
-                    return org.python.types.Bool.getBool(1);
+                    return org.python.types.Bool.TRUE;
                 }
                 if (this.value[i] > other_bytes[i]) {
-                    return org.python.types.Bool.getBool(0);
+                    return org.python.types.Bool.FALSE;
                 }
             }
             if (this.value.length < other_bytes.length) {
-                return org.python.types.Bool.getBool(1);
+                return org.python.types.Bool.TRUE;
             }
-            return org.python.types.Bool.getBool(0);
+            return org.python.types.Bool.FALSE;
         } else if (other instanceof org.python.types.ByteArray) {
             byte[] other_bytes = (byte[]) ((org.python.types.ByteArray) other).value;
             if (other_bytes == null) {
-                return org.python.types.Bool.getBool(0);
+                return org.python.types.Bool.FALSE;
             }
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] < other_bytes[i]) {
-                    return org.python.types.Bool.getBool(1);
+                    return org.python.types.Bool.TRUE;
                 }
                 if (this.value[i] > other_bytes[i]) {
-                    return org.python.types.Bool.getBool(0);
+                    return org.python.types.Bool.FALSE;
                 }
             }
             if (this.value.length < other_bytes.length) {
-                return org.python.types.Bool.getBool(1);
+                return org.python.types.Bool.TRUE;
             }
-            return org.python.types.Bool.getBool(0);
+            return org.python.types.Bool.FALSE;
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }

--- a/python/common/org/python/types/ByteArray.java
+++ b/python/common/org/python/types/ByteArray.java
@@ -210,7 +210,7 @@ public class ByteArray extends org.python.types.Object {
             __doc__ = ""
     )
     public org.python.Object __bool__() {
-        return new org.python.types.Bool(this.value.length > 0);
+        return org.python.types.Bool.getBool(this.value.length > 0);
     }
 
     @org.python.Method(
@@ -220,10 +220,10 @@ public class ByteArray extends org.python.types.Object {
     public org.python.Object __eq__(org.python.Object other) {
         if (other instanceof org.python.types.Bytes) {
             byte[] other_value = ((org.python.types.Bytes) other).value;
-            return new org.python.types.Bool(Arrays.equals(this.value, other_value));
+            return org.python.types.Bool.getBool(Arrays.equals(this.value, other_value));
         } else if (other instanceof org.python.types.ByteArray) {
             byte[] other_value = ((org.python.types.ByteArray) other).value;
-            return new org.python.types.Bool(Arrays.equals(this.value, other_value));
+            return org.python.types.Bool.getBool(Arrays.equals(this.value, other_value));
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -413,33 +413,33 @@ public class ByteArray extends org.python.types.Object {
             byte[] other_bytes = (byte[]) ((org.python.types.Bytes) other).value;
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] > other_bytes[i]) {
-                    return new org.python.types.Bool(1);
+                    return org.python.types.Bool.getBool(1);
                 }
                 if (this.value[i] < other_bytes[i]) {
-                    return new org.python.types.Bool(0);
+                    return org.python.types.Bool.getBool(0);
                 }
             }
             if (this.value.length < other_bytes.length) {
-                return new org.python.types.Bool(0);
+                return org.python.types.Bool.getBool(0);
             }
-            return new org.python.types.Bool(1);
+            return org.python.types.Bool.getBool(1);
         } else if (other instanceof org.python.types.ByteArray) {
             byte[] other_bytes = (byte[]) ((org.python.types.ByteArray) other).value;
             if (other_bytes == null) {
-                return new org.python.types.Bool(1);
+                return org.python.types.Bool.getBool(1);
             }
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] > other_bytes[i]) {
-                    return new org.python.types.Bool(1);
+                    return org.python.types.Bool.getBool(1);
                 }
                 if (this.value[i] < other_bytes[i]) {
-                    return new org.python.types.Bool(0);
+                    return org.python.types.Bool.getBool(0);
                 }
             }
             if (this.value.length < other_bytes.length) {
-                return new org.python.types.Bool(0);
+                return org.python.types.Bool.getBool(0);
             }
-            return new org.python.types.Bool(1);
+            return org.python.types.Bool.getBool(1);
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -453,16 +453,16 @@ public class ByteArray extends org.python.types.Object {
             byte[] other_bytes = (byte[]) ((org.python.types.Bytes) other).value;
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] > other_bytes[i]) {
-                    return new org.python.types.Bool(1);
+                    return org.python.types.Bool.getBool(1);
                 }
                 if (this.value[i] < other_bytes[i]) {
-                    return new org.python.types.Bool(0);
+                    return org.python.types.Bool.getBool(0);
                 }
             }
             if (this.value.length <= other_bytes.length) {
-                return new org.python.types.Bool(0);
+                return org.python.types.Bool.getBool(0);
             }
-            return new org.python.types.Bool(1);
+            return org.python.types.Bool.getBool(1);
         } else if (other instanceof org.python.types.ByteArray) {
             byte[] other_bytes = (byte[]) ((org.python.types.ByteArray) other).value;
             if (other_bytes == null) {
@@ -470,16 +470,16 @@ public class ByteArray extends org.python.types.Object {
             }
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] > other_bytes[i]) {
-                    return new org.python.types.Bool(1);
+                    return org.python.types.Bool.getBool(1);
                 }
                 if (this.value[i] < other_bytes[i]) {
-                    return new org.python.types.Bool(0);
+                    return org.python.types.Bool.getBool(0);
                 }
             }
             if (this.value.length <= other_bytes.length) {
-                return new org.python.types.Bool(0);
+                return org.python.types.Bool.getBool(0);
             }
-            return new org.python.types.Bool(1);
+            return org.python.types.Bool.getBool(1);
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -493,16 +493,16 @@ public class ByteArray extends org.python.types.Object {
             byte[] other_bytes = (byte[]) ((org.python.types.Bytes) other).value;
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] < other_bytes[i]) {
-                    return new org.python.types.Bool(1);
+                    return org.python.types.Bool.getBool(1);
                 }
                 if (this.value[i] > other_bytes[i]) {
-                    return new org.python.types.Bool(0);
+                    return org.python.types.Bool.getBool(0);
                 }
             }
             if (this.value.length <= other_bytes.length) {
-                return new org.python.types.Bool(1);
+                return org.python.types.Bool.getBool(1);
             }
-            return new org.python.types.Bool(0);
+            return org.python.types.Bool.getBool(0);
         } else if (other instanceof org.python.types.ByteArray) {
             byte[] other_bytes = (byte[]) ((org.python.types.ByteArray) other).value;
             if (other_bytes == null) {
@@ -510,16 +510,16 @@ public class ByteArray extends org.python.types.Object {
             }
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] < other_bytes[i]) {
-                    return new org.python.types.Bool(1);
+                    return org.python.types.Bool.getBool(1);
                 }
                 if (this.value[i] > other_bytes[i]) {
-                    return new org.python.types.Bool(0);
+                    return org.python.types.Bool.getBool(0);
                 }
             }
             if (this.value.length <= other_bytes.length) {
-                return new org.python.types.Bool(1);
+                return org.python.types.Bool.getBool(1);
             }
-            return new org.python.types.Bool(0);
+            return org.python.types.Bool.getBool(0);
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -533,33 +533,33 @@ public class ByteArray extends org.python.types.Object {
             byte[] other_bytes = (byte[]) ((org.python.types.Bytes) other).value;
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] < other_bytes[i]) {
-                    return new org.python.types.Bool(1);
+                    return org.python.types.Bool.getBool(1);
                 }
                 if (this.value[i] > other_bytes[i]) {
-                    return new org.python.types.Bool(0);
+                    return org.python.types.Bool.getBool(0);
                 }
             }
             if (this.value.length < other_bytes.length) {
-                return new org.python.types.Bool(1);
+                return org.python.types.Bool.getBool(1);
             }
-            return new org.python.types.Bool(0);
+            return org.python.types.Bool.getBool(0);
         } else if (other instanceof org.python.types.ByteArray) {
             byte[] other_bytes = (byte[]) ((org.python.types.ByteArray) other).value;
             if (other_bytes == null) {
-                return new org.python.types.Bool(0);
+                return org.python.types.Bool.getBool(0);
             }
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] < other_bytes[i]) {
-                    return new org.python.types.Bool(1);
+                    return org.python.types.Bool.getBool(1);
                 }
                 if (this.value[i] > other_bytes[i]) {
-                    return new org.python.types.Bool(0);
+                    return org.python.types.Bool.getBool(0);
                 }
             }
             if (this.value.length < other_bytes.length) {
-                return new org.python.types.Bool(1);
+                return org.python.types.Bool.getBool(1);
             }
-            return new org.python.types.Bool(0);
+            return org.python.types.Bool.getBool(0);
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -764,49 +764,49 @@ public class ByteArray extends org.python.types.Object {
             __doc__ = "B.isalnum() -> bool\n\nReturn True if all characters in B are alphanumeric\nand there is at least one character in B, False otherwise."
     )
     public org.python.Object isalnum() {
-        return new Bool(Bytes._isalnum(this.value));
+        return org.python.types.Bool.getBool(Bytes._isalnum(this.value));
     }
 
     @org.python.Method(
             __doc__ = "B.isalpha() -> bool\n\nReturn True if all characters in B are alphabetic\nand there is at least one character in B, False otherwise."
     )
     public org.python.Object isalpha() {
-        return new Bool(Bytes._isalpha(this.value));
+        return org.python.types.Bool.getBool(Bytes._isalpha(this.value));
     }
 
     @org.python.Method(
             __doc__ = "B.isdigit() -> bool\n\nReturn True if all characters in B are digits\nand there is at least one character in B, False otherwise."
     )
     public org.python.Object isdigit() {
-        return new Bool(Bytes._isdigit(this.value));
+        return org.python.types.Bool.getBool(Bytes._isdigit(this.value));
     }
 
     @org.python.Method(
             __doc__ = "B.islower() -> bool\n\nReturn True if all cased characters in B are lowercase and there is\nat least one cased character in B, False otherwise."
     )
     public org.python.Object islower() {
-        return new Bool(Bytes._islower(this.value));
+        return org.python.types.Bool.getBool(Bytes._islower(this.value));
     }
 
     @org.python.Method(
             __doc__ = "B.isspace() -> bool\n\nReturn True if all characters in B are whitespace\nand there is at least one character in B, False otherwise."
     )
     public org.python.Object isspace() {
-        return new Bool(Bytes._isspace(this.value));
+        return org.python.types.Bool.getBool(Bytes._isspace(this.value));
     }
 
     @org.python.Method(
             __doc__ = "B.istitle() -> bool\n\nReturn True if B is a titlecased string and there is at least one\ncharacter in B, i.e. uppercase characters may only follow uncased\ncharacters and lowercase characters only cased ones. Return False\notherwise."
     )
     public org.python.Object istitle() {
-        return new Bool(Bytes._istitle(this.value));
+        return org.python.types.Bool.getBool(Bytes._istitle(this.value));
     }
 
     @org.python.Method(
             __doc__ = "B.isupper() -> bool\n\nReturn True if all cased characters in B are uppercase and there is\nat least one cased character in B, False otherwise."
     )
     public org.python.Object isupper() {
-        return new Bool(Bytes._isupper(this.value));
+        return org.python.types.Bool.getBool(Bytes._isupper(this.value));
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Bytes.java
+++ b/python/common/org/python/types/Bytes.java
@@ -294,33 +294,33 @@ public class Bytes extends org.python.types.Object {
             byte[] other_bytes = (byte[]) ((org.python.types.Bytes) other).value;
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] > other_bytes[i]) {
-                    return org.python.types.Bool.getBool(1);
+                    return org.python.types.Bool.TRUE;
                 }
                 if (this.value[i] < other_bytes[i]) {
-                    return org.python.types.Bool.getBool(0);
+                    return org.python.types.Bool.FALSE;
                 }
             }
             if (this.value.length < other_bytes.length) {
-                return org.python.types.Bool.getBool(0);
+                return org.python.types.Bool.FALSE;
             }
-            return org.python.types.Bool.getBool(1);
+            return org.python.types.Bool.TRUE;
         } else if (other instanceof org.python.types.ByteArray) {
             byte[] other_bytes = (byte[]) ((org.python.types.ByteArray) other).value;
             if (other_bytes == null) {
-                return org.python.types.Bool.getBool(1);
+                return org.python.types.Bool.TRUE;
             }
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] > other_bytes[i]) {
-                    return org.python.types.Bool.getBool(1);
+                    return org.python.types.Bool.TRUE;
                 }
                 if (this.value[i] < other_bytes[i]) {
-                    return org.python.types.Bool.getBool(0);
+                    return org.python.types.Bool.FALSE;
                 }
             }
             if (this.value.length < other_bytes.length) {
-                return org.python.types.Bool.getBool(0);
+                return org.python.types.Bool.FALSE;
             }
-            return org.python.types.Bool.getBool(1);
+            return org.python.types.Bool.TRUE;
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -334,16 +334,16 @@ public class Bytes extends org.python.types.Object {
             byte[] other_bytes = (byte[]) ((org.python.types.Bytes) other).value;
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] > other_bytes[i]) {
-                    return org.python.types.Bool.getBool(1);
+                    return org.python.types.Bool.TRUE;
                 }
                 if (this.value[i] < other_bytes[i]) {
-                    return org.python.types.Bool.getBool(0);
+                    return org.python.types.Bool.FALSE;
                 }
             }
             if (this.value.length <= other_bytes.length) {
-                return org.python.types.Bool.getBool(0);
+                return org.python.types.Bool.FALSE;
             }
-            return org.python.types.Bool.getBool(1);
+            return org.python.types.Bool.TRUE;
         } else if (other instanceof org.python.types.ByteArray) {
             byte[] other_bytes = (byte[]) ((org.python.types.ByteArray) other).value;
             if (other_bytes == null) {
@@ -351,16 +351,16 @@ public class Bytes extends org.python.types.Object {
             }
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] > other_bytes[i]) {
-                    return org.python.types.Bool.getBool(1);
+                    return org.python.types.Bool.TRUE;
                 }
                 if (this.value[i] < other_bytes[i]) {
-                    return org.python.types.Bool.getBool(0);
+                    return org.python.types.Bool.FALSE;
                 }
             }
             if (this.value.length <= other_bytes.length) {
-                return org.python.types.Bool.getBool(0);
+                return org.python.types.Bool.FALSE;
             }
-            return org.python.types.Bool.getBool(1);
+            return org.python.types.Bool.TRUE;
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -374,16 +374,16 @@ public class Bytes extends org.python.types.Object {
             byte[] other_bytes = (byte[]) ((org.python.types.Bytes) other).value;
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] < other_bytes[i]) {
-                    return org.python.types.Bool.getBool(1);
+                    return org.python.types.Bool.TRUE;
                 }
                 if (this.value[i] > other_bytes[i]) {
-                    return org.python.types.Bool.getBool(0);
+                    return org.python.types.Bool.FALSE;
                 }
             }
             if (this.value.length <= other_bytes.length) {
-                return org.python.types.Bool.getBool(1);
+                return org.python.types.Bool.TRUE;
             }
-            return org.python.types.Bool.getBool(0);
+            return org.python.types.Bool.FALSE;
         } else if (other instanceof org.python.types.ByteArray) {
             byte[] other_bytes = (byte[]) ((org.python.types.ByteArray) other).value;
             if (other_bytes == null) {
@@ -391,16 +391,16 @@ public class Bytes extends org.python.types.Object {
             }
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] < other_bytes[i]) {
-                    return org.python.types.Bool.getBool(1);
+                    return org.python.types.Bool.TRUE;
                 }
                 if (this.value[i] > other_bytes[i]) {
-                    return org.python.types.Bool.getBool(0);
+                    return org.python.types.Bool.FALSE;
                 }
             }
             if (this.value.length <= other_bytes.length) {
-                return org.python.types.Bool.getBool(1);
+                return org.python.types.Bool.TRUE;
             }
-            return org.python.types.Bool.getBool(0);
+            return org.python.types.Bool.FALSE;
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -414,33 +414,33 @@ public class Bytes extends org.python.types.Object {
             byte[] other_bytes = (byte[]) ((org.python.types.Bytes) other).value;
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] < other_bytes[i]) {
-                    return org.python.types.Bool.getBool(1);
+                    return org.python.types.Bool.TRUE;
                 }
                 if (this.value[i] > other_bytes[i]) {
-                    return org.python.types.Bool.getBool(0);
+                    return org.python.types.Bool.FALSE;
                 }
             }
             if (this.value.length < other_bytes.length) {
-                return org.python.types.Bool.getBool(1);
+                return org.python.types.Bool.TRUE;
             }
-            return org.python.types.Bool.getBool(0);
+            return org.python.types.Bool.FALSE;
         } else if (other instanceof org.python.types.ByteArray) {
             byte[] other_bytes = (byte[]) ((org.python.types.ByteArray) other).value;
             if (other_bytes == null) {
-                return org.python.types.Bool.getBool(0);
+                return org.python.types.Bool.FALSE;
             }
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] < other_bytes[i]) {
-                    return org.python.types.Bool.getBool(1);
+                    return org.python.types.Bool.TRUE;
                 }
                 if (this.value[i] > other_bytes[i]) {
-                    return org.python.types.Bool.getBool(0);
+                    return org.python.types.Bool.FALSE;
                 }
             }
             if (this.value.length < other_bytes.length) {
-                return org.python.types.Bool.getBool(1);
+                return org.python.types.Bool.TRUE;
             }
-            return org.python.types.Bool.getBool(0);
+            return org.python.types.Bool.FALSE;
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }

--- a/python/common/org/python/types/Bytes.java
+++ b/python/common/org/python/types/Bytes.java
@@ -266,7 +266,7 @@ public class Bytes extends org.python.types.Object {
         int counter_slice = 0;
         for (int i = 0; i < this.value.length + 1; i++) {
             if (counter_slice == bslice.length) {
-                return org.python.types.Bool.getBool(true);
+                return org.python.types.Bool.TRUE;
             } else if (i == this.value.length) {
                 break;
             } else if (bslice[counter_slice] == this.value[i]) {
@@ -275,7 +275,7 @@ public class Bytes extends org.python.types.Object {
                 counter_slice = 0;
             }
         }
-        return org.python.types.Bool.getBool(false);
+        return org.python.types.Bool.FALSE;
     }
 
     @org.python.Method(
@@ -925,15 +925,15 @@ public class Bytes extends org.python.types.Object {
                 }
                 boolean ok = ((org.python.types.Bool) this.endsOrStartsWith(item, null, null, direction)).value;
                 if (ok) {
-                    return org.python.types.Bool.getBool(true);
+                    return org.python.types.Bool.TRUE;
                 }
             }
-            return org.python.types.Bool.getBool(false);
+            return org.python.types.Bool.FALSE;
 
         } else if (substring instanceof Bytes) {
             byte[] substringValue = ((Bytes) substring).value;
             if (substringValue.length > this.value.length) {
-                return org.python.types.Bool.getBool(false);
+                return org.python.types.Bool.FALSE;
             }
 
             int startIndex;

--- a/python/common/org/python/types/Bytes.java
+++ b/python/common/org/python/types/Bytes.java
@@ -164,13 +164,13 @@ public class Bytes extends org.python.types.Object {
     public org.python.Object __eq__(org.python.Object other) {
         if (other instanceof org.python.types.Bytes) {
             byte[] other_value = ((org.python.types.Bytes) other).value;
-            return new org.python.types.Bool(Arrays.equals(this.value, other_value));
+            return org.python.types.Bool.getBool(Arrays.equals(this.value, other_value));
         } else if (other instanceof org.python.types.ByteArray) {
             byte[] other_value = ((org.python.types.ByteArray) other).value;
             if (other_value == null) {
                 other_value = new byte[0];
             }
-            return new org.python.types.Bool(Arrays.equals(this.value, other_value));
+            return org.python.types.Bool.getBool(Arrays.equals(this.value, other_value));
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -236,7 +236,7 @@ public class Bytes extends org.python.types.Object {
             __doc__ = ""
     )
     public org.python.Object __bool__() {
-        return new org.python.types.Bool(this.value.length > 0);
+        return org.python.types.Bool.getBool(this.value.length > 0);
     }
 
     @org.python.Method(
@@ -266,7 +266,7 @@ public class Bytes extends org.python.types.Object {
         int counter_slice = 0;
         for (int i = 0; i < this.value.length + 1; i++) {
             if (counter_slice == bslice.length) {
-                return new org.python.types.Bool(true);
+                return org.python.types.Bool.getBool(true);
             } else if (i == this.value.length) {
                 break;
             } else if (bslice[counter_slice] == this.value[i]) {
@@ -275,7 +275,7 @@ public class Bytes extends org.python.types.Object {
                 counter_slice = 0;
             }
         }
-        return new org.python.types.Bool(false);
+        return org.python.types.Bool.getBool(false);
     }
 
     @org.python.Method(
@@ -294,33 +294,33 @@ public class Bytes extends org.python.types.Object {
             byte[] other_bytes = (byte[]) ((org.python.types.Bytes) other).value;
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] > other_bytes[i]) {
-                    return new org.python.types.Bool(1);
+                    return org.python.types.Bool.getBool(1);
                 }
                 if (this.value[i] < other_bytes[i]) {
-                    return new org.python.types.Bool(0);
+                    return org.python.types.Bool.getBool(0);
                 }
             }
             if (this.value.length < other_bytes.length) {
-                return new org.python.types.Bool(0);
+                return org.python.types.Bool.getBool(0);
             }
-            return new org.python.types.Bool(1);
+            return org.python.types.Bool.getBool(1);
         } else if (other instanceof org.python.types.ByteArray) {
             byte[] other_bytes = (byte[]) ((org.python.types.ByteArray) other).value;
             if (other_bytes == null) {
-                return new org.python.types.Bool(1);
+                return org.python.types.Bool.getBool(1);
             }
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] > other_bytes[i]) {
-                    return new org.python.types.Bool(1);
+                    return org.python.types.Bool.getBool(1);
                 }
                 if (this.value[i] < other_bytes[i]) {
-                    return new org.python.types.Bool(0);
+                    return org.python.types.Bool.getBool(0);
                 }
             }
             if (this.value.length < other_bytes.length) {
-                return new org.python.types.Bool(0);
+                return org.python.types.Bool.getBool(0);
             }
-            return new org.python.types.Bool(1);
+            return org.python.types.Bool.getBool(1);
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -334,16 +334,16 @@ public class Bytes extends org.python.types.Object {
             byte[] other_bytes = (byte[]) ((org.python.types.Bytes) other).value;
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] > other_bytes[i]) {
-                    return new org.python.types.Bool(1);
+                    return org.python.types.Bool.getBool(1);
                 }
                 if (this.value[i] < other_bytes[i]) {
-                    return new org.python.types.Bool(0);
+                    return org.python.types.Bool.getBool(0);
                 }
             }
             if (this.value.length <= other_bytes.length) {
-                return new org.python.types.Bool(0);
+                return org.python.types.Bool.getBool(0);
             }
-            return new org.python.types.Bool(1);
+            return org.python.types.Bool.getBool(1);
         } else if (other instanceof org.python.types.ByteArray) {
             byte[] other_bytes = (byte[]) ((org.python.types.ByteArray) other).value;
             if (other_bytes == null) {
@@ -351,16 +351,16 @@ public class Bytes extends org.python.types.Object {
             }
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] > other_bytes[i]) {
-                    return new org.python.types.Bool(1);
+                    return org.python.types.Bool.getBool(1);
                 }
                 if (this.value[i] < other_bytes[i]) {
-                    return new org.python.types.Bool(0);
+                    return org.python.types.Bool.getBool(0);
                 }
             }
             if (this.value.length <= other_bytes.length) {
-                return new org.python.types.Bool(0);
+                return org.python.types.Bool.getBool(0);
             }
-            return new org.python.types.Bool(1);
+            return org.python.types.Bool.getBool(1);
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -374,16 +374,16 @@ public class Bytes extends org.python.types.Object {
             byte[] other_bytes = (byte[]) ((org.python.types.Bytes) other).value;
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] < other_bytes[i]) {
-                    return new org.python.types.Bool(1);
+                    return org.python.types.Bool.getBool(1);
                 }
                 if (this.value[i] > other_bytes[i]) {
-                    return new org.python.types.Bool(0);
+                    return org.python.types.Bool.getBool(0);
                 }
             }
             if (this.value.length <= other_bytes.length) {
-                return new org.python.types.Bool(1);
+                return org.python.types.Bool.getBool(1);
             }
-            return new org.python.types.Bool(0);
+            return org.python.types.Bool.getBool(0);
         } else if (other instanceof org.python.types.ByteArray) {
             byte[] other_bytes = (byte[]) ((org.python.types.ByteArray) other).value;
             if (other_bytes == null) {
@@ -391,16 +391,16 @@ public class Bytes extends org.python.types.Object {
             }
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] < other_bytes[i]) {
-                    return new org.python.types.Bool(1);
+                    return org.python.types.Bool.getBool(1);
                 }
                 if (this.value[i] > other_bytes[i]) {
-                    return new org.python.types.Bool(0);
+                    return org.python.types.Bool.getBool(0);
                 }
             }
             if (this.value.length <= other_bytes.length) {
-                return new org.python.types.Bool(1);
+                return org.python.types.Bool.getBool(1);
             }
-            return new org.python.types.Bool(0);
+            return org.python.types.Bool.getBool(0);
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -414,33 +414,33 @@ public class Bytes extends org.python.types.Object {
             byte[] other_bytes = (byte[]) ((org.python.types.Bytes) other).value;
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] < other_bytes[i]) {
-                    return new org.python.types.Bool(1);
+                    return org.python.types.Bool.getBool(1);
                 }
                 if (this.value[i] > other_bytes[i]) {
-                    return new org.python.types.Bool(0);
+                    return org.python.types.Bool.getBool(0);
                 }
             }
             if (this.value.length < other_bytes.length) {
-                return new org.python.types.Bool(1);
+                return org.python.types.Bool.getBool(1);
             }
-            return new org.python.types.Bool(0);
+            return org.python.types.Bool.getBool(0);
         } else if (other instanceof org.python.types.ByteArray) {
             byte[] other_bytes = (byte[]) ((org.python.types.ByteArray) other).value;
             if (other_bytes == null) {
-                return new org.python.types.Bool(0);
+                return org.python.types.Bool.getBool(0);
             }
             for (int i = 0; i < Math.min(this.value.length, other_bytes.length); i++) {
                 if (this.value[i] < other_bytes[i]) {
-                    return new org.python.types.Bool(1);
+                    return org.python.types.Bool.getBool(1);
                 }
                 if (this.value[i] > other_bytes[i]) {
-                    return new org.python.types.Bool(0);
+                    return org.python.types.Bool.getBool(0);
                 }
             }
             if (this.value.length < other_bytes.length) {
-                return new org.python.types.Bool(1);
+                return org.python.types.Bool.getBool(1);
             }
-            return new org.python.types.Bool(0);
+            return org.python.types.Bool.getBool(0);
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -925,15 +925,15 @@ public class Bytes extends org.python.types.Object {
                 }
                 boolean ok = ((org.python.types.Bool) this.endsOrStartsWith(item, null, null, direction)).value;
                 if (ok) {
-                    return new org.python.types.Bool(true);
+                    return org.python.types.Bool.getBool(true);
                 }
             }
-            return new org.python.types.Bool(false);
+            return org.python.types.Bool.getBool(false);
 
         } else if (substring instanceof Bytes) {
             byte[] substringValue = ((Bytes) substring).value;
             if (substringValue.length > this.value.length) {
-                return new org.python.types.Bool(false);
+                return org.python.types.Bool.getBool(false);
             }
 
             int startIndex;
@@ -949,7 +949,7 @@ public class Bytes extends org.python.types.Object {
 
             byte[] thisValuePart = Arrays.copyOfRange(this.value, startIndex, endIndex);
             boolean ok = Arrays.equals(thisValuePart, substringValue);
-            return new org.python.types.Bool(ok);
+            return org.python.types.Bool.getBool(ok);
         } else {
             String methodName;
             if (direction < 0) {
@@ -1101,7 +1101,7 @@ public class Bytes extends org.python.types.Object {
             __doc__ = "B.isalnum() -> bool\n\nReturn True if all characters in B are alphanumeric\nand there is at least one character in B, False otherwise."
     )
     public org.python.Object isalnum() {
-        return new Bool(_isalnum(this.value));
+        return org.python.types.Bool.getBool(_isalnum(this.value));
     }
 
     public static boolean _isalpha(byte[] input) {
@@ -1124,7 +1124,7 @@ public class Bytes extends org.python.types.Object {
             __doc__ = "B.isalpha() -> bool\n\nReturn True if all characters in B are alphabetic\nand there is at least one character in B, False otherwise."
     )
     public org.python.Object isalpha() {
-        return new Bool(_isalpha(this.value));
+        return org.python.types.Bool.getBool(_isalpha(this.value));
     }
 
     public static boolean _isdigit(byte ch) {
@@ -1150,7 +1150,7 @@ public class Bytes extends org.python.types.Object {
             __doc__ = "B.isdigit() -> bool\n\nReturn True if all characters in B are digits\nand there is at least one character in B, False otherwise."
     )
     public org.python.Object isdigit() {
-        return new Bool(_isdigit(this.value));
+        return org.python.types.Bool.getBool(_isdigit(this.value));
     }
 
     public static boolean _islower(byte[] input) {
@@ -1171,7 +1171,7 @@ public class Bytes extends org.python.types.Object {
             __doc__ = "B.islower() -> bool\n\nReturn True if all cased characters in B are lowercase and there is\nat least one cased character in B, False otherwise."
     )
     public org.python.Object islower() {
-        return new Bool(_islower(this.value));
+        return org.python.types.Bool.getBool(_islower(this.value));
     }
 
     public static boolean _isspace(byte[] input) {
@@ -1191,7 +1191,7 @@ public class Bytes extends org.python.types.Object {
             __doc__ = "B.isspace() -> bool\n\nReturn True if all characters in B are whitespace\nand there is at least one character in B, False otherwise."
     )
     public org.python.Object isspace() {
-        return new Bool(_isspace(this.value));
+        return org.python.types.Bool.getBool(_isspace(this.value));
     }
 
     public static boolean _istitle(byte[] input) {
@@ -1214,7 +1214,7 @@ public class Bytes extends org.python.types.Object {
             __doc__ = "B.istitle() -> bool\n\nReturn True if B is a titlecased string and there is at least one\ncharacter in B, i.e. uppercase characters may only follow uncased\ncharacters and lowercase characters only cased ones. Return False\notherwise."
     )
     public org.python.Object istitle() {
-        return new org.python.types.Bool(_istitle(this.value));
+        return org.python.types.Bool.getBool(_istitle(this.value));
     }
 
     public static boolean _isupper(byte[] input) {
@@ -1235,7 +1235,7 @@ public class Bytes extends org.python.types.Object {
             __doc__ = "B.isupper() -> bool\n\nReturn True if all cased characters in B are uppercase and there is\nat least one cased character in B, False otherwise."
     )
     public org.python.Object isupper() {
-        return new Bool(_isupper(this.value));
+        return org.python.types.Bool.getBool(_isupper(this.value));
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Complex.java
+++ b/python/common/org/python/types/Complex.java
@@ -219,12 +219,12 @@ public class Complex extends org.python.types.Object {
     public org.python.Object __eq__(org.python.Object other) {
         if (other instanceof org.python.types.Complex) {
             org.python.types.Complex other_obj = (org.python.types.Complex) other;
-            return new org.python.types.Bool(
+            return org.python.types.Bool.getBool(
                     ((org.python.types.Bool) this.real.__eq__(other_obj.real)).value
                     && ((org.python.types.Bool) this.imag.__eq__(other_obj.imag)).value);
         } else if (other instanceof org.python.types.Float || other instanceof org.python.types.Int
                 || other instanceof org.python.types.Bool) {
-            return new org.python.types.Bool(
+            return org.python.types.Bool.getBool(
                     ((org.python.types.Bool) this.real.__eq__(other)).value
                     && ((org.python.types.Bool) this.imag.__eq__(new org.python.types.Int(0))).value);
         }
@@ -252,7 +252,7 @@ public class Complex extends org.python.types.Object {
     )
     public org.python.types.Bool __bool__() {
         // A complex number is "truthy" if either its real component or imaginary component are > 0
-        return new org.python.types.Bool((this.real.value != 0.0) || (this.imag.value != 0.0));
+        return org.python.types.Bool.getBool((this.real.value != 0.0) || (this.imag.value != 0.0));
     }
 
     public boolean __setattr_null(java.lang.String name, org.python.Object value) {

--- a/python/common/org/python/types/Dict.java
+++ b/python/common/org/python/types/Dict.java
@@ -322,9 +322,9 @@ public class Dict extends org.python.types.Object {
         // allow unhashable type error to be percolated up.
         try {
             __getitem__(item);
-            return org.python.types.Bool.getBool(true);
+            return org.python.types.Bool.TRUE;
         } catch (org.python.exceptions.KeyError e) {
-            return org.python.types.Bool.getBool(false);
+            return org.python.types.Bool.FALSE;
         }
     }
 
@@ -336,9 +336,9 @@ public class Dict extends org.python.types.Object {
         // allow unhashable type error to be percolated up.
         try {
             __getitem__(item);
-            return org.python.types.Bool.getBool(false);
+            return org.python.types.Bool.FALSE;
         } catch (org.python.exceptions.KeyError e) {
-            return org.python.types.Bool.getBool(true);
+            return org.python.types.Bool.TRUE;
         }
     }
 

--- a/python/common/org/python/types/Dict.java
+++ b/python/common/org/python/types/Dict.java
@@ -172,7 +172,7 @@ public class Dict extends org.python.types.Object {
             __doc__ = ""
     )
     public org.python.Object __bool__() {
-        return new org.python.types.Bool(!this.value.isEmpty());
+        return org.python.types.Bool.getBool(!this.value.isEmpty());
     }
 
     @org.python.Method(
@@ -198,7 +198,7 @@ public class Dict extends org.python.types.Object {
     public org.python.Object __eq__(org.python.Object other) {
         if (other instanceof org.python.types.Dict) {
             org.python.types.Dict otherDict = (org.python.types.Dict) other;
-            return new org.python.types.Bool(this.value.equals(otherDict.value));
+            return org.python.types.Bool.getBool(this.value.equals(otherDict.value));
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -322,9 +322,9 @@ public class Dict extends org.python.types.Object {
         // allow unhashable type error to be percolated up.
         try {
             __getitem__(item);
-            return new org.python.types.Bool(true);
+            return org.python.types.Bool.getBool(true);
         } catch (org.python.exceptions.KeyError e) {
-            return new org.python.types.Bool(false);
+            return org.python.types.Bool.getBool(false);
         }
     }
 
@@ -336,9 +336,9 @@ public class Dict extends org.python.types.Object {
         // allow unhashable type error to be percolated up.
         try {
             __getitem__(item);
-            return new org.python.types.Bool(false);
+            return org.python.types.Bool.getBool(false);
         } catch (org.python.exceptions.KeyError e) {
-            return new org.python.types.Bool(true);
+            return org.python.types.Bool.getBool(true);
         }
     }
 

--- a/python/common/org/python/types/Float.java
+++ b/python/common/org/python/types/Float.java
@@ -137,15 +137,15 @@ public class Float extends org.python.types.Object {
     public org.python.Object __lt__(org.python.Object other) {
         if (other instanceof org.python.types.Int) {
             long other_val = ((org.python.types.Int) other).value;
-            return new org.python.types.Bool(this.value < ((double) other_val));
+            return org.python.types.Bool.getBool(this.value < ((double) other_val));
         } else if (other instanceof org.python.types.Float) {
             double other_val = ((org.python.types.Float) other).value;
-            return new org.python.types.Bool(this.value < other_val);
+            return org.python.types.Bool.getBool(this.value < other_val);
         } else if (other instanceof org.python.types.Bool) {
             if (((org.python.types.Bool) other).value) {
-                return new org.python.types.Bool(this.value < 1.0);
+                return org.python.types.Bool.getBool(this.value < 1.0);
             } else {
-                return new org.python.types.Bool(this.value < 0.0);
+                return org.python.types.Bool.getBool(this.value < 0.0);
             }
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
@@ -158,15 +158,15 @@ public class Float extends org.python.types.Object {
     public org.python.Object __le__(org.python.Object other) {
         if (other instanceof org.python.types.Int) {
             long other_val = ((org.python.types.Int) other).value;
-            return new org.python.types.Bool(this.value <= ((double) other_val));
+            return org.python.types.Bool.getBool(this.value <= ((double) other_val));
         } else if (other instanceof org.python.types.Float) {
             double other_val = ((org.python.types.Float) other).value;
-            return new org.python.types.Bool(this.value <= other_val);
+            return org.python.types.Bool.getBool(this.value <= other_val);
         } else if (other instanceof org.python.types.Bool) {
             if (((org.python.types.Bool) other).value) {
-                return new org.python.types.Bool(this.value <= 1.0);
+                return org.python.types.Bool.getBool(this.value <= 1.0);
             } else {
-                return new org.python.types.Bool(this.value <= 0.0);
+                return org.python.types.Bool.getBool(this.value <= 0.0);
             }
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
@@ -178,14 +178,14 @@ public class Float extends org.python.types.Object {
     )
     public org.python.Object __eq__(org.python.Object other) {
         if (other instanceof org.python.types.Int) {
-            return new org.python.types.Bool(this.value == ((double) ((org.python.types.Int) other).value));
+            return org.python.types.Bool.getBool(this.value == ((double) ((org.python.types.Int) other).value));
         } else if (other instanceof org.python.types.Float) {
-            return new org.python.types.Bool(this.value == ((org.python.types.Float) other).value);
+            return org.python.types.Bool.getBool(this.value == ((org.python.types.Float) other).value);
         } else if (other instanceof org.python.types.Bool) {
             if (((org.python.types.Bool) other).value) {
-                return new org.python.types.Bool(this.value == 1.0);
+                return org.python.types.Bool.getBool(this.value == 1.0);
             } else {
-                return new org.python.types.Bool(this.value == 0.0);
+                return org.python.types.Bool.getBool(this.value == 0.0);
             }
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
@@ -198,15 +198,15 @@ public class Float extends org.python.types.Object {
     public org.python.Object __gt__(org.python.Object other) {
         if (other instanceof org.python.types.Int) {
             long other_val = ((org.python.types.Int) other).value;
-            return new org.python.types.Bool(this.value > ((double) other_val));
+            return org.python.types.Bool.getBool(this.value > ((double) other_val));
         } else if (other instanceof org.python.types.Float) {
             double other_val = ((org.python.types.Float) other).value;
-            return new org.python.types.Bool(this.value > other_val);
+            return org.python.types.Bool.getBool(this.value > other_val);
         } else if (other instanceof org.python.types.Bool) {
             if (((org.python.types.Bool) other).value) {
-                return new org.python.types.Bool(this.value > 1.0);
+                return org.python.types.Bool.getBool(this.value > 1.0);
             } else {
-                return new org.python.types.Bool(this.value > 0.0);
+                return org.python.types.Bool.getBool(this.value > 0.0);
             }
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
@@ -219,15 +219,15 @@ public class Float extends org.python.types.Object {
     public org.python.Object __ge__(org.python.Object other) {
         if (other instanceof org.python.types.Int) {
             long other_val = ((org.python.types.Int) other).value;
-            return new org.python.types.Bool(this.value >= ((double) other_val));
+            return org.python.types.Bool.getBool(this.value >= ((double) other_val));
         } else if (other instanceof org.python.types.Float) {
             double other_val = ((org.python.types.Float) other).value;
-            return new org.python.types.Bool(this.value >= other_val);
+            return org.python.types.Bool.getBool(this.value >= other_val);
         } else if (other instanceof org.python.types.Bool) {
             if (((org.python.types.Bool) other).value) {
-                return new org.python.types.Bool(this.value >= 1.0);
+                return org.python.types.Bool.getBool(this.value >= 1.0);
             } else {
-                return new org.python.types.Bool(this.value >= 0.0);
+                return org.python.types.Bool.getBool(this.value >= 0.0);
             }
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
@@ -237,7 +237,7 @@ public class Float extends org.python.types.Object {
             __doc__ = "self != 0"
     )
     public org.python.types.Bool __bool__() {
-        return new org.python.types.Bool(this.value != 0.0);
+        return org.python.types.Bool.getBool(this.value != 0.0);
     }
 
     public boolean __setattr_null(java.lang.String name, org.python.Object value) {
@@ -674,9 +674,9 @@ public class Float extends org.python.types.Object {
     )
     public org.python.Object is_integer() {
         if (this.value == Math.floor(this.value) && !Double.isInfinite(this.value)) {
-            return new org.python.types.Bool(true);
+            return org.python.types.Bool.getBool(true);
         }
-        return new org.python.types.Bool(false);
+        return org.python.types.Bool.getBool(false);
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Float.java
+++ b/python/common/org/python/types/Float.java
@@ -674,9 +674,9 @@ public class Float extends org.python.types.Object {
     )
     public org.python.Object is_integer() {
         if (this.value == Math.floor(this.value) && !Double.isInfinite(this.value)) {
-            return org.python.types.Bool.getBool(true);
+            return org.python.types.Bool.TRUE;
         }
-        return org.python.types.Bool.getBool(false);
+        return org.python.types.Bool.FALSE;
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/FrozenSet.java
+++ b/python/common/org/python/types/FrozenSet.java
@@ -103,7 +103,7 @@ public class FrozenSet extends org.python.types.Object {
             __doc__ = ""
     )
     public org.python.types.Bool __bool__() {
-        return new org.python.types.Bool(this.value.size() > 0);
+        return org.python.types.Bool.getBool(this.value.size() > 0);
     }
 
     @org.python.Method(
@@ -142,7 +142,7 @@ public class FrozenSet extends org.python.types.Object {
             args = {"item"}
     )
     public org.python.Object __contains__(org.python.Object other) {
-        return new org.python.types.Bool(this.value.contains(other));
+        return org.python.types.Bool.getBool(this.value.contains(other));
     }
 
     @org.python.Method(
@@ -150,7 +150,7 @@ public class FrozenSet extends org.python.types.Object {
             args = {"item"}
     )
     public org.python.Object __not_contains__(org.python.Object other) {
-        return new org.python.types.Bool(!this.value.contains(other));
+        return org.python.types.Bool.getBool(!this.value.contains(other));
     }
 
     @org.python.Method(
@@ -167,10 +167,10 @@ public class FrozenSet extends org.python.types.Object {
     public org.python.Object __lt__(org.python.Object other) {
         if (other instanceof org.python.types.FrozenSet) {
             org.python.types.FrozenSet otherSet = (org.python.types.FrozenSet) other;
-            return new org.python.types.Bool(otherSet.value.containsAll(this.value) && !this.value.equals(otherSet.value));
+            return org.python.types.Bool.getBool(otherSet.value.containsAll(this.value) && !this.value.equals(otherSet.value));
         } else if (other instanceof org.python.types.Set) {
             org.python.types.Set otherSet = (org.python.types.Set) other;
-            return new org.python.types.Bool(otherSet.value.containsAll(this.value) && !this.value.equals(otherSet.value));
+            return org.python.types.Bool.getBool(otherSet.value.containsAll(this.value) && !this.value.equals(otherSet.value));
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -182,10 +182,10 @@ public class FrozenSet extends org.python.types.Object {
     public org.python.Object __le__(org.python.Object other) {
         if (other instanceof org.python.types.FrozenSet) {
             org.python.types.FrozenSet otherSet = (org.python.types.FrozenSet) other;
-            return new org.python.types.Bool(otherSet.value.containsAll(this.value));
+            return org.python.types.Bool.getBool(otherSet.value.containsAll(this.value));
         } else if (other instanceof org.python.types.Set) {
             org.python.types.Set otherSet = (org.python.types.Set) other;
-            return new org.python.types.Bool(otherSet.value.containsAll(this.value));
+            return org.python.types.Bool.getBool(otherSet.value.containsAll(this.value));
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -197,10 +197,10 @@ public class FrozenSet extends org.python.types.Object {
     public org.python.Object __eq__(org.python.Object other) {
         if (other instanceof org.python.types.FrozenSet) {
             org.python.types.FrozenSet otherSet = (org.python.types.FrozenSet) other;
-            return new org.python.types.Bool(this.value.equals(otherSet.value));
+            return org.python.types.Bool.getBool(this.value.equals(otherSet.value));
         } else if (other instanceof org.python.types.Set) {
             org.python.types.Set otherSet = (org.python.types.Set) other;
-            return new org.python.types.Bool(this.value.equals(otherSet.value));
+            return org.python.types.Bool.getBool(this.value.equals(otherSet.value));
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -212,10 +212,10 @@ public class FrozenSet extends org.python.types.Object {
     public org.python.Object __gt__(org.python.Object other) {
         if (other instanceof org.python.types.FrozenSet) {
             org.python.types.FrozenSet otherSet = (org.python.types.FrozenSet) other;
-            return new org.python.types.Bool(this.value.containsAll(otherSet.value) && !this.value.equals(otherSet.value));
+            return org.python.types.Bool.getBool(this.value.containsAll(otherSet.value) && !this.value.equals(otherSet.value));
         } else if (other instanceof org.python.types.Set) {
             org.python.types.Set otherSet = (org.python.types.Set) other;
-            return new org.python.types.Bool(this.value.containsAll(otherSet.value) && !this.value.equals(otherSet.value));
+            return org.python.types.Bool.getBool(this.value.containsAll(otherSet.value) && !this.value.equals(otherSet.value));
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -227,10 +227,10 @@ public class FrozenSet extends org.python.types.Object {
     public org.python.Object __ge__(org.python.Object other) {
         if (other instanceof org.python.types.FrozenSet) {
             org.python.types.FrozenSet otherSet = (org.python.types.FrozenSet) other;
-            return new org.python.types.Bool(this.value.containsAll(otherSet.value));
+            return org.python.types.Bool.getBool(this.value.containsAll(otherSet.value));
         } else if (other instanceof org.python.types.Set) {
             org.python.types.Set otherSet = (org.python.types.Set) other;
-            return new org.python.types.Bool(this.value.containsAll(otherSet.value));
+            return org.python.types.Bool.getBool(this.value.containsAll(otherSet.value));
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -346,9 +346,9 @@ public class FrozenSet extends org.python.types.Object {
             }
             org.python.types.FrozenSet temp = (org.python.types.FrozenSet) this.__and__(other);
             if (temp.__len__().value > 0) {
-                return new org.python.types.Bool(false);
+                return org.python.types.Bool.getBool(false);
             } else {
-                return new org.python.types.Bool(true);
+                return org.python.types.Bool.getBool(true);
             }
         } catch (org.python.exceptions.AttributeError e) {
             throw new org.python.exceptions.TypeError("'" + other.typeName() + "' object is not iterable");

--- a/python/common/org/python/types/FrozenSet.java
+++ b/python/common/org/python/types/FrozenSet.java
@@ -346,9 +346,9 @@ public class FrozenSet extends org.python.types.Object {
             }
             org.python.types.FrozenSet temp = (org.python.types.FrozenSet) this.__and__(other);
             if (temp.__len__().value > 0) {
-                return org.python.types.Bool.getBool(false);
+                return org.python.types.Bool.FALSE;
             } else {
-                return org.python.types.Bool.getBool(true);
+                return org.python.types.Bool.TRUE;
             }
         } catch (org.python.exceptions.AttributeError e) {
             throw new org.python.exceptions.TypeError("'" + other.typeName() + "' object is not iterable");

--- a/python/common/org/python/types/Function.java
+++ b/python/common/org/python/types/Function.java
@@ -176,7 +176,7 @@ public class Function extends org.python.types.Object implements org.python.Call
             __doc__ = ""
     )
     public org.python.Object __bool__() {
-        return org.python.types.Bool.getBool(true);
+        return org.python.types.Bool.TRUE;
     }
 
     private void checkMissingArgs(int requiredArgs, int passedArgs, java.util.Map<java.lang.String, org.python.Object> kwargs, java.util.List<org.python.Object> varnames, int first_arg) {

--- a/python/common/org/python/types/Function.java
+++ b/python/common/org/python/types/Function.java
@@ -176,7 +176,7 @@ public class Function extends org.python.types.Object implements org.python.Call
             __doc__ = ""
     )
     public org.python.Object __bool__() {
-        return new org.python.types.Bool(true);
+        return org.python.types.Bool.getBool(true);
     }
 
     private void checkMissingArgs(int requiredArgs, int passedArgs, java.util.Map<java.lang.String, org.python.Object> kwargs, java.util.List<org.python.Object> varnames, int first_arg) {

--- a/python/common/org/python/types/Int.java
+++ b/python/common/org/python/types/Int.java
@@ -118,9 +118,9 @@ public class Int extends org.python.types.Object {
     )
     public org.python.Object __lt__(org.python.Object other) {
         if (other instanceof org.python.types.Int) {
-            return new org.python.types.Bool(this.value < ((org.python.types.Int) other).value);
+            return org.python.types.Bool.getBool(this.value < ((org.python.types.Int) other).value);
         } else if (other instanceof org.python.types.Bool) {
-            return new org.python.types.Bool(((double) this.value) < (((org.python.types.Bool) other).value ? 1 : 0));
+            return org.python.types.Bool.getBool(((double) this.value) < (((org.python.types.Bool) other).value ? 1 : 0));
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -131,9 +131,9 @@ public class Int extends org.python.types.Object {
     )
     public org.python.Object __le__(org.python.Object other) {
         if (other instanceof org.python.types.Int) {
-            return new org.python.types.Bool(this.value <= ((org.python.types.Int) other).value);
+            return org.python.types.Bool.getBool(this.value <= ((org.python.types.Int) other).value);
         } else if (other instanceof org.python.types.Bool) {
-            return new org.python.types.Bool(((double) this.value) <= (((org.python.types.Bool) other).value ? 1 : 0));
+            return org.python.types.Bool.getBool(((double) this.value) <= (((org.python.types.Bool) other).value ? 1 : 0));
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -144,16 +144,16 @@ public class Int extends org.python.types.Object {
     )
     public org.python.Object __eq__(org.python.Object other) {
         if (other instanceof org.python.types.Int) {
-            return new org.python.types.Bool(this.value == ((org.python.types.Int) other).value);
+            return org.python.types.Bool.getBool(this.value == ((org.python.types.Int) other).value);
         } else if (other instanceof org.python.types.Bool) {
             org.python.types.Bool temp = (org.python.types.Bool) other;
             if (this.value == 1 && temp.value) {
-                return new org.python.types.Bool(1);
+                return org.python.types.Bool.getBool(1);
             }
             if (this.value == 0 && !temp.value) {
-                return new org.python.types.Bool(1);
+                return org.python.types.Bool.getBool(1);
             }
-            return new org.python.types.Bool(0);
+            return org.python.types.Bool.getBool(0);
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -164,9 +164,9 @@ public class Int extends org.python.types.Object {
     )
     public org.python.Object __gt__(org.python.Object other) {
         if (other instanceof org.python.types.Int) {
-            return new org.python.types.Bool(this.value > ((org.python.types.Int) other).value);
+            return org.python.types.Bool.getBool(this.value > ((org.python.types.Int) other).value);
         } else if (other instanceof org.python.types.Bool) {
-            return new org.python.types.Bool(((double) this.value) > (((org.python.types.Bool) other).value ? 1 : 0));
+            return org.python.types.Bool.getBool(((double) this.value) > (((org.python.types.Bool) other).value ? 1 : 0));
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -177,9 +177,9 @@ public class Int extends org.python.types.Object {
     )
     public org.python.Object __ge__(org.python.Object other) {
         if (other instanceof org.python.types.Int) {
-            return new org.python.types.Bool(this.value >= ((org.python.types.Int) other).value);
+            return org.python.types.Bool.getBool(this.value >= ((org.python.types.Int) other).value);
         } else if (other instanceof org.python.types.Bool) {
-            return new org.python.types.Bool(((double) this.value) >= (((org.python.types.Bool) other).value ? 1 : 0));
+            return org.python.types.Bool.getBool(((double) this.value) >= (((org.python.types.Bool) other).value ? 1 : 0));
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -188,7 +188,7 @@ public class Int extends org.python.types.Object {
             __doc__ = "self != 0"
     )
     public org.python.types.Bool __bool__() {
-        return new org.python.types.Bool(this.value);
+        return org.python.types.Bool.getBool(this.value);
     }
 
     public boolean __setattr_null(java.lang.String name, org.python.Object value) {

--- a/python/common/org/python/types/Int.java
+++ b/python/common/org/python/types/Int.java
@@ -148,12 +148,12 @@ public class Int extends org.python.types.Object {
         } else if (other instanceof org.python.types.Bool) {
             org.python.types.Bool temp = (org.python.types.Bool) other;
             if (this.value == 1 && temp.value) {
-                return org.python.types.Bool.getBool(1);
+                return org.python.types.Bool.TRUE;
             }
             if (this.value == 0 && !temp.value) {
-                return org.python.types.Bool.getBool(1);
+                return org.python.types.Bool.TRUE;
             }
-            return org.python.types.Bool.getBool(0);
+            return org.python.types.Bool.FALSE;
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }

--- a/python/common/org/python/types/List.java
+++ b/python/common/org/python/types/List.java
@@ -156,7 +156,7 @@ public class List extends org.python.types.Object {
             __doc__ = ""
     )
     public org.python.Object __bool__() {
-        return new org.python.types.Bool(!this.value.isEmpty());
+        return org.python.types.Bool.getBool(!this.value.isEmpty());
     }
 
     @org.python.Method(
@@ -212,7 +212,7 @@ public class List extends org.python.types.Object {
             }
 
             // all items were identical, break tie by size
-            return new org.python.types.Bool(size < otherSize);
+            return org.python.types.Bool.getBool(size < otherSize);
         } else {
             return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
         }
@@ -246,7 +246,7 @@ public class List extends org.python.types.Object {
             }
 
             // all items were identical, break tie by size
-            return new org.python.types.Bool(size <= otherSize);
+            return org.python.types.Bool.getBool(size <= otherSize);
         } else {
             return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
         }
@@ -259,7 +259,7 @@ public class List extends org.python.types.Object {
     public org.python.Object __eq__(org.python.Object other) {
         if (other instanceof org.python.types.List) {
             org.python.types.List otherList = (org.python.types.List) other;
-            return new org.python.types.Bool(this.value.equals(otherList.value));
+            return org.python.types.Bool.getBool(this.value.equals(otherList.value));
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -292,7 +292,7 @@ public class List extends org.python.types.Object {
             }
 
             // all items were identical, break tie by size
-            return new org.python.types.Bool(size > otherSize);
+            return org.python.types.Bool.getBool(size > otherSize);
         } else {
             return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
         }
@@ -326,7 +326,7 @@ public class List extends org.python.types.Object {
             }
 
             // all items were identical, break tie by size
-            return new org.python.types.Bool(size >= otherSize);
+            return org.python.types.Bool.getBool(size >= otherSize);
         } else {
             return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
         }
@@ -559,7 +559,7 @@ public class List extends org.python.types.Object {
                 break;
             }
         }
-        return new org.python.types.Bool(found);
+        return org.python.types.Bool.getBool(found);
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Method.java
+++ b/python/common/org/python/types/Method.java
@@ -39,7 +39,7 @@ public class Method extends org.python.types.Object implements org.python.Callab
             __doc__ = ""
     )
     public org.python.Object __bool__() {
-        return new org.python.types.Bool(true);
+        return org.python.types.Bool.getBool(true);
     }
 
     public org.python.Object invoke(org.python.Object[] args, java.util.Map<java.lang.String, org.python.Object> kwargs) {

--- a/python/common/org/python/types/Method.java
+++ b/python/common/org/python/types/Method.java
@@ -39,7 +39,7 @@ public class Method extends org.python.types.Object implements org.python.Callab
             __doc__ = ""
     )
     public org.python.Object __bool__() {
-        return org.python.types.Bool.getBool(true);
+        return org.python.types.Bool.TRUE;
     }
 
     public org.python.Object invoke(org.python.Object[] args, java.util.Map<java.lang.String, org.python.Object> kwargs) {

--- a/python/common/org/python/types/NoneType.java
+++ b/python/common/org/python/types/NoneType.java
@@ -48,7 +48,7 @@ public class NoneType extends org.python.types.Object {
             __doc__ = ""
     )
     public org.python.Object __bool__() {
-        return org.python.types.Bool.getBool(false);
+        return org.python.types.Bool.FALSE;
     }
 
     @org.python.Method(
@@ -73,7 +73,7 @@ public class NoneType extends org.python.types.Object {
     )
     public org.python.Object __eq__(org.python.Object other) {
         if (other instanceof org.python.types.NoneType) {
-            return org.python.types.Bool.getBool(true);
+            return org.python.types.Bool.TRUE;
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }

--- a/python/common/org/python/types/NoneType.java
+++ b/python/common/org/python/types/NoneType.java
@@ -48,7 +48,7 @@ public class NoneType extends org.python.types.Object {
             __doc__ = ""
     )
     public org.python.Object __bool__() {
-        return new org.python.types.Bool(false);
+        return org.python.types.Bool.getBool(false);
     }
 
     @org.python.Method(
@@ -73,7 +73,7 @@ public class NoneType extends org.python.types.Object {
     )
     public org.python.Object __eq__(org.python.Object other) {
         if (other instanceof org.python.types.NoneType) {
-            return new org.python.types.Bool(true);
+            return org.python.types.Bool.getBool(true);
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }

--- a/python/common/org/python/types/NotImplementedType.java
+++ b/python/common/org/python/types/NotImplementedType.java
@@ -47,7 +47,7 @@ public class NotImplementedType extends org.python.types.Object {
             __doc__ = ""
     )
     public org.python.types.Bool __bool__() {
-        return new org.python.types.Bool(true);
+        return org.python.types.Bool.getBool(true);
     }
 
     @org.python.Method(
@@ -72,7 +72,7 @@ public class NotImplementedType extends org.python.types.Object {
     )
     public org.python.Object __eq__(org.python.Object other) {
         if (other instanceof org.python.types.NotImplementedType) {
-            return new org.python.types.Bool(true);
+            return org.python.types.Bool.getBool(true);
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }

--- a/python/common/org/python/types/NotImplementedType.java
+++ b/python/common/org/python/types/NotImplementedType.java
@@ -47,7 +47,7 @@ public class NotImplementedType extends org.python.types.Object {
             __doc__ = ""
     )
     public org.python.types.Bool __bool__() {
-        return org.python.types.Bool.getBool(true);
+        return org.python.types.Bool.TRUE;
     }
 
     @org.python.Method(
@@ -72,7 +72,7 @@ public class NotImplementedType extends org.python.types.Object {
     )
     public org.python.Object __eq__(org.python.Object other) {
         if (other instanceof org.python.types.NotImplementedType) {
-            return org.python.types.Bool.getBool(true);
+            return org.python.types.Bool.TRUE;
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }

--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -215,7 +215,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
     )
     public org.python.Object __eq__(org.python.Object other) {
         if (this == other) {
-            return new org.python.types.Bool(true);
+            return org.python.types.Bool.getBool(true);
         } else {
             return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
         }
@@ -232,7 +232,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         if (result instanceof org.python.types.NotImplementedType) {
             return result;
         }
-        return new org.python.types.Bool(!((org.python.types.Bool) result).value);
+        return org.python.types.Bool.getBool(!((org.python.types.Bool) result).value);
     }
 
     @org.python.Method(
@@ -978,7 +978,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
             __doc__ = ""
     )
     public org.python.Object __not__() {
-        return new org.python.types.Bool(!((org.python.types.Bool) this.__bool__()).value);
+        return org.python.types.Bool.getBool(!((org.python.types.Bool) this.__bool__()).value);
     }
 
     @org.python.Method(
@@ -1054,9 +1054,9 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         // identity implies equality
         if (v == w) {
             if (op == org.python.types.Object.CMP_OP.EQ) {
-                return new org.python.types.Bool(true);
+                return org.python.types.Bool.getBool(true);
             } else if (op == org.python.types.Object.CMP_OP.NE) {
-                return new org.python.types.Bool(false);
+                return org.python.types.Bool.getBool(false);
             }
         }
         org.python.Object result = __cmp__(v, w, op.oper, op.operMethod, op.reflOperMethod);
@@ -1094,9 +1094,9 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         }
 
         if (oper.equals("==")) {
-            return new org.python.types.Bool(v == w);
+            return org.python.types.Bool.getBool(v == w);
         } else if (oper.equals("!=")) {
-            return new org.python.types.Bool(v != w);
+            return org.python.types.Bool.getBool(v != w);
         }
 
         if (org.Python.VERSION < 0x03060000) {

--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -215,7 +215,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
     )
     public org.python.Object __eq__(org.python.Object other) {
         if (this == other) {
-            return org.python.types.Bool.getBool(true);
+            return org.python.types.Bool.TRUE;
         } else {
             return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
         }
@@ -1054,9 +1054,9 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         // identity implies equality
         if (v == w) {
             if (op == org.python.types.Object.CMP_OP.EQ) {
-                return org.python.types.Bool.getBool(true);
+                return org.python.types.Bool.TRUE;
             } else if (op == org.python.types.Object.CMP_OP.NE) {
-                return org.python.types.Bool.getBool(false);
+                return org.python.types.Bool.FALSE;
             }
         }
         org.python.Object result = __cmp__(v, w, op.oper, op.operMethod, op.reflOperMethod);

--- a/python/common/org/python/types/Range.java
+++ b/python/common/org/python/types/Range.java
@@ -143,7 +143,7 @@ public class Range extends org.python.types.Object {
             __doc__ = "Implement __bool__(self)."
     )
     public org.python.Object __bool__() {
-        return new org.python.types.Bool(
+        return org.python.types.Bool.getBool(
                 ((org.python.types.Int) this.__len__()).value > 0
         );
     }
@@ -192,7 +192,7 @@ public class Range extends org.python.types.Object {
     public org.python.Object __eq__(org.python.Object other) {
         if (other instanceof org.python.types.Range) {
             org.python.types.Range range2 = (org.python.types.Range) other;
-            return new org.python.types.Bool(
+            return org.python.types.Bool.getBool(
                 (this.start == range2.start) &&
                 (this.stop == range2.stop) &&
                 (this.step == range2.step)

--- a/python/common/org/python/types/Set.java
+++ b/python/common/org/python/types/Set.java
@@ -497,9 +497,9 @@ public class Set extends org.python.types.Object {
             throw new org.python.exceptions.TypeError("'" + other.typeName() + "' object is not iterable");
         }
         if (intersection.size() == 0) {
-            return org.python.types.Bool.getBool(true);
+            return org.python.types.Bool.TRUE;
         }
-        return org.python.types.Bool.getBool(false);
+        return org.python.types.Bool.FALSE;
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Set.java
+++ b/python/common/org/python/types/Set.java
@@ -131,10 +131,10 @@ public class Set extends org.python.types.Object {
     public org.python.Object __lt__(org.python.Object other) {
         if (other instanceof org.python.types.Set) {
             org.python.types.Set otherSet = (org.python.types.Set) other;
-            return new org.python.types.Bool(otherSet.value.containsAll(this.value) && !this.value.equals(otherSet.value));
+            return org.python.types.Bool.getBool(otherSet.value.containsAll(this.value) && !this.value.equals(otherSet.value));
         } else if (other instanceof org.python.types.FrozenSet) {
             org.python.types.FrozenSet otherSet = (org.python.types.FrozenSet) other;
-            return new org.python.types.Bool(otherSet.value.containsAll(this.value) && !this.value.equals(otherSet.value));
+            return org.python.types.Bool.getBool(otherSet.value.containsAll(this.value) && !this.value.equals(otherSet.value));
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -146,10 +146,10 @@ public class Set extends org.python.types.Object {
     public org.python.Object __le__(org.python.Object other) {
         if (other instanceof org.python.types.Set) {
             org.python.types.Set otherSet = (org.python.types.Set) other;
-            return new org.python.types.Bool(otherSet.value.containsAll(this.value));
+            return org.python.types.Bool.getBool(otherSet.value.containsAll(this.value));
         } else if (other instanceof org.python.types.FrozenSet) {
             org.python.types.FrozenSet otherSet = (org.python.types.FrozenSet) other;
-            return new org.python.types.Bool(otherSet.value.containsAll(this.value));
+            return org.python.types.Bool.getBool(otherSet.value.containsAll(this.value));
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -161,10 +161,10 @@ public class Set extends org.python.types.Object {
     public org.python.Object __eq__(org.python.Object other) {
         if (other instanceof org.python.types.Set) {
             org.python.types.Set otherSet = (org.python.types.Set) other;
-            return new org.python.types.Bool(this.value.equals(otherSet.value));
+            return org.python.types.Bool.getBool(this.value.equals(otherSet.value));
         } else if (other instanceof org.python.types.FrozenSet) {
             org.python.types.FrozenSet otherSet = (org.python.types.FrozenSet) other;
-            return new org.python.types.Bool(this.value.equals(otherSet.value));
+            return org.python.types.Bool.getBool(this.value.equals(otherSet.value));
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -176,10 +176,10 @@ public class Set extends org.python.types.Object {
     public org.python.Object __gt__(org.python.Object other) {
         if (other instanceof org.python.types.Set) {
             org.python.types.Set otherSet = (org.python.types.Set) other;
-            return new org.python.types.Bool(this.value.containsAll(otherSet.value) && !this.value.equals(otherSet.value));
+            return org.python.types.Bool.getBool(this.value.containsAll(otherSet.value) && !this.value.equals(otherSet.value));
         } else if (other instanceof org.python.types.FrozenSet) {
             org.python.types.FrozenSet otherSet = (org.python.types.FrozenSet) other;
-            return new org.python.types.Bool(this.value.containsAll(otherSet.value) && !this.value.equals(otherSet.value));
+            return org.python.types.Bool.getBool(this.value.containsAll(otherSet.value) && !this.value.equals(otherSet.value));
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -191,10 +191,10 @@ public class Set extends org.python.types.Object {
     public org.python.Object __ge__(org.python.Object other) {
         if (other instanceof org.python.types.Set) {
             org.python.types.Set otherSet = (org.python.types.Set) other;
-            return new org.python.types.Bool(this.value.containsAll(otherSet.value));
+            return org.python.types.Bool.getBool(this.value.containsAll(otherSet.value));
         } else if (other instanceof org.python.types.FrozenSet) {
             org.python.types.FrozenSet otherSet = (org.python.types.FrozenSet) other;
-            return new org.python.types.Bool(this.value.containsAll(otherSet.value));
+            return org.python.types.Bool.getBool(this.value.containsAll(otherSet.value));
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -208,7 +208,7 @@ public class Set extends org.python.types.Object {
             __doc__ = ""
     )
     public org.python.types.Bool __bool__() {
-        return new org.python.types.Bool(this.value.size() > 0);
+        return org.python.types.Bool.getBool(this.value.size() > 0);
     }
 
     @org.python.Method(
@@ -258,7 +258,7 @@ public class Set extends org.python.types.Object {
             args = {"item"}
     )
     public org.python.Object __contains__(org.python.Object other) {
-        return new org.python.types.Bool(this.value.contains(other));
+        return org.python.types.Bool.getBool(this.value.contains(other));
     }
 
     @org.python.Method(
@@ -266,7 +266,7 @@ public class Set extends org.python.types.Object {
             args = {"item"}
     )
     public org.python.Object __not_contains__(org.python.Object other) {
-        return new org.python.types.Bool(!this.value.contains(other));
+        return org.python.types.Bool.getBool(!this.value.contains(other));
     }
 
     @org.python.Method(
@@ -497,9 +497,9 @@ public class Set extends org.python.types.Object {
             throw new org.python.exceptions.TypeError("'" + other.typeName() + "' object is not iterable");
         }
         if (intersection.size() == 0) {
-            return new org.python.types.Bool(true);
+            return org.python.types.Bool.getBool(true);
         }
-        return new org.python.types.Bool(false);
+        return org.python.types.Bool.getBool(false);
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Slice.java
+++ b/python/common/org/python/types/Slice.java
@@ -315,6 +315,6 @@ public class Slice extends org.python.types.Object {
             __doc__ = ""
     )
     public org.python.Object __not__() {
-        return org.python.types.Bool.getBool(false);
+        return org.python.types.Bool.FALSE;
     }
 }

--- a/python/common/org/python/types/Slice.java
+++ b/python/common/org/python/types/Slice.java
@@ -315,6 +315,6 @@ public class Slice extends org.python.types.Object {
             __doc__ = ""
     )
     public org.python.Object __not__() {
-        return new org.python.types.Bool(false);
+        return org.python.types.Bool.getBool(false);
     }
 }

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -822,14 +822,14 @@ public class Str extends org.python.types.Object {
     )
     public org.python.Object isalnum() {
         if (this.value.isEmpty()) {
-            return org.python.types.Bool.getBool(false);
+            return org.python.types.Bool.FALSE;
         }
         for (char c : this.value.toCharArray()) {
             if (!java.lang.Character.isLetter(c) && !java.lang.Character.isDigit(c)) {
-                return org.python.types.Bool.getBool(false);
+                return org.python.types.Bool.FALSE;
             }
         }
-        return org.python.types.Bool.getBool(true);
+        return org.python.types.Bool.TRUE;
     }
 
     @org.python.Method(
@@ -840,14 +840,14 @@ public class Str extends org.python.types.Object {
     )
     public org.python.Object isalpha() {
         if (this.value.isEmpty()) {
-            return org.python.types.Bool.getBool(false);
+            return org.python.types.Bool.FALSE;
         }
         for (char ch : this.value.toCharArray()) {
             if (!(Character.isLetter(ch))) {
-                return org.python.types.Bool.getBool(false);
+                return org.python.types.Bool.FALSE;
             }
         }
-        return org.python.types.Bool.getBool(true);
+        return org.python.types.Bool.TRUE;
     }
 
     @org.python.Method(
@@ -858,14 +858,14 @@ public class Str extends org.python.types.Object {
     )
     public org.python.Object isdecimal() {
         if (this.value.isEmpty()) {
-            return org.python.types.Bool.getBool(false);
+            return org.python.types.Bool.FALSE;
         }
         for (char c : this.value.toCharArray()) {
             if (!java.lang.Character.isDigit(c)) {
-                return org.python.types.Bool.getBool(false);
+                return org.python.types.Bool.FALSE;
             }
         }
-        return org.python.types.Bool.getBool(true);
+        return org.python.types.Bool.TRUE;
     }
 
     @org.python.Method(
@@ -876,14 +876,14 @@ public class Str extends org.python.types.Object {
     )
     public org.python.Object isdigit() {
         if (this.value.isEmpty()) {
-            return org.python.types.Bool.getBool(false);
+            return org.python.types.Bool.FALSE;
         }
         for (char ch : this.value.toCharArray()) {
             if (!(Character.isDigit(ch))) {
-                return org.python.types.Bool.getBool(false);
+                return org.python.types.Bool.FALSE;
             }
         }
-        return org.python.types.Bool.getBool(true);
+        return org.python.types.Bool.TRUE;
     }
 
     @org.python.Method(
@@ -897,7 +897,7 @@ public class Str extends org.python.types.Object {
     )
     public org.python.Object isidentifier() {
         if (this.value.isEmpty()) {
-            return org.python.types.Bool.getBool(false);
+            return org.python.types.Bool.FALSE;
         }
         boolean firstCheck = true;
         for (char ch : this.value.toCharArray()) {
@@ -907,16 +907,16 @@ public class Str extends org.python.types.Object {
             }
             if (firstCheck) {
                 if (!(Character.isUnicodeIdentifierStart(ch))) {
-                    return org.python.types.Bool.getBool(false);
+                    return org.python.types.Bool.FALSE;
                 }
                 firstCheck = false;
             } else {
                 if (!(Character.isUnicodeIdentifierPart(ch))) {
-                    return org.python.types.Bool.getBool(false);
+                    return org.python.types.Bool.FALSE;
                 }
             }
         }
-        return org.python.types.Bool.getBool(true);
+        return org.python.types.Bool.TRUE;
     }
 
     @org.python.Method(
@@ -927,9 +927,9 @@ public class Str extends org.python.types.Object {
     )
     public org.python.Object islower() {
         if (!this.value.isEmpty() && this.value.toLowerCase().equals(this.value)) {
-            return org.python.types.Bool.getBool(true);
+            return org.python.types.Bool.TRUE;
         }
-        return org.python.types.Bool.getBool(false);
+        return org.python.types.Bool.FALSE;
     }
 
     @org.python.Method(
@@ -940,14 +940,14 @@ public class Str extends org.python.types.Object {
     )
     public org.python.Object isnumeric() {
         if (this.value.isEmpty()) {
-            return org.python.types.Bool.getBool(false);
+            return org.python.types.Bool.FALSE;
         }
         for (char ch : this.value.toCharArray()) {
             if (!(Character.isDigit(ch))) {
-                return org.python.types.Bool.getBool(false);
+                return org.python.types.Bool.FALSE;
             }
         }
-        return org.python.types.Bool.getBool(true);
+        return org.python.types.Bool.TRUE;
     }
 
     @org.python.Method(
@@ -959,10 +959,10 @@ public class Str extends org.python.types.Object {
     public org.python.Object isprintable() {
         for (char ch : this.value.toCharArray()) {
             if (!this.isCharPrintable(ch)) {
-                return org.python.types.Bool.getBool(false);
+                return org.python.types.Bool.FALSE;
             }
         }
-        return org.python.types.Bool.getBool(true);
+        return org.python.types.Bool.TRUE;
     }
 
     @org.python.Method(
@@ -973,14 +973,14 @@ public class Str extends org.python.types.Object {
     )
     public org.python.Object isspace() {
         if (this.value.isEmpty()) {
-            return org.python.types.Bool.getBool(false);
+            return org.python.types.Bool.FALSE;
         }
         for (char ch : this.value.toCharArray()) {
             if (!isWhitespace(ch)) {
-                return org.python.types.Bool.getBool(false);
+                return org.python.types.Bool.FALSE;
             }
         }
-        return org.python.types.Bool.getBool(true);
+        return org.python.types.Bool.TRUE;
     }
 
     @org.python.Method(
@@ -993,18 +993,18 @@ public class Str extends org.python.types.Object {
     )
     public org.python.Object istitle() {
         if (this.value.isEmpty()) {
-            return org.python.types.Bool.getBool(false);
+            return org.python.types.Bool.FALSE;
         }
 
         if (this.value.equals(_title(this.value))) {
             for (int idx = 0; idx < this.value.length(); idx++) {
                 if (Character.isLetter(this.value.charAt(idx))) {
-                    return org.python.types.Bool.getBool(true);
+                    return org.python.types.Bool.TRUE;
                 }
             }
         }
 
-        return org.python.types.Bool.getBool(false);
+        return org.python.types.Bool.FALSE;
     }
 
     @org.python.Method(
@@ -1015,9 +1015,9 @@ public class Str extends org.python.types.Object {
     )
     public org.python.Object isupper() {
         if (!this.value.isEmpty() && this.value.toUpperCase().equals(this.value)) {
-            return org.python.types.Bool.getBool(true);
+            return org.python.types.Bool.TRUE;
         }
-        return org.python.types.Bool.getBool(false);
+        return org.python.types.Bool.FALSE;
     }
 
     @org.python.Method(
@@ -1616,7 +1616,7 @@ public class Str extends org.python.types.Object {
     )
     public org.python.Object splitlines(org.python.Object keepends) {
         if (keepends == null) {
-            keepends = org.python.types.Bool.getBool(false);
+            keepends = org.python.types.Bool.FALSE;
         }
 
         org.python.types.List result = new org.python.types.List();

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -199,7 +199,7 @@ public class Str extends org.python.types.Object {
     public org.python.Object __lt__(org.python.Object other) {
         if (other instanceof org.python.types.Str) {
             java.lang.String value = ((org.python.types.Str) other).value;
-            return new org.python.types.Bool(this.value.compareTo(value) < 0);
+            return org.python.types.Bool.getBool(this.value.compareTo(value) < 0);
         } else {
             return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
         }
@@ -212,7 +212,7 @@ public class Str extends org.python.types.Object {
     public org.python.Object __le__(org.python.Object other) {
         if (other instanceof org.python.types.Str) {
             java.lang.String value = ((org.python.types.Str) other).value;
-            return new org.python.types.Bool(this.value.compareTo(value) <= 0);
+            return org.python.types.Bool.getBool(this.value.compareTo(value) <= 0);
         } else {
             return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
         }
@@ -225,7 +225,7 @@ public class Str extends org.python.types.Object {
     public org.python.Object __eq__(org.python.Object other) {
         if (other instanceof org.python.types.Str) {
             java.lang.String value = ((org.python.types.Str) other).value;
-            return new org.python.types.Bool(this.value.equals(value));
+            return org.python.types.Bool.getBool(this.value.equals(value));
         } else {
             return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
         }
@@ -238,7 +238,7 @@ public class Str extends org.python.types.Object {
     public org.python.Object __gt__(org.python.Object other) {
         if (other instanceof org.python.types.Str) {
             java.lang.String value = ((org.python.types.Str) other).value;
-            return new org.python.types.Bool(this.value.compareTo(value) > 0);
+            return org.python.types.Bool.getBool(this.value.compareTo(value) > 0);
         } else {
             return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
         }
@@ -251,7 +251,7 @@ public class Str extends org.python.types.Object {
     public org.python.Object __ge__(org.python.Object other) {
         if (other instanceof org.python.types.Str) {
             java.lang.String value = ((org.python.types.Str) other).value;
-            return new org.python.types.Bool(this.value.compareTo(value) >= 0);
+            return org.python.types.Bool.getBool(this.value.compareTo(value) >= 0);
         } else {
             return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
         }
@@ -512,7 +512,7 @@ public class Str extends org.python.types.Object {
             __doc__ = ""
     )
     public org.python.Object __bool__() {
-        return new org.python.types.Bool(this.value.length() > 0);
+        return org.python.types.Bool.getBool(this.value.length() > 0);
     }
 
     @org.python.Method(
@@ -688,7 +688,7 @@ public class Str extends org.python.types.Object {
             }
             java.lang.String original = this.__getitem__(new org.python.types.Slice(start, end)).toString();
             boolean result = original.endsWith(((org.python.types.Str) suffix).toString());
-            return new org.python.types.Bool(result);
+            return org.python.types.Bool.getBool(result);
         }
         throw new org.python.exceptions.TypeError("endswith first arg must be str, not " + suffix.typeName());
     }
@@ -822,14 +822,14 @@ public class Str extends org.python.types.Object {
     )
     public org.python.Object isalnum() {
         if (this.value.isEmpty()) {
-            return new org.python.types.Bool(false);
+            return org.python.types.Bool.getBool(false);
         }
         for (char c : this.value.toCharArray()) {
             if (!java.lang.Character.isLetter(c) && !java.lang.Character.isDigit(c)) {
-                return new org.python.types.Bool(false);
+                return org.python.types.Bool.getBool(false);
             }
         }
-        return new org.python.types.Bool(true);
+        return org.python.types.Bool.getBool(true);
     }
 
     @org.python.Method(
@@ -840,14 +840,14 @@ public class Str extends org.python.types.Object {
     )
     public org.python.Object isalpha() {
         if (this.value.isEmpty()) {
-            return new org.python.types.Bool(false);
+            return org.python.types.Bool.getBool(false);
         }
         for (char ch : this.value.toCharArray()) {
             if (!(Character.isLetter(ch))) {
-                return new org.python.types.Bool(false);
+                return org.python.types.Bool.getBool(false);
             }
         }
-        return new org.python.types.Bool(true);
+        return org.python.types.Bool.getBool(true);
     }
 
     @org.python.Method(
@@ -858,14 +858,14 @@ public class Str extends org.python.types.Object {
     )
     public org.python.Object isdecimal() {
         if (this.value.isEmpty()) {
-            return new org.python.types.Bool(false);
+            return org.python.types.Bool.getBool(false);
         }
         for (char c : this.value.toCharArray()) {
             if (!java.lang.Character.isDigit(c)) {
-                return new org.python.types.Bool(false);
+                return org.python.types.Bool.getBool(false);
             }
         }
-        return new org.python.types.Bool(true);
+        return org.python.types.Bool.getBool(true);
     }
 
     @org.python.Method(
@@ -876,14 +876,14 @@ public class Str extends org.python.types.Object {
     )
     public org.python.Object isdigit() {
         if (this.value.isEmpty()) {
-            return new org.python.types.Bool(false);
+            return org.python.types.Bool.getBool(false);
         }
         for (char ch : this.value.toCharArray()) {
             if (!(Character.isDigit(ch))) {
-                return new org.python.types.Bool(false);
+                return org.python.types.Bool.getBool(false);
             }
         }
-        return new org.python.types.Bool(true);
+        return org.python.types.Bool.getBool(true);
     }
 
     @org.python.Method(
@@ -897,7 +897,7 @@ public class Str extends org.python.types.Object {
     )
     public org.python.Object isidentifier() {
         if (this.value.isEmpty()) {
-            return new org.python.types.Bool(false);
+            return org.python.types.Bool.getBool(false);
         }
         boolean firstCheck = true;
         for (char ch : this.value.toCharArray()) {
@@ -907,16 +907,16 @@ public class Str extends org.python.types.Object {
             }
             if (firstCheck) {
                 if (!(Character.isUnicodeIdentifierStart(ch))) {
-                    return new org.python.types.Bool(false);
+                    return org.python.types.Bool.getBool(false);
                 }
                 firstCheck = false;
             } else {
                 if (!(Character.isUnicodeIdentifierPart(ch))) {
-                    return new org.python.types.Bool(false);
+                    return org.python.types.Bool.getBool(false);
                 }
             }
         }
-        return new org.python.types.Bool(true);
+        return org.python.types.Bool.getBool(true);
     }
 
     @org.python.Method(
@@ -927,9 +927,9 @@ public class Str extends org.python.types.Object {
     )
     public org.python.Object islower() {
         if (!this.value.isEmpty() && this.value.toLowerCase().equals(this.value)) {
-            return new org.python.types.Bool(true);
+            return org.python.types.Bool.getBool(true);
         }
-        return new org.python.types.Bool(false);
+        return org.python.types.Bool.getBool(false);
     }
 
     @org.python.Method(
@@ -940,14 +940,14 @@ public class Str extends org.python.types.Object {
     )
     public org.python.Object isnumeric() {
         if (this.value.isEmpty()) {
-            return new org.python.types.Bool(false);
+            return org.python.types.Bool.getBool(false);
         }
         for (char ch : this.value.toCharArray()) {
             if (!(Character.isDigit(ch))) {
-                return new org.python.types.Bool(false);
+                return org.python.types.Bool.getBool(false);
             }
         }
-        return new org.python.types.Bool(true);
+        return org.python.types.Bool.getBool(true);
     }
 
     @org.python.Method(
@@ -959,10 +959,10 @@ public class Str extends org.python.types.Object {
     public org.python.Object isprintable() {
         for (char ch : this.value.toCharArray()) {
             if (!this.isCharPrintable(ch)) {
-                return new org.python.types.Bool(false);
+                return org.python.types.Bool.getBool(false);
             }
         }
-        return new org.python.types.Bool(true);
+        return org.python.types.Bool.getBool(true);
     }
 
     @org.python.Method(
@@ -973,14 +973,14 @@ public class Str extends org.python.types.Object {
     )
     public org.python.Object isspace() {
         if (this.value.isEmpty()) {
-            return new org.python.types.Bool(false);
+            return org.python.types.Bool.getBool(false);
         }
         for (char ch : this.value.toCharArray()) {
             if (!isWhitespace(ch)) {
-                return new org.python.types.Bool(false);
+                return org.python.types.Bool.getBool(false);
             }
         }
-        return new org.python.types.Bool(true);
+        return org.python.types.Bool.getBool(true);
     }
 
     @org.python.Method(
@@ -993,18 +993,18 @@ public class Str extends org.python.types.Object {
     )
     public org.python.Object istitle() {
         if (this.value.isEmpty()) {
-            return new org.python.types.Bool(false);
+            return org.python.types.Bool.getBool(false);
         }
 
         if (this.value.equals(_title(this.value))) {
             for (int idx = 0; idx < this.value.length(); idx++) {
                 if (Character.isLetter(this.value.charAt(idx))) {
-                    return new org.python.types.Bool(true);
+                    return org.python.types.Bool.getBool(true);
                 }
             }
         }
 
-        return new org.python.types.Bool(false);
+        return org.python.types.Bool.getBool(false);
     }
 
     @org.python.Method(
@@ -1015,9 +1015,9 @@ public class Str extends org.python.types.Object {
     )
     public org.python.Object isupper() {
         if (!this.value.isEmpty() && this.value.toUpperCase().equals(this.value)) {
-            return new org.python.types.Bool(true);
+            return org.python.types.Bool.getBool(true);
         }
-        return new org.python.types.Bool(false);
+        return org.python.types.Bool.getBool(false);
     }
 
     @org.python.Method(
@@ -1616,7 +1616,7 @@ public class Str extends org.python.types.Object {
     )
     public org.python.Object splitlines(org.python.Object keepends) {
         if (keepends == null) {
-            keepends = new org.python.types.Bool(false);
+            keepends = org.python.types.Bool.getBool(false);
         }
 
         org.python.types.List result = new org.python.types.List();
@@ -1685,7 +1685,7 @@ public class Str extends org.python.types.Object {
             }
             java.lang.String original = this.__getitem__(new org.python.types.Slice(start, end)).toString();
             boolean result = original.startsWith(((org.python.types.Str) suffix).toString());
-            return new org.python.types.Bool(result);
+            return org.python.types.Bool.getBool(result);
         }
         throw new org.python.exceptions.TypeError("startswith first arg must be str, not " + suffix.typeName());
     }
@@ -2581,4 +2581,3 @@ final class PythonFormatter {
     public static final char SIGN_NEGATIV = '+';
     public static final char SIGN_UNDEFINED = '\0';
 }
-

--- a/python/common/org/python/types/Super.java
+++ b/python/common/org/python/types/Super.java
@@ -164,7 +164,7 @@ public class Super implements org.python.Object {
             args = {"other"}
     )
     public org.python.Object __eq__(org.python.Object other) {
-        return new org.python.types.Bool(System.identityHashCode(this) == System.identityHashCode(other));
+        return org.python.types.Bool.getBool(System.identityHashCode(this) == System.identityHashCode(other));
     }
 
     @org.python.Method(
@@ -178,7 +178,7 @@ public class Super implements org.python.Object {
         if (result instanceof org.python.types.NotImplementedType) {
             return result;
         }
-        return new org.python.types.Bool(!((org.python.types.Bool) result).value);
+        return org.python.types.Bool.getBool(!((org.python.types.Bool) result).value);
     }
 
     @org.python.Method(
@@ -880,7 +880,7 @@ public class Super implements org.python.Object {
             __doc__ = ""
     )
     public org.python.Object __not__() {
-        return new org.python.types.Bool(!((org.python.types.Bool) this.__bool__()).value);
+        return org.python.types.Bool.getBool(!((org.python.types.Bool) this.__bool__()).value);
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Tuple.java
+++ b/python/common/org/python/types/Tuple.java
@@ -102,7 +102,7 @@ public class Tuple extends org.python.types.Object {
             __doc__ = ""
     )
     public org.python.Object __bool__() {
-        return new org.python.types.Bool(!this.value.isEmpty());
+        return org.python.types.Bool.getBool(!this.value.isEmpty());
     }
 
     @org.python.Method(
@@ -133,7 +133,7 @@ public class Tuple extends org.python.types.Object {
             }
 
             // all items were identical, break tie by size
-            return new org.python.types.Bool(size < otherSize);
+            return org.python.types.Bool.getBool(size < otherSize);
         } else {
             return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
         }
@@ -167,7 +167,7 @@ public class Tuple extends org.python.types.Object {
             }
 
             // all items were identical, break tie by size
-            return new org.python.types.Bool(size <= otherSize);
+            return org.python.types.Bool.getBool(size <= otherSize);
         } else {
             return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
         }
@@ -180,7 +180,7 @@ public class Tuple extends org.python.types.Object {
     public org.python.Object __eq__(org.python.Object other) {
         if (other instanceof org.python.types.Tuple) {
             org.python.types.Tuple otherTuple = (org.python.types.Tuple) other;
-            return new org.python.types.Bool(this.value.equals(otherTuple.value));
+            return org.python.types.Bool.getBool(this.value.equals(otherTuple.value));
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -213,7 +213,7 @@ public class Tuple extends org.python.types.Object {
             }
 
             // all items were identical, break tie by size
-            return new org.python.types.Bool(size > otherSize);
+            return org.python.types.Bool.getBool(size > otherSize);
         } else {
             return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
         }
@@ -247,7 +247,7 @@ public class Tuple extends org.python.types.Object {
             }
 
             // all items were identical, break tie by size
-            return new org.python.types.Bool(size >= otherSize);
+            return org.python.types.Bool.getBool(size >= otherSize);
         } else {
             return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
         }
@@ -363,7 +363,7 @@ public class Tuple extends org.python.types.Object {
             args = {"item"}
     )
     public org.python.Object __contains__(org.python.Object item) {
-        return new org.python.types.Bool(this.value.contains(item));
+        return org.python.types.Bool.getBool(this.value.contains(item));
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Type.java
+++ b/python/common/org/python/types/Type.java
@@ -178,7 +178,7 @@ public class Type extends org.python.types.Object implements org.python.Callable
         } else {
             if (value.getClass() == java.lang.Boolean.TYPE
                     || value.getClass() == java.lang.Boolean.class) {
-                return new org.python.types.Bool((java.lang.Boolean) value);
+                return org.python.types.Bool.getBool((java.lang.Boolean) value);
             } else if (value.getClass() == java.lang.Byte.TYPE
                     || value.getClass() == java.lang.Byte.class) {
                 return new org.python.types.Int((java.lang.Byte) value);

--- a/voc/python/ast.py
+++ b/voc/python/ast.py
@@ -1758,17 +1758,14 @@ class Visitor(ast.NodeVisitor):
                     IF([], JavaOpcodes.IF_ACMPNE),
                 )
                 self.context.add_opcodes(
-                        java.New('org/python/types/Bool'),
-                        JavaOpcodes.ICONST_1(),
-                        java.Init('org/python/types/Bool', 'Z'),
+                        JavaOpcodes.GETSTATIC('org/python/types/Bool', 'TRUE', 'Lorg/python/Object;'),
                 )
                 self.context.add_opcodes(
                     ELSE(),
                 )
                 self.context.add_opcodes(
-                        java.New('org/python/types/Bool'),
-                        JavaOpcodes.ICONST_0(),
-                        java.Init('org/python/types/Bool', 'Z'),
+                        JavaOpcodes.GETSTATIC('org/python/types/Bool', 'FALSE', 'Lorg/python/Object;'),
+
                 )
                 self.context.add_opcodes(
                     END_IF(),
@@ -1779,17 +1776,13 @@ class Visitor(ast.NodeVisitor):
                     IF([], JavaOpcodes.IF_ACMPEQ),
                 )
                 self.context.add_opcodes(
-                        java.New('org/python/types/Bool'),
-                        JavaOpcodes.ICONST_1(),
-                        java.Init('org/python/types/Bool', 'Z'),
+                        JavaOpcodes.GETSTATIC('org/python/types/Bool', 'TRUE', 'Lorg/python/Object;'),
                 )
                 self.context.add_opcodes(
                     ELSE(),
                 )
                 self.context.add_opcodes(
-                        java.New('org/python/types/Bool'),
-                        JavaOpcodes.ICONST_0(),
-                        java.Init('org/python/types/Bool', 'Z'),
+                        JavaOpcodes.GETSTATIC('org/python/types/Bool', 'FALSE', 'Lorg/python/Object;'),
                 )
                 self.context.add_opcodes(
                     END_IF(),
@@ -2109,15 +2102,13 @@ class Visitor(ast.NodeVisitor):
             )
         elif node.value is True:
             self.context.add_opcodes(
-                java.New('org/python/types/Bool'),
-                JavaOpcodes.ICONST_1(),
-                java.Init('org/python/types/Bool', 'Z'),
+                JavaOpcodes.GETSTATIC('org/python/types/Bool', 'TRUE', 'Lorg/python/Object;'),
+
             )
         elif node.value is False:
             self.context.add_opcodes(
-                java.New('org/python/types/Bool'),
-                JavaOpcodes.ICONST_0(),
-                java.Init('org/python/types/Bool', 'Z'),
+                JavaOpcodes.GETSTATIC('org/python/types/Bool', 'FALSE', 'Lorg/python/Object;'),
+
             )
         else:
             raise NotImplementedError("Unknown named constant %s" % node.value)

--- a/voc/python/ast.py
+++ b/voc/python/ast.py
@@ -1758,13 +1758,13 @@ class Visitor(ast.NodeVisitor):
                     IF([], JavaOpcodes.IF_ACMPNE),
                 )
                 self.context.add_opcodes(
-                        JavaOpcodes.GETSTATIC('org/python/types/Bool', 'TRUE', 'Lorg/python/Object;'),
+                        JavaOpcodes.GETSTATIC('org/python/types/Bool', 'TRUE', 'Lorg/python/types/Bool;'),
                 )
                 self.context.add_opcodes(
                     ELSE(),
                 )
                 self.context.add_opcodes(
-                        JavaOpcodes.GETSTATIC('org/python/types/Bool', 'FALSE', 'Lorg/python/Object;'),
+                        JavaOpcodes.GETSTATIC('org/python/types/Bool', 'FALSE', 'Lorg/python/types/Bool;'),
 
                 )
                 self.context.add_opcodes(
@@ -1776,13 +1776,13 @@ class Visitor(ast.NodeVisitor):
                     IF([], JavaOpcodes.IF_ACMPEQ),
                 )
                 self.context.add_opcodes(
-                        JavaOpcodes.GETSTATIC('org/python/types/Bool', 'TRUE', 'Lorg/python/Object;'),
+                        JavaOpcodes.GETSTATIC('org/python/types/Bool', 'TRUE', 'Lorg/python/types/Bool;'),
                 )
                 self.context.add_opcodes(
                     ELSE(),
                 )
                 self.context.add_opcodes(
-                        JavaOpcodes.GETSTATIC('org/python/types/Bool', 'FALSE', 'Lorg/python/Object;'),
+                        JavaOpcodes.GETSTATIC('org/python/types/Bool', 'FALSE', 'Lorg/python/types/Bool;'),
                 )
                 self.context.add_opcodes(
                     END_IF(),
@@ -2102,12 +2102,12 @@ class Visitor(ast.NodeVisitor):
             )
         elif node.value is True:
             self.context.add_opcodes(
-                JavaOpcodes.GETSTATIC('org/python/types/Bool', 'TRUE', 'Lorg/python/Object;'),
+                JavaOpcodes.GETSTATIC('org/python/types/Bool', 'TRUE', 'Lorg/python/types/Bool;'),
 
             )
         elif node.value is False:
             self.context.add_opcodes(
-                JavaOpcodes.GETSTATIC('org/python/types/Bool', 'FALSE', 'Lorg/python/Object;'),
+                JavaOpcodes.GETSTATIC('org/python/types/Bool', 'FALSE', 'Lorg/python/types/Bool;'),
 
             )
         else:

--- a/voc/python/blocks.py
+++ b/voc/python/blocks.py
@@ -193,11 +193,11 @@ class Block(Accumulator):
                 if isinstance(value, bool):
                     if value is True:
                         self.add_opcodes(
-                            JavaOpcodes.GETSTATIC('org/python/types/Bool', 'TRUE', 'Lorg/python/Object;'),
+                            JavaOpcodes.GETSTATIC('org/python/types/Bool', 'TRUE', 'Lorg/python/types/Bool;'),
                         )
                     else:
                         self.add_opcodes(
-                            JavaOpcodes.GETSTATIC('org/python/types/Bool', 'FALSE', 'Lorg/python/Object;'),
+                            JavaOpcodes.GETSTATIC('org/python/types/Bool', 'FALSE', 'Lorg/python/types/Bool;'),
                         )
 
                 elif isinstance(value, int):

--- a/voc/python/blocks.py
+++ b/voc/python/blocks.py
@@ -191,11 +191,14 @@ class Block(Accumulator):
                 )
             else:
                 if isinstance(value, bool):
-                    self.add_opcodes(
-                        java.New('org/python/types/Bool'),
-                        ICONST_val(value),
-                        java.Init('org/python/types/Bool', 'Z'),
-                    )
+                    if value is True:
+                        self.add_opcodes(
+                            JavaOpcodes.GETSTATIC('org/python/types/Bool', 'TRUE', 'Lorg/python/Object;'),
+                        )
+                    else:
+                        self.add_opcodes(
+                            JavaOpcodes.GETSTATIC('org/python/types/Bool', 'FALSE', 'Lorg/python/Object;'),
+                        )
 
                 elif isinstance(value, int):
                     self.add_opcodes(

--- a/voc/python/methods.py
+++ b/voc/python/methods.py
@@ -50,9 +50,12 @@ def to_python(accumulator, annotation, var_name):
         accumulator.add_opcodes(
             # DEBUG("INPUT %s TRANSFORM %s" % (i, annotation)),
 
-            java.New('org/python/types/Bool'),
             ILOAD_name(var_name),
-            java.Init('org/python/types/Bool', 'Z'),
+            JavaOpcodes.INVOKESTATIC(
+                'org/python/types/Bool',
+                'getBool',
+                args=['Ljava/lang/Long;'],
+                returns='Lorg/python/types/Bool;'),
         )
     elif annotation == "byte":
         accumulator.add_opcodes(


### PR DESCRIPTION
This PR improves execution time by using preallocated instances of True and False, never creating new `Boolean` objects. 

Performance benchmark stats ([test here](https://github.com/patiences/voc/commit/f161e5c97aaa5dab5c8bfba7ed1d7e150f596c89)): 

**Pre-change** 
Running test_booleans
  Elapsed time:  85.63200672800303  sec
  CPU process time:  0.0009250000000000091  sec

Running test_booleans
  Elapsed time:  83.78228437301004  sec
  CPU process time:  0.00013499999999999623  sec

Running test_booleans
  Elapsed time:  80.98856862200773  sec
  CPU process time:  0.00012000000000000899  sec

**With this change** 
Running test_booleans
  Elapsed time:  42.00830070799566  sec
  CPU process time:  0.0008920000000000039  sec

Running test_booleans
  Elapsed time:  41.94127046901849  sec
  CPU process time:  0.0007800000000000029  sec

Running test_booleans
  Elapsed time:  43.51021371400566  sec
  CPU process time:  0.0009509999999999796  sec