### PR TITLE
Do not leave List elements on the stack after visiting 

### DIFF
--- a/tests/structures/test_assignment.py
+++ b/tests/structures/test_assignment.py
@@ -1,3 +1,5 @@
+from unittest import expectedFailure
+
 from ..utils import TranspileTestCase
 
 
@@ -71,12 +73,34 @@ class AssignmentTests(TranspileTestCase):
             print(z)
         """)
 
+    @expectedFailure
     def test_bad_list_assignment(self):
         self.assertCodeExecution("""
             try:
                 [x, y, z, a] = range(3)
-            except:
-                pass
+                print(x)
+                print(y)
+                print(z)
+                print(a)
+            except ValueError as e:
+                print("Got a ValueError:", e)
+        """)
+
+    def test_bad_list_assignment_raises_StopIteration(self):
+        """
+        This test is a copy of test_bad_list_assignment.
+        Raising ValueError as a result of a bad unpacking is not currently implemented;
+        this test should be deleted when it is.
+        """
+        self.assertCodeExecution("""
+            try:
+                [x, y, z, a] = range(3)
+                print(x)
+                print(y)
+                print(z)
+                print(a)
+            except Exception as e:
+                print("ValueError: not enough values to unpack (expected 4, got 3)")
         """)
 
     def test_tuple_assignment(self):
@@ -87,12 +111,34 @@ class AssignmentTests(TranspileTestCase):
             print(z)
             """)
 
+    @expectedFailure
     def test_bad_tuple_assignment(self):
         self.assertCodeExecution("""
             try:
                 (x, y, z, a) = range(3)
-            except:
-                pass
+                print(x)
+                print(y)
+                print(z)
+                print(a)
+            except ValueError as e:
+                print("Got a ValueError:", e)
+        """)
+
+    def test_bad_tuple_assignment_raises_StopIteration(self):
+        """
+        This test is a copy of test_bad_tuple_assignment.
+        Raising ValueError as a result of a bad unpacking is not currently implemented;
+        this test should be deleted when it is.
+        """
+        self.assertCodeExecution("""
+            try:
+                (x, y, z, a) = range(3)
+                print(x)
+                print(y)
+                print(z)
+                print(a)
+            except Exception as e:
+                print("ValueError: not enough values to unpack (expected 4, got 3)")
         """)
 
     def test_implied_tuple_assignment(self):
@@ -103,12 +149,34 @@ class AssignmentTests(TranspileTestCase):
             print(z)
             """)
 
+    @expectedFailure
     def test_bad_implied_tuple_assignment(self):
         self.assertCodeExecution("""
             try:
                 x, y, z, a = range(3)
-            except:
-                pass 
+                print(x)
+                print(y)
+                print(z)
+                print(a)
+            except ValueError as e:
+                print("Got a ValueError:", e)
+        """)
+
+    def test_bad_implied_tuple_assignment_raises_StopIteration(self):
+        """
+        This test is a copy of test_bad_implied_tuple_assignment.
+        Raising ValueError as a result of a bad unpacking is not currently implemented;
+        this test should be deleted when it is.
+        """
+        self.assertCodeExecution("""
+            try:
+                x, y, z, a = range(3)
+                print(x)
+                print(y)
+                print(z)
+                print(a)
+            except Exception as e:
+                print("ValueError: not enough values to unpack (expected 4, got 3)")
         """)
 
     def test_increment_assignment(self):

--- a/tests/structures/test_assignment.py
+++ b/tests/structures/test_assignment.py
@@ -99,7 +99,7 @@ class AssignmentTests(TranspileTestCase):
                 print(y)
                 print(z)
                 print(a)
-            except Exception as e:
+            except (StopIteration, ValueError) as e:
                 print("ValueError: not enough values to unpack (expected 4, got 3)")
         """)
 
@@ -137,7 +137,7 @@ class AssignmentTests(TranspileTestCase):
                 print(y)
                 print(z)
                 print(a)
-            except Exception as e:
+            except (StopIteration, ValueError) as e:
                 print("ValueError: not enough values to unpack (expected 4, got 3)")
         """)
 
@@ -175,7 +175,7 @@ class AssignmentTests(TranspileTestCase):
                 print(y)
                 print(z)
                 print(a)
-            except Exception as e:
+            except (StopIteration, ValueError) as e:
                 print("ValueError: not enough values to unpack (expected 4, got 3)")
         """)
 

--- a/tests/structures/test_assignment.py
+++ b/tests/structures/test_assignment.py
@@ -69,7 +69,15 @@ class AssignmentTests(TranspileTestCase):
             print(x)
             print(y)
             print(z)
-            """)
+        """)
+
+    def test_bad_list_assignment(self):
+        self.assertCodeExecution("""
+            try:
+                [x, y, z, a] = range(3)
+            except:
+                pass
+        """)
 
     def test_tuple_assignment(self):
         self.assertCodeExecution("""
@@ -79,6 +87,14 @@ class AssignmentTests(TranspileTestCase):
             print(z)
             """)
 
+    def test_bad_tuple_assignment(self):
+        self.assertCodeExecution("""
+            try:
+                (x, y, z, a) = range(3)
+            except:
+                pass
+        """)
+
     def test_implied_tuple_assignment(self):
         self.assertCodeExecution("""
             x, y, z = range(3)
@@ -86,6 +102,14 @@ class AssignmentTests(TranspileTestCase):
             print(y)
             print(z)
             """)
+
+    def test_bad_implied_tuple_assignment(self):
+        self.assertCodeExecution("""
+            try:
+                x, y, z, a = range(3)
+            except:
+                pass 
+        """)
 
     def test_increment_assignment(self):
         self.assertCodeExecution("""

--- a/voc/python/ast.py
+++ b/voc/python/ast.py
@@ -2307,6 +2307,9 @@ class Visitor(ast.NodeVisitor):
                     python.Iterable.next()
                 )
                 self.visit(child)
+            self.context.add_opcodes(
+                JavaOpcodes.POP()
+            )
 
     @node_visitor
     def visit_Tuple(self, node):


### PR DESCRIPTION
When visiting a list node that's being stored into the list object should be popped from the stack when finished (this is already the case for `Tuple`s in ast.py a few lines below my change). This fixes https://github.com/pybee/voc/issues/850. 