### PR TITLE
fix Method repr()

### DIFF
--- a/python/common/org/python/types/DictItems.java
+++ b/python/common/org/python/types/DictItems.java
@@ -111,7 +111,7 @@ public class DictItems extends org.python.types.Object {
             __doc__ = ""
     )
     public org.python.Object __bool__() {
-        return new org.python.types.Bool(!this.value.isEmpty());
+        return org.python.types.Bool.getBool(!this.value.isEmpty());
     }
 
     @org.python.Method(
@@ -198,7 +198,7 @@ public class DictItems extends org.python.types.Object {
     public org.python.Object __lt__(org.python.Object other) {
         if (other instanceof org.python.types.DictItems) {
             org.python.types.DictItems otherItems = (org.python.types.DictItems) other;
-            return new org.python.types.Bool(otherItems.value.containsAll(this.value) && !this.value.equals(otherItems.value));
+            return org.python.types.Bool.getBool(otherItems.value.containsAll(this.value) && !this.value.equals(otherItems.value));
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -210,7 +210,7 @@ public class DictItems extends org.python.types.Object {
     public org.python.Object __le__(org.python.Object other) {
         if (other instanceof org.python.types.DictItems) {
             org.python.types.DictItems otherItems = (org.python.types.DictItems) other;
-            return new org.python.types.Bool(otherItems.value.containsAll(this.value));
+            return org.python.types.Bool.getBool(otherItems.value.containsAll(this.value));
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -222,7 +222,7 @@ public class DictItems extends org.python.types.Object {
     public org.python.Object __eq__(org.python.Object other) {
         if (other instanceof org.python.types.DictItems) {
             org.python.types.DictItems otherItems = (org.python.types.DictItems) other;
-            return new org.python.types.Bool(this.value.equals(otherItems.value));
+            return org.python.types.Bool.getBool(this.value.equals(otherItems.value));
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -234,7 +234,7 @@ public class DictItems extends org.python.types.Object {
     public org.python.Object __gt__(org.python.Object other) {
         if (other instanceof org.python.types.DictItems) {
             org.python.types.DictItems otherItems = (org.python.types.DictItems) other;
-            return new org.python.types.Bool(this.value.containsAll(otherItems.value) && !this.value.equals(otherItems.value));
+            return org.python.types.Bool.getBool(this.value.containsAll(otherItems.value) && !this.value.equals(otherItems.value));
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -246,7 +246,7 @@ public class DictItems extends org.python.types.Object {
     public org.python.Object __ge__(org.python.Object other) {
         if (other instanceof org.python.types.DictItems) {
             org.python.types.DictItems otherItems = (org.python.types.DictItems) other;
-            return new org.python.types.Bool(this.value.containsAll(otherItems.value));
+            return org.python.types.Bool.getBool(this.value.containsAll(otherItems.value));
         }
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
@@ -331,6 +331,6 @@ public class DictItems extends org.python.types.Object {
     public org.python.Object isdisjoint(org.python.Object other) {
         java.util.Set<org.python.Object> generated = this.fromIter(other);
         generated.retainAll(this.value);
-        return new org.python.types.Bool(generated.size() > 0);
+        return org.python.types.Bool.getBool(generated.size() > 0);
     }
 }

--- a/python/common/org/python/types/DictKeys.java
+++ b/python/common/org/python/types/DictKeys.java
@@ -221,7 +221,7 @@ public class DictKeys extends org.python.types.FrozenSet {
         } catch (org.python.exceptions.StopIteration si) {
         }
         generated.retainAll(this.value);
-        return new org.python.types.Bool(generated.size() > 0);
+        return org.python.types.Bool.getBool(generated.size() > 0);
     }
     /**
      * The following methods are not present in Python's dict_keys but are present in DictKeys (inherited from FrozenSet)

--- a/python/common/org/python/types/DictValues.java
+++ b/python/common/org/python/types/DictValues.java
@@ -101,7 +101,7 @@ public class DictValues extends org.python.types.Object {
             __doc__ = ""
     )
     public org.python.Object __bool__() {
-        return new org.python.types.Bool(!this.value.isEmpty());
+        return org.python.types.Bool.getBool(!this.value.isEmpty());
     }
 
     @org.python.Method(
@@ -168,7 +168,7 @@ public class DictValues extends org.python.types.Object {
             args = {"item"}
     )
     public org.python.Object __contains__(org.python.Object item) {
-        return new org.python.types.Bool(this.value.contains(item));
+        return org.python.types.Bool.getBool(this.value.contains(item));
     }
 
     @org.python.Method(
@@ -176,6 +176,6 @@ public class DictValues extends org.python.types.Object {
             args = {"item"}
     )
     public org.python.Object __not_contains__(org.python.Object item) {
-        return new org.python.types.Bool(!this.value.contains(item));
+        return org.python.types.Bool.getBool(!this.value.contains(item));
     }
 }

--- a/python/common/org/python/types/Method.java
+++ b/python/common/org/python/types/Method.java
@@ -27,7 +27,7 @@ public class Method extends org.python.types.Object implements org.python.Callab
         } else {
             return new org.python.types.Str(
                     String.format("<bound method %s.%s of %s>",
-                            this.im_class.__dict__.get("__name__"),
+                            this.im_class,
                             this.im_func.__dict__.get("__name__"),
                             this.im_self
                     )

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,6 @@
 import io
 import re
 from setuptools import setup, find_packages
-import sys
-
-if sys.version_info[:2] < (3, 4):
-    raise SystemExit("VOC requires Python 3.4+")
 
 with io.open('./voc/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
@@ -28,6 +24,7 @@ setup(
     author_email='russell@keith-magee.com',
     url='http://pybee.org/voc',
     packages=find_packages(exclude=['docs', 'tests']),
+    python_requires='>=3.4',
     entry_points={
         'console_scripts': [
             'voc = voc.__main__:main',

--- a/tests/builtins/test_set.py
+++ b/tests/builtins/test_set.py
@@ -14,9 +14,32 @@ class BuiltinSetFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     ]
 
     not_implemented_versions = {
-             'test_tuple': (3.4, 3.5, 3.6)
     }
 
     is_flakey = [
         'test_dict',
     ]
+
+    substitutions = {
+        # output, keyed to all possible inputs
+        "{3, 1.2, True}": [
+            "{1.2, 3, True}", "{True, 1.2, 3}", "{True, 3, 1.2}", "{3, True, 1.2}", "{1.2, True, 3}"
+        ],
+        "{1, 2.3456, 'another'}": [
+            "{1, 'another', 2.3456}", "{'another', 1, 2.3456}", "{'another', 2.3456, 1}", "{2.3456, 'another', 1}",
+            "{2.3456, 1, 'another'}"
+        ],
+        "{'on', 'to', 'an'}": [
+            "{'on', 'an', 'to'}", "{'to', 'an', 'on'}", "{'to', 'on', 'an'}", "{'an', 'to', 'on'}", "{'an', 'on', 'to'}"
+        ],
+        "{'one', 'two', 'six'}": [
+            "{'one', 'six', 'two'}", "{'two', 'one', 'six'}", "{'two', 'six', 'one'}", "{'six', 'one', 'two'}",
+            "{'six', 'two', 'one'}"
+        ],
+        "{1, 2.3456, 7}": [
+            "{1, 7, 2.3456}", "{2.34556, 1, 7}", "{2.3456, 7, 1}", "{7, 2.3456, 1}", "{7, 1, 2.3456}"
+        ],
+        "{'a', 'b', 'c'}": [
+            "{'a', 'c', 'b'}", "{'b', 'a', 'c'}", "{'b', 'c', 'a'}", "{'c', 'a', 'b'}", "{'c', 'b', 'c'}"
+        ]
+    }


### PR DESCRIPTION
While debugging I came across lines like: 
```
- Comparator: <bound method null.__eq__ of test>
``` 
Kept me on the wrong trail for a bit. Turns out `org.python.types.Type` objects on `org.python.types.Method`s don't have a `__name__` registered. This change uses `org.python.types.Type`'s `repr` method, resulting in logs like: 
```
- Comparator: <bound method <class 'str'>.__eq__ of test>
``` 