### PR TITLE
Remove unneeded cast to org/python/types/Int

### DIFF
--- a/voc/python/blocks.py
+++ b/voc/python/blocks.py
@@ -155,9 +155,7 @@ class Block(Accumulator):
         self.add_opcodes(
             LCONST_val(value),
             JavaOpcodes.INVOKESTATIC('org/python/types/Int', 'getInt', args=['J'], returns='Lorg/python/types/Int;'),
-            JavaOpcodes.CHECKCAST('org/python/types/Int'),
         )
-
 
     def add_float(self, value):
         self.add_opcodes(


### PR DESCRIPTION
The static method `org.python.types.Int.getInt()` returns a `org/python/types/Int`, so the `CHECKCAST` operation is unnecessary. 

Related to https://github.com/pybee/voc/pull/825