### PR TITLE
Do not create code objects

### DIFF
--- a/tests/benchmarks.py
+++ b/tests/benchmarks.py
@@ -113,6 +113,31 @@ def test_function_var_load(test_case):
             foo()
     """), timed=True)
 
+def test_code(test_case):
+    print("Running", "test_code")
+    test_case.runAsJava(adjust("""
+        def main(n):
+            def foo(n):
+                return n + 1
+            def bar(n):
+                return n + 1
+            def baz(n):
+                return n + 1
+            def buzz(n):
+                return n + 1
+            def bizz(n):
+                return n + 1
+            def bozz(n):
+                return n + 1
+            def yam(n):
+                return n + 1
+            def yarn(n):
+                return n + 1
+            return foo(bar(baz(buzz(bizz(bozz(yam(yarn(n))))))))
+        for i in range(100000):
+            main(i)
+    """), timed=True)
+
 def main():
     test_case = TranspileTestCase()
     test_case.setUpClass()
@@ -121,6 +146,7 @@ def main():
     test_global_var_load(test_case)
     test_class_var_load(test_case)
     test_function_var_load(test_case)
+    test_code(test_case)
 
 if __name__== "__main__":
   main()

--- a/tests/structures/test_function.py
+++ b/tests/structures/test_function.py
@@ -1,3 +1,5 @@
+from unittest import expectedFailure
+
 from ..utils import TranspileTestCase
 
 
@@ -386,4 +388,25 @@ class FunctionTests(TranspileTestCase):
                 print('a' in {1, 'a', False, 1.1, b'1', (2)})
 
             func()
+        """)
+
+    @expectedFailure
+    def test_function_has_code_attr(self):
+        self.assertCodeExecution("""
+            def func():
+                return 1
+
+            if func.__code__ is not None:
+                print("Code object exists")
+        """)
+
+    @expectedFailure
+    def test_function_code_attr(self):
+        self.assertCodeExecution("""
+            def func():
+                return 1
+
+            print("__code__:", func.__code__)
+            print("Function name:", func.__code__.co_name)
+            print("Arg count:", func.__code__.co_argcount)
         """)

--- a/voc/python/blocks.py
+++ b/voc/python/blocks.py
@@ -223,6 +223,49 @@ class Block(Accumulator):
         else:
             raise RuntimeError("Unknown constant type %s" % type(val))
 
+    def add_list(self, data):
+        self.add_opcodes(
+            java.New('java/util/ArrayList'),
+            java.Init('java/util/ArrayList'),
+        )
+
+        for value in data:
+            self.add_opcodes(
+                JavaOpcodes.DUP(),
+            )
+
+            if value is None:
+                self.add_opcodes(
+                    python.NONE()
+                )
+            elif isinstance(value, frozenset):
+                self.add_opcodes(
+                    java.New('org/python/types/FrozenSet'),
+                    python.Set(),
+                )
+                for elt in value:
+                    self.add_opcodes(
+                        JavaOpcodes.DUP()
+                    )
+
+                    self._add_value(elt)
+
+                    self.add_opcodes(
+                        python.Set.add()
+                    )
+                self.add_opcodes(
+                    java.Init(
+                        'org/python/types/FrozenSet',
+                        'Lorg/python/types/Set;',
+                    )
+                )
+            else:
+                self._add_value(value)
+
+            self.add_opcodes(
+                java.List.add(),
+            )
+
     def add_tuple(self, data):
         self.add_opcodes(
             java.New('org/python/types/Tuple'),
@@ -282,56 +325,15 @@ class Block(Accumulator):
         )
 
         self.add_str(function.code.co_name)
-
-        # Add the code object
         self.add_opcodes(
-                java.New('org/python/types/Code'),
+            JavaOpcodes.LDC_W(function.code.co_argcount),
+            JavaOpcodes.LDC_W(function.code.co_kwonlyargcount),
+            JavaOpcodes.LDC_W(function.code.co_flags),
         )
-
-        self.add_int(function.code.co_argcount)
-        self.add_tuple(function.code.co_cellvars)
-
-        self.add_opcodes(
-                JavaOpcodes.ACONST_NULL(),  # co_code
-        )
-
         self.add_tuple(function.code.co_consts)
-        self.add_str(function.code.co_filename)
-        self.add_int(function.code.co_firstlineno)
-        self.add_int(function.code.co_flags)
-        self.add_tuple(function.code.co_freevars)
-        self.add_int(function.code.co_kwonlyargcount)
+        self.add_list(function.code.co_varnames)
 
         self.add_opcodes(
-                JavaOpcodes.ACONST_NULL(),  # co_lnotab
-        )
-
-        self.add_str(function.code.co_name)
-        self.add_tuple(function.code.co_names)
-        self.add_int(function.code.co_nlocals)
-        self.add_int(function.code.co_stacksize)
-        self.add_tuple(function.code.co_varnames)
-
-        self.add_opcodes(
-                java.Init(
-                    'org/python/types/Code',
-                    'Lorg/python/types/Int;',
-                    'Lorg/python/types/Tuple;',
-                    'Lorg/python/types/Bytes;',
-                    'Lorg/python/types/Tuple;',
-                    'Lorg/python/types/Str;',
-                    'Lorg/python/types/Int;',
-                    'Lorg/python/types/Int;',
-                    'Lorg/python/types/Tuple;',
-                    'Lorg/python/types/Int;',
-                    'Lorg/python/types/Bytes;',
-                    'Lorg/python/types/Str;',
-                    'Lorg/python/types/Tuple;',
-                    'Lorg/python/types/Int;',
-                    'Lorg/python/types/Int;',
-                    'Lorg/python/types/Tuple;',
-                ),
-
                 # Get a Java Method representing the new function
                 JavaOpcodes.LDC_W(Classref(function.class_descriptor)),
                 JavaOpcodes.LDC_W(function.pyimpl_name),
@@ -396,7 +398,11 @@ class Block(Accumulator):
                 java.Init(
                     'org/python/types/Function',
                     'Lorg/python/types/Str;',
-                    'Lorg/python/types/Code;',
+                    'I',
+                    'I',
+                    'I',
+                    'Lorg/python/types/Tuple;',
+                    'Ljava/util/List;',
                     'Ljava/lang/reflect/Method;',
                     'Ljava/util/Map;',
                     'Ljava/util/List;',

--- a/voc/python/blocks.py
+++ b/voc/python/blocks.py
@@ -269,48 +269,8 @@ class Block(Accumulator):
     def add_tuple(self, data):
         self.add_opcodes(
             java.New('org/python/types/Tuple'),
-
-            java.New('java/util/ArrayList'),
-            java.Init('java/util/ArrayList'),
         )
-
-        for value in data:
-            self.add_opcodes(
-                JavaOpcodes.DUP(),
-            )
-
-            if value is None:
-                self.add_opcodes(
-                    python.NONE()
-                )
-            elif isinstance(value, frozenset):
-                self.add_opcodes(
-                    java.New('org/python/types/FrozenSet'),
-                    python.Set(),
-                )
-                for elt in value:
-                    self.add_opcodes(
-                        JavaOpcodes.DUP()
-                    )
-
-                    self._add_value(elt)
-
-                    self.add_opcodes(
-                        python.Set.add()
-                    )
-                self.add_opcodes(
-                    java.Init(
-                        'org/python/types/FrozenSet',
-                        'Lorg/python/types/Set;',
-                    )
-                )
-            else:
-                self._add_value(value)
-
-            self.add_opcodes(
-                java.List.add(),
-            )
-
+        self.add_list(data)
         self.add_opcodes(
             java.Init('org/python/types/Tuple', 'Ljava/util/List;'),
         )


### PR DESCRIPTION
This change is about not creating `Code` objects, only grabbing the values that are needed. This reduces the overhead of creating functions (so it is a one-time gain per function). Let's see some performance stats: 

**On benchmarking test:**
*Without optimization*
```
Running test_code
  Elapsed time:  69.84982615604531  sec
  CPU process time:  0.0008669999999999511  sec
```
```
Running test_code
  Elapsed time:  69.89342098298948  sec
  CPU process time:  0.0009319999999999329  sec
```
```
Running test_code
  Elapsed time:  68.42389843205456  sec
  CPU process time:  0.0009710000000000552  sec
```
```
Running test_code
  Elapsed time:  69.35569038696121  sec
  CPU process time:  0.0010740000000000194  sec
```

*With optimization*
```
Running test_code
  Elapsed time:  51.62230951199308  sec
  CPU process time:  0.0008390000000000342  sec
```
```
Running test_code
  Elapsed time:  52.12950277002528  sec
  CPU process time:  0.0010590000000000321  sec
```
```
Running test_code
  Elapsed time:  52.203202828997746  sec
  CPU process time:  0.0009040000000000159  sec
```
```
Running test_code
  Elapsed time:  52.396196495043114  sec
  CPU process time:  0.0010430000000000161  sec
``` 

About a 25% improvement. 

**On pystone:**

*Without optimization* 
```
test_pystone (tests.test_pystone.PystoneTest) ... Pystone(1.2) time for 50000 passes = 38.7340
This machine benchmarks at 1290.85 pystones/second
```
```
test_pystone (tests.test_pystone.PystoneTest) ... Pystone(1.2) time for 50000 passes = 38.2483
This machine benchmarks at 1307.25 pystones/second
```
```
test_pystone (tests.test_pystone.PystoneTest) ... Pystone(1.2) time for 50000 passes = 40.6756
This machine benchmarks at 1229.24 pystones/second
```

*With optimization* 
```
test_pystone (tests.test_pystone.PystoneTest) ... Pystone(1.2) time for 50000 passes = 35.3792
This machine benchmarks at 1413.26 pystones/second
```
```
test_pystone (tests.test_pystone.PystoneTest) ... Pystone(1.2) time for 50000 passes = 35.2154
This machine benchmarks at 1419.83 pystones/second
```
```
test_pystone (tests.test_pystone.PystoneTest) ... Pystone(1.2) time for 50000 passes = 36.0494
This machine benchmarks at 1386.99 pystones/second
```

About a 8-ish% improvement. 