### PR TITLE
Fixed #866 RunTimeError when generator is nested in more than 1 level of function definition

### DIFF
--- a/tests/structures/test_function.py
+++ b/tests/structures/test_function.py
@@ -1,5 +1,3 @@
-from unittest import expectedFailure
-
 from ..utils import TranspileTestCase
 
 
@@ -240,7 +238,6 @@ class FunctionTests(TranspileTestCase):
             print("value =", myfunc(5))
             """)
 
-    @expectedFailure
     def test_redefine_nested_from_other_function(self):
         self.assertCodeExecution("""
             def func():
@@ -257,6 +254,20 @@ class FunctionTests(TranspileTestCase):
 
             func()
             func2()
+            """)
+
+    def test_define_nested_generator(self):
+        self.assertCodeExecution("""
+            def wrapper():
+                def func():
+                    def gen():
+                        yield 'Hello World'
+
+                    print(next(gen()))
+
+                func()
+
+            wrapper()
             """)
 
     def test_noarg_unexpected_extra_arg(self):

--- a/tests/structures/test_function.py
+++ b/tests/structures/test_function.py
@@ -1,3 +1,5 @@
+from unittest import expectedFailure
+
 from ..utils import TranspileTestCase
 
 
@@ -238,6 +240,7 @@ class FunctionTests(TranspileTestCase):
             print("value =", myfunc(5))
             """)
 
+    @expectedFailure
     def test_redefine_nested_from_other_function(self):
         self.assertCodeExecution("""
             def func():

--- a/voc/python/methods.py
+++ b/voc/python/methods.py
@@ -1115,7 +1115,7 @@ class GeneratorFunction(Function):
             JavaOpcodes.LDC_W(self.generator),
 
             # p2: The actual generator method
-            java.Class.forName(self.klass.class_name),
+            java.Class.forName(self.class_descriptor.replace('/', '.')),
 
             JavaOpcodes.LDC_W(self.method_name + "$generator"),
             java.Array(1, 'java/lang/Class'),


### PR DESCRIPTION
On closer inspection, the reason for the `RuntimeError` in #866 was due to incorrect class path name.

Considering the code below (Test.py):
```
def wrapped():
    def func():
        def gen():
            yield 'Hello World'

        print(next(gen()))

    func()
    
wrapped()
```

The path to `gen` would be `python.Test.func$gen`, as indicated in compilation output:
```
Compiling Test.py ...
Writing .\python\Test.class ...
Writing .\python\Test\func.class ...
Writing .\python\Test\func$gen.class ...
```
However, during runtime, the path to `gen` becomes `python.Test.func.gen` instead of `python.Test.func$gen`, causing `java.lang.ClassNotFoundException` which is wrapped in `RuntimeError`.

The root cause is on line 1118 of `methods.py`, when declaring classpath of generator method, `self.klass.class_name` returns `python.Test.func.gen`. To fix this, I replaced it with `self.class_descriptor.replace('/', '.')` to get `python.Test.func$gen`