### PR TITLE
Fixed #861 Redefining nested function from other function overrides original nested function

### DIFF
--- a/tests/structures/test_function.py
+++ b/tests/structures/test_function.py
@@ -1,5 +1,3 @@
-from unittest import expectedFailure
-
 from ..utils import TranspileTestCase
 
 
@@ -240,7 +238,6 @@ class FunctionTests(TranspileTestCase):
             print("value =", myfunc(5))
             """)
 
-    @expectedFailure
     def test_redefine_nested_from_other_function(self):
         self.assertCodeExecution("""
             def func():

--- a/voc/python/methods.py
+++ b/voc/python/methods.py
@@ -446,9 +446,13 @@ class Function(Block):
         # If a function is added to a function, it is added as an anonymous
         # inner class to the function/method's parent module/class.
         from .klass import ClosureClass
+        if not (isinstance(self, Closure) or isinstance(self, GeneratorClosure)):
+            # prepend name to first level nested function
+            name = self.name + '$' + name
+
         klass = ClosureClass(
             parent=self._parent,
-            name=self.name + '$' + name,
+            name=name,
             closure_var_names=code.co_freevars,
         )
         self.module.classes.append(klass)

--- a/voc/python/methods.py
+++ b/voc/python/methods.py
@@ -448,7 +448,7 @@ class Function(Block):
         from .klass import ClosureClass
         klass = ClosureClass(
             parent=self._parent,
-            name=name,
+            name=self.name + '$' + name,
             closure_var_names=code.co_freevars,
         )
         self.module.classes.append(klass)


### PR DESCRIPTION
Fixed #861 according to the approach described in that ticket