### PR TITLE
Added closure related test cases

### DIFF
--- a/tests/structures/test_closure.py
+++ b/tests/structures/test_closure.py
@@ -1,3 +1,5 @@
+from unittest import expectedFailure
+
 from ..utils import TranspileTestCase
 
 
@@ -12,3 +14,75 @@ class ClosureTests(TranspileTestCase):
                 level2()
             level3()
             """, run_in_function=False)
+
+    @expectedFailure
+    def test_rebind_closure_var_before_closure_construction(self):
+        self.assertCodeExecution("""
+            def func():
+                closure_var = 'before nested is defined'
+                def nested():
+                    print(closure_var)
+                closure_var = 'after nested is defined'
+                nested() 
+            func()
+            """)
+
+    @expectedFailure
+    def test_generator_closure(self):
+        self.assertCodeExecution("""
+            def func():
+                closure_var = 'hello world'
+                def gen():
+                    print(closure_var)
+                    yield
+                next(gen())
+            func()
+            
+            def gen():
+                closure_var = 'hello world'
+                def func():
+                    print(closure_var)
+                func()
+                yield
+            next(gen())
+            """)
+
+    @expectedFailure
+    def test_class_closure(self):
+        self.assertCodeExecution("""
+            def func():
+                closure_var = 'hello world'
+                class Inner:
+                    print(closure_var)
+                Inner()
+            func()
+
+            def gen():
+                closure_var = 'hello world'
+                class Inner:
+                    print(closure_var)
+                Inner()
+                yield
+            next(gen())
+            """)
+
+    @expectedFailure
+    def test_method_closure(self):
+        self.assertCodeExecution("""
+            def func():
+                closure_var = 'hello world'
+                class Inner:
+                    def method(self):
+                        print(closure_var)
+                Inner().method()
+            func()
+
+            def gen():
+                closure_var = 'hello world'
+                class Inner:
+                    def method(self):
+                        print(closure_var)
+                Inner().method()
+                yield
+            next(gen())
+            """)

--- a/tests/structures/test_closure.py
+++ b/tests/structures/test_closure.py
@@ -15,7 +15,6 @@ class ClosureTests(TranspileTestCase):
             level3()
             """, run_in_function=False)
 
-    @expectedFailure
     def test_rebind_closure_var_before_closure_construction(self):
         self.assertCodeExecution("""
             def func():
@@ -23,11 +22,10 @@ class ClosureTests(TranspileTestCase):
                 def nested():
                     print(closure_var)
                 closure_var = 'after nested is defined'
-                nested() 
+                nested()
             func()
             """)
 
-    @expectedFailure
     def test_generator_closure(self):
         self.assertCodeExecution("""
             def func():
@@ -37,7 +35,7 @@ class ClosureTests(TranspileTestCase):
                     yield
                 next(gen())
             func()
-            
+
             def gen():
                 closure_var = 'hello world'
                 def func():

--- a/tests/structures/test_nonlocal.py
+++ b/tests/structures/test_nonlocal.py
@@ -1,0 +1,127 @@
+from unittest import expectedFailure
+
+from ..utils import TranspileTestCase
+
+
+class NonlocalTests(TranspileTestCase):
+    @expectedFailure
+    def test_nonlocal_func(self):
+        self.assertCodeExecution("""
+            def func():
+                a = 'a from outer'
+                b = 'b from outer'
+                def nested_func():
+                    nonlocal a
+                    print(a)
+                    a = 'a from inner'
+                    print(a)
+                    b = 'b from inner'
+                    print(b)
+
+                nested_func()
+                print(a)
+                print(b)
+
+            func()
+
+            def func2():
+                a = 'a from outer'
+                b = 'b from outer'
+                def nested_func2():
+                    nonlocal a
+                    print(a)
+                    a = 'a from inner'
+                    print(a)
+                    def nested_nested_func():
+                        nonlocal b
+                        print(b)
+                        b = 'b from innest'
+                        print(b)
+
+                    nested_nested_func()
+
+                nested_func2()
+                print(a)
+                print(b)
+
+            func2()
+        """)
+
+    @expectedFailure
+    def test_nonlocal_class(self):
+        self.assertCodeExecution("""
+            def func():
+                a = 'a from outer'
+                b = 'b from outer'
+                class Inner():
+                    nonlocal a
+                    print(a)
+                    a = 'a from inner'
+                    b = 'b from inner'
+                    print(a)
+                    print(b)
+
+                Inner()
+                print(a)
+                print(b)
+
+            func()
+        """)
+
+    @expectedFailure
+    def test_nonlocal_method(self):
+        self.assertCodeExecution("""
+            def func():
+                a = 'a from outer'
+                b = 'b from outer'
+                class Klass:
+                    def method(self):
+                        nonlocal a
+                        print(a)
+                        a = 'a from inner'
+                        print(a)
+                        print(b)
+
+                Klass().method()
+                print(a)
+                print(b)
+
+            func()
+        """)
+
+    @expectedFailure
+    def test_nonlocal_generator(self):
+        self.assertCodeExecution("""
+            def func():
+                a = 'a from outer'
+                b = 'b from outer'
+                def gen():
+                    nonlocal a
+                    print(a)
+                    print(b)
+                    a = 'a from inner'
+                    yield a
+
+                print(next(gen()))
+                print(a)
+                print(b)
+
+            func()
+
+            def func2():
+                a = 'a from outer'
+                b = 'b from outer'
+                def gen():
+                    nonlocal a
+                    print(a)
+                    print(b)
+                    a = 'a from inner'
+                    yield a
+
+                print(next(gen()))
+                print(a)
+                print(b)
+                yield
+
+            next(func2())
+        """)

--- a/tests/structures/test_nonlocal.py
+++ b/tests/structures/test_nonlocal.py
@@ -4,7 +4,6 @@ from ..utils import TranspileTestCase
 
 
 class NonlocalTests(TranspileTestCase):
-    @expectedFailure
     def test_nonlocal_func(self):
         self.assertCodeExecution("""
             def func():


### PR DESCRIPTION
While all but one test cases failed because voc currently doesn't support closure in generator, class and method context yet, I want to highlight 1 particular test case which isn't addressed in voc's current closure creation logic. As pointed out by @freakboy3742 , consider the following:
```
def func():
    closure_var = 'before nested is defined'
    def nested():
        print(closure_var)
    closure_var = 'after nested is defined'
    nested() 
func()
```
CPython3 will print `after nested is defined` in console while voc prints `before nested is defined`.
This is because voc takes the value of closure variable at the moment the closure function is defined and that value is stored in `closure_vars` field of that closure. Thus any rebinding of closure variables in enclosing scope after closure definition is not known to the closure.

As @freakboy3742 mentioned, current implementation of closure in voc may require some modifications /rework to allow closure to acquire the 'latest' value of closure variable. 
Perhaps we could make use of `code.co_cellvars` in enclosing scope's context and store free variables somewhere else instead of local register of enclosing context so both enclosing scope and closure scope can be directed to that storage space when they want to access free variables. Plus it would also make nonlocal implementation easier because closure can directly modify nonlocal value in that same storage space.