### PR TITLE
Comparisons optimization 

### DIFF
--- a/python/common/org/Python.java
+++ b/python/common/org/Python.java
@@ -1066,11 +1066,7 @@ public class Python {
     }
 
     private static boolean compareKeys(org.python.Object first, org.python.Object second) {
-        return org.python.types.Object.__cmp__(
-                    first,
-                    second,
-                    org.python.types.Object.CMP_OP.GT
-                ).toBoolean();
+        return org.python.types.Object.__gt__(first, second).toBoolean();
     }
 
     @org.python.Method(
@@ -1584,11 +1580,11 @@ public class Python {
         public int compare(org.python.Object o1, org.python.Object o2) {
             o1 = applyKey(o1, key);
             o2 = applyKey(o2, key);
-            org.python.Object result = org.python.types.Object.__cmp_bool__(o1, o2, org.python.types.Object.CMP_OP.LT);
+            org.python.Object result = org.python.types.Object.__lt__(o1, o2);
             if (result.toBoolean()) {
                 return reverse ? 1 : -1;
             }
-            result = org.python.types.Object.__cmp_bool__(o2, o1, org.python.types.Object.CMP_OP.LT);
+            result = org.python.types.Object.__lt__(o2, o1);
             if (result.toBoolean()) {
                 return reverse ? -1 : 1;
             }

--- a/python/common/org/python/types/Int.java
+++ b/python/common/org/python/types/Int.java
@@ -198,6 +198,7 @@ public class Int extends org.python.types.Object {
             }
             return org.python.types.Bool.FALSE;
         }
+        
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
 

--- a/python/common/org/python/types/Int.java
+++ b/python/common/org/python/types/Int.java
@@ -198,7 +198,6 @@ public class Int extends org.python.types.Object {
             }
             return org.python.types.Bool.FALSE;
         }
-        
         return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
     }
 

--- a/python/common/org/python/types/List.java
+++ b/python/common/org/python/types/List.java
@@ -198,8 +198,8 @@ public class List extends org.python.types.Object {
             // check how many items are identical on the lists
             int i = 0;
             for (i = 0; i < count; i++) {
-                org.python.types.Bool result = (org.python.types.Bool) org.python.types.Object.__cmp_bool__(
-                        this.value.get(i), otherList.value.get(i), org.python.types.Object.CMP_OP.EQ);
+                org.python.types.Bool result = (org.python.types.Bool) org.python.types.Object.__cmp_eq__(
+                        this.value.get(i), otherList.value.get(i));
                 if (!result.value) {
                     break;
                 }
@@ -207,8 +207,7 @@ public class List extends org.python.types.Object {
 
             // not all items were identical, result is that of the first non-identical item
             if (i < count) {
-                return org.python.types.Object.__cmp_bool__(this.value.get(i), otherList.value.get(i),
-                        org.python.types.Object.CMP_OP.LT);
+                return org.python.types.Object.__lt__(this.value.get(i), otherList.value.get(i));
             }
 
             // all items were identical, break tie by size
@@ -232,8 +231,8 @@ public class List extends org.python.types.Object {
             // check how many items are identical on the lists
             int i = 0;
             for (i = 0; i < count; i++) {
-                org.python.types.Bool result = (org.python.types.Bool) org.python.types.Object.__cmp_bool__(
-                        this.value.get(i), otherList.value.get(i), org.python.types.Object.CMP_OP.EQ);
+                org.python.types.Bool result = (org.python.types.Bool) org.python.types.Object.__cmp_eq__(
+                        this.value.get(i), otherList.value.get(i));
                 if (!result.value) {
                     break;
                 }
@@ -241,8 +240,7 @@ public class List extends org.python.types.Object {
 
             // not all items were identical, result is that of the first non-identical item
             if (i < count) {
-                return org.python.types.Object.__cmp_bool__(this.value.get(i), otherList.value.get(i),
-                        org.python.types.Object.CMP_OP.LE);
+                return org.python.types.Object.__le__(this.value.get(i), otherList.value.get(i));
             }
 
             // all items were identical, break tie by size
@@ -278,8 +276,8 @@ public class List extends org.python.types.Object {
             // check how many items are identical on the lists
             int i = 0;
             for (i = 0; i < count; i++) {
-                org.python.types.Bool result = (org.python.types.Bool) org.python.types.Object.__cmp_bool__(
-                        this.value.get(i), otherList.value.get(i), org.python.types.Object.CMP_OP.EQ);
+                org.python.types.Bool result = (org.python.types.Bool) org.python.types.Object.__cmp_eq__(
+                        this.value.get(i), otherList.value.get(i));
                 if (!result.value) {
                     break;
                 }
@@ -287,8 +285,7 @@ public class List extends org.python.types.Object {
 
             // not all items were identical, result is that of the first non-identical item
             if (i < count) {
-                return org.python.types.Object.__cmp_bool__(this.value.get(i), otherList.value.get(i),
-                        org.python.types.Object.CMP_OP.GT);
+                return org.python.types.Object.__gt__(this.value.get(i), otherList.value.get(i));
             }
 
             // all items were identical, break tie by size
@@ -312,8 +309,8 @@ public class List extends org.python.types.Object {
             // check how many items are identical on the lists
             int i = 0;
             for (i = 0; i < count; i++) {
-                org.python.types.Bool result = (org.python.types.Bool) org.python.types.Object.__cmp_bool__(
-                        this.value.get(i), otherList.value.get(i), org.python.types.Object.CMP_OP.EQ);
+                org.python.types.Bool result = (org.python.types.Bool) org.python.types.Object.__cmp_eq__(
+                        this.value.get(i), otherList.value.get(i));
                 if (!result.value) {
                     break;
                 }
@@ -321,8 +318,7 @@ public class List extends org.python.types.Object {
 
             // not all items were identical, result is that of the first non-identical item
             if (i < count) {
-                return org.python.types.Object.__cmp_bool__(this.value.get(i), otherList.value.get(i),
-                        org.python.types.Object.CMP_OP.GE);
+                return org.python.types.Object.__ge__(this.value.get(i), otherList.value.get(i));
             }
 
             // all items were identical, break tie by size
@@ -553,8 +549,8 @@ public class List extends org.python.types.Object {
     public org.python.Object __contains__(org.python.Object item) {
         boolean found = false;
         for (int i = 0; i < this.value.size(); i++) {
-            if (((org.python.types.Bool) org.python.types.Object.__cmp_bool__(
-                    item, this.value.get(i), org.python.types.Object.CMP_OP.EQ)).value) {
+            if (((org.python.types.Bool) org.python.types.Object.__cmp_eq__(
+                    item, this.value.get(i))).value) {
                 found = true;
                 break;
             }
@@ -664,8 +660,8 @@ public class List extends org.python.types.Object {
     public org.python.Object count(org.python.Object other) {
         int count = 0;
         for (int i = 0; i < this.value.size(); i++) {
-            if (((org.python.types.Bool) org.python.types.Object.__cmp_bool__(
-                    other, this.value.get(i), org.python.types.Object.CMP_OP.EQ)).value) {
+            if (((org.python.types.Bool) org.python.types.Object.__cmp_eq__(
+                    other, this.value.get(i))).value) {
                 count++;
             }
         }
@@ -763,8 +759,8 @@ public class List extends org.python.types.Object {
         }
 
         for (int i = iStart; i < Math.min(iEnd, this.value.size()); i++) {
-            if (((org.python.types.Bool) org.python.types.Object.__cmp_bool__(
-                    item, this.value.get(i), org.python.types.Object.CMP_OP.EQ)).value) {
+            if (((org.python.types.Bool) org.python.types.Object.__cmp_eq__(
+                    item, this.value.get(i))).value) {
                 return org.python.types.Int.getInt(i);
             }
         }
@@ -818,8 +814,8 @@ public class List extends org.python.types.Object {
     )
     public org.python.Object remove(org.python.Object item) {
         for (int i = 0; i < this.value.size(); i++) {
-            if (((org.python.types.Bool) org.python.types.Object.__cmp_bool__(
-                    item, this.value.get(i), org.python.types.Object.CMP_OP.EQ)).value) {
+            if (((org.python.types.Bool) org.python.types.Object.__cmp_eq__(
+                    item, this.value.get(i))).value) {
                 this.value.remove(i);
                 return org.python.types.NoneType.NONE;
             }

--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -1108,9 +1108,31 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         }
     }
 
+    private static org.python.Object resolveComparison(int cmpResult, String methodName) {
+        switch(methodName) {
+            case "__eq__":
+                return org.python.types.Bool.getBool(cmpResult == 0);
+            case "__lt__":
+                return org.python.types.Bool.getBool(cmpResult < 0);
+            case "__le__":
+                return org.python.types.Bool.getBool(cmpResult <= 0);
+            case "__gt__":
+                return org.python.types.Bool.getBool(cmpResult > 0);
+            case "__ge__":
+                return org.python.types.Bool.getBool(cmpResult >= 0);
+            default:
+                return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
+        }
+    }
+
     private static org.python.Object invokeComparison(org.python.Object x, org.python.Object y, String methodName) {
         if (methodName == null) {
             return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
+        }
+
+        if (x instanceof org.python.types.Str && y instanceof org.python.types.Str) {
+            int res = ((org.python.types.Str) x).value.compareTo(((org.python.types.Str) y).value);
+            return resolveComparison(res, methodName);
         }
 
         org.python.Object comparator = x.__getattribute_null(methodName);
@@ -1121,6 +1143,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         org.python.Object[] args = new org.python.Object[1];
         args[0] = y;
         return (org.python.Object) ((org.python.types.Method) comparator).invoke(args, null);
+
     }
 
     public static boolean isSequence(org.python.Object other) {

--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -1341,7 +1341,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
             if (w_builtin) {
                 result = w.__le__(v);
             } else {
-                result = invokeComparison(w, v, "__le");
+                result = invokeComparison(w, v, "__le__");
             }
 
             if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {

--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -1081,15 +1081,15 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
 
         // Now check reflection
         if (!reflectedChecked) {
-          if (w_builtin) {
-              result = w.__gt__(v);
-          } else {
-              result = invokeComparison(w, v, "__gt__");
-          }
+            if (w_builtin) {
+                result = w.__gt__(v);
+            } else {
+                result = invokeComparison(w, v, "__gt__");
+            }
 
-          if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
-              return result;
-          }
+            if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
+                return result;
+            }
         }
 
         // Error case
@@ -1136,15 +1136,15 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
 
         // Now check reflection
         if (!reflectedChecked) {
-          if (w_builtin) {
-              result = w.__ge__(v);
-          } else {
-              result = invokeComparison(w, v, "__ge__");
-          }
+            if (w_builtin) {
+                result = w.__ge__(v);
+            } else {
+                result = invokeComparison(w, v, "__ge__");
+            }
 
-          if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
-              return result;
-          }
+            if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
+                return result;
+            }
         }
 
         // Error case
@@ -1190,15 +1190,15 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
 
         // Now check reflection
         if (!reflectedChecked) {
-          if (w_builtin) {
-              result = w.__eq__(v);
-          } else {
-              result = invokeComparison(w, v, "__eq__");
-          }
+            if (w_builtin) {
+                result = w.__eq__(v);
+            } else {
+                result = invokeComparison(w, v, "__eq__");
+            }
 
-          if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
-              return result;
-          }
+            if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
+                return result;
+            }
         }
 
         return org.python.types.Bool.getBool(v == w);
@@ -1237,15 +1237,15 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
 
         // Now check reflection
         if (!reflectedChecked) {
-          if (w_builtin) {
-              result = w.__ne__(v);
-          } else {
-              result = invokeComparison(w, v, "__ne__");
-          }
+            if (w_builtin) {
+                result = w.__ne__(v);
+            } else {
+                result = invokeComparison(w, v, "__ne__");
+            }
 
-          if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
-              return result;
-          }
+            if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
+                return result;
+            }
         }
 
         return org.python.types.Bool.getBool(v != w);
@@ -1284,15 +1284,15 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
 
         // Now check reflection
         if (!reflectedChecked) {
-          if (w_builtin) {
-              result = w.__lt__(v);
-          } else {
+            if (w_builtin) {
+                result = w.__lt__(v);
+            } else {
               result = invokeComparison(w, v, "__lt__");
-          }
+            }
 
-          if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
-              return result;
-          }
+            if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
+                return result;
+            }
         }
 
         // Error case
@@ -1338,15 +1338,15 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
 
         // Now check reflection
         if (!reflectedChecked) {
-          if (w_builtin) {
-              result = w.__le__(v);
-          } else {
-              result = invokeComparison(w, v, "__le");
-          }
+            if (w_builtin) {
+                result = w.__le__(v);
+            } else {
+                result = invokeComparison(w, v, "__le");
+            }
 
-          if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
-              return result;
-          }
+            if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
+                return result;
+            }
         }
 
         // Error case
@@ -1393,15 +1393,15 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
 
         // Now check reflection
         if (!reflectedChecked) {
-          if (w_builtin) {
-              result = w.__contains__(v);
-          } else {
-              result = invokeComparison(w, v, "__contains__");
-          }
+            if (w_builtin) {
+                result = w.__contains__(v);
+            } else {
+                result = invokeComparison(w, v, "__contains__");
+            }
 
-          if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
-              return result;
-          }
+            if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
+                return result;
+            }
         }
 
         // Error case
@@ -1447,15 +1447,15 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
 
         // Now check reflection
         if (!reflectedChecked) {
-          if (w_builtin) {
-              result = w.__not_contains__(v);
-          } else {
-              result = invokeComparison(w, v, "__not_contains__");
-          }
+            if (w_builtin) {
+                result = w.__not_contains__(v);
+            } else {
+                result = invokeComparison(w, v, "__not_contains__");
+            }
 
-          if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
-              return result;
-          }
+            if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
+                return result;
+            }
         }
 
         // Error case

--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -1038,14 +1038,27 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         return (result instanceof org.python.types.Bool) ? result : result.__bool__();
     }
 
+    private static boolean isBuiltin(org.python.Object obj) {
+        return obj instanceof org.python.types.Int || obj instanceof org.python.types.Str ||
+                obj instanceof org.python.types.Bool || obj instanceof org.python.types.Float ||
+                obj instanceof org.python.types.List || obj instanceof org.python.types.Dict ||
+                obj instanceof org.python.types.Tuple || obj instanceof org.python.types.Set ||
+                obj instanceof org.python.types.Range || obj instanceof org.python.types.Slice || 
+                obj instanceof org.python.types.Bytes || obj instanceof org.python.types.Complex ||
+                obj instanceof org.python.types.ByteArray || obj instanceof org.python.types.FrozenSet ||
+                obj instanceof org.python.types.MemoryView;
+    }
+
     public static org.python.Object __lt__(org.python.Object v, org.python.Object w) {
         org.python.Object result = org.python.types.NotImplementedType.NOT_IMPLEMENTED;
         boolean reflectedChecked = v.type() != w.type()
                 && ((org.python.types.Bool) org.Python.isinstance(w, v.type())).value;
+        boolean v_builtin = isBuiltin(v);
+        boolean w_builtin = isBuiltin(w);
 
         // Reflective case
         if (reflectedChecked) {
-            if (w instanceof org.python.types.Str) { // TODO all builtin types
+            if (w_builtin) {
                 result = w.__gt__(v);
             } else {
                 result = invokeComparison(w, v, "__gt__");
@@ -1057,19 +1070,18 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         }
 
         // Normal case
-        if (v instanceof org.python.types.Str) { // TODO all builtin types
+        if (v_builtin) {
             result = v.__lt__(w);
         } else {
             result = invokeComparison(v, w, "__lt__");
         }
-
         if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
             return result;
         }
 
         // Now check reflection
         if (!reflectedChecked) {
-          if (w instanceof org.python.types.Str) { // TODO all builtin types
+          if (w_builtin) {
               result = w.__gt__(v);
           } else {
               result = invokeComparison(w, v, "__gt__");
@@ -1095,9 +1107,13 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         boolean reflectedChecked = v.type() != w.type()
                 && ((org.python.types.Bool) org.Python.isinstance(w, v.type())).value;
 
+        boolean v_builtin = isBuiltin(v);
+        boolean w_builtin = isBuiltin(w);
+
+
         // Reflective case
         if (reflectedChecked) {
-            if (w instanceof org.python.types.Str) { // TODO all builtin types
+            if (w_builtin) {
                 result = w.__ge__(v);
             } else {
                 result = invokeComparison(w, v, "__ge__");
@@ -1109,15 +1125,18 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         }
 
         // Normal case
-        if (v instanceof org.python.types.Str) { // TODO all builtin types
+        if (v_builtin) {
             result = v.__le__(w);
         } else {
             result = invokeComparison(v, w, "__le__");
         }
+        if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
+            return result;
+        }
 
         // Now check reflection
         if (!reflectedChecked) {
-          if (w instanceof org.python.types.Str) { // TODO all builtin types
+          if (w_builtin) {
               result = w.__ge__(v);
           } else {
               result = invokeComparison(w, v, "__ge__");
@@ -1126,10 +1145,6 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
           if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
               return result;
           }
-        }
-
-        if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
-            return result;
         }
 
         // Error case
@@ -1147,9 +1162,12 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         boolean reflectedChecked = v.type() != w.type()
                 && ((org.python.types.Bool) org.Python.isinstance(w, v.type())).value;
 
+        boolean v_builtin = isBuiltin(v);
+        boolean w_builtin = isBuiltin(w);
+
         // Reflective case
         if (reflectedChecked) {
-            if (w instanceof org.python.types.Str) { // TODO all builtin types
+            if (w_builtin) {
                 result = w.__eq__(v);
             } else {
                 result = invokeComparison(w, v, "__eq__");
@@ -1161,19 +1179,18 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         }
 
         // Normal case
-        if (v instanceof org.python.types.Str) { // TODO all builtin types
+        if (v_builtin) {
             result = v.__eq__(w);
         } else {
             result = invokeComparison(v, w, "__eq__");
         }
-
         if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
             return result;
         }
 
         // Now check reflection
         if (!reflectedChecked) {
-          if (w instanceof org.python.types.Str) { // TODO all builtin types
+          if (w_builtin) {
               result = w.__eq__(v);
           } else {
               result = invokeComparison(w, v, "__eq__");
@@ -1191,10 +1208,12 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         org.python.Object result = org.python.types.NotImplementedType.NOT_IMPLEMENTED;
         boolean reflectedChecked = v.type() != w.type()
                 && ((org.python.types.Bool) org.Python.isinstance(w, v.type())).value;
+        boolean v_builtin = isBuiltin(v);
+        boolean w_builtin = isBuiltin(w);
 
         // Reflective case
         if (reflectedChecked) {
-            if (w instanceof org.python.types.Str) { // TODO all builtin types
+            if (w_builtin) {
                 result = w.__ne__(v);
             } else {
                 result = invokeComparison(w, v, "__ne__");
@@ -1206,7 +1225,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         }
 
         // Normal case
-        if (v instanceof org.python.types.Str) { // TODO all builtin types
+        if (v_builtin) {
             result = v.__ne__(w);
         } else {
             result = invokeComparison(v, w, "__ne__");
@@ -1218,7 +1237,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
 
         // Now check reflection
         if (!reflectedChecked) {
-          if (w instanceof org.python.types.Str) { // TODO all builtin types
+          if (w_builtin) {
               result = w.__ne__(v);
           } else {
               result = invokeComparison(w, v, "__ne__");
@@ -1236,10 +1255,12 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         org.python.Object result = org.python.types.NotImplementedType.NOT_IMPLEMENTED;
         boolean reflectedChecked = v.type() != w.type()
                 && ((org.python.types.Bool) org.Python.isinstance(w, v.type())).value;
+        boolean v_builtin = isBuiltin(v);
+        boolean w_builtin = isBuiltin(w);
 
         // Reflective case
         if (reflectedChecked) {
-            if (w instanceof org.python.types.Str) { // TODO all builtin types
+            if (w_builtin) {
                 result = w.__lt__(v);
             } else {
                 result = invokeComparison(w, v, "__lt__");
@@ -1251,7 +1272,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         }
 
         // Normal case
-        if (v instanceof org.python.types.Str) { // TODO all builtin types
+        if (v_builtin) {
             result = v.__gt__(w);
         } else {
             result = invokeComparison(v, w, "__gt__");
@@ -1263,7 +1284,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
 
         // Now check reflection
         if (!reflectedChecked) {
-          if (w instanceof org.python.types.Str) { // TODO all builtin types
+          if (w_builtin) {
               result = w.__lt__(v);
           } else {
               result = invokeComparison(w, v, "__lt__");
@@ -1288,10 +1309,12 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         org.python.Object result = org.python.types.NotImplementedType.NOT_IMPLEMENTED;
         boolean reflectedChecked = v.type() != w.type()
                 && ((org.python.types.Bool) org.Python.isinstance(w, v.type())).value;
+        boolean v_builtin = isBuiltin(v);
+        boolean w_builtin = isBuiltin(w);
 
         // Reflective case
         if (reflectedChecked) {
-            if (w instanceof org.python.types.Str) { // TODO all builtin types
+            if (w_builtin) {
                 result = w.__le__(v);
             } else {
                 result = invokeComparison(w, v, "__le__");
@@ -1303,7 +1326,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         }
 
         // Normal case
-        if (v instanceof org.python.types.Str) { // TODO all builtin types
+        if (v_builtin) {
             result = v.__ge__(w);
         } else {
             result = invokeComparison(v, w, "__ge__");
@@ -1315,7 +1338,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
 
         // Now check reflection
         if (!reflectedChecked) {
-          if (w instanceof org.python.types.Str) { // TODO all builtin types
+          if (w_builtin) {
               result = w.__le__(v);
           } else {
               result = invokeComparison(w, v, "__le");
@@ -1341,10 +1364,12 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         org.python.Object result = org.python.types.NotImplementedType.NOT_IMPLEMENTED;
         boolean reflectedChecked = v.type() != w.type()
                 && ((org.python.types.Bool) org.Python.isinstance(w, v.type())).value;
+        boolean v_builtin = isBuiltin(v);
+        boolean w_builtin = isBuiltin(w);
 
         // Reflective case
         if (reflectedChecked) {
-            if (w instanceof org.python.types.Str) { // TODO all builtin types
+            if (w_builtin) {
                 result = w.__contains__(v);
             } else {
                 result = invokeComparison(w, v, "__contains__");
@@ -1356,7 +1381,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         }
 
         // Normal case
-        if (v instanceof org.python.types.Str) { // TODO all builtin types
+        if (v_builtin) {
             result = v.__contains__(w);
         } else {
             result = invokeComparison(v, w, "__contains__");
@@ -1368,7 +1393,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
 
         // Now check reflection
         if (!reflectedChecked) {
-          if (w instanceof org.python.types.Str) { // TODO all builtin types
+          if (w_builtin) {
               result = w.__contains__(v);
           } else {
               result = invokeComparison(w, v, "__contains__");
@@ -1393,10 +1418,12 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         org.python.Object result = org.python.types.NotImplementedType.NOT_IMPLEMENTED;
         boolean reflectedChecked = v.type() != w.type()
                 && ((org.python.types.Bool) org.Python.isinstance(w, v.type())).value;
+        boolean v_builtin = isBuiltin(v);
+        boolean w_builtin = isBuiltin(w);
 
         // Reflective case
         if (reflectedChecked) {
-            if (w instanceof org.python.types.Str) { // TODO all builtin types
+            if (w_builtin) {
                 result = w.__not_contains__(v);
             } else {
                 result = invokeComparison(w, v, "__not_contains__");
@@ -1408,7 +1435,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         }
 
         // Normal case
-        if (v instanceof org.python.types.Str) { // TODO all builtin types
+        if (v_builtin) {
             result = v.__not_contains__(w);
         } else {
             result = invokeComparison(v, w, "__not_contains__");
@@ -1420,7 +1447,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
 
         // Now check reflection
         if (!reflectedChecked) {
-          if (w instanceof org.python.types.Str) { // TODO all builtin types
+          if (w_builtin) {
               result = w.__not_contains__(v);
           } else {
               result = invokeComparison(w, v, "__not_contains__");

--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -1359,28 +1359,10 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         }
     }
 
-    // FIXME how can __contains__/in be reflective?
     public static org.python.Object __contains__(org.python.Object v, org.python.Object w) {
-        org.python.Object result = org.python.types.NotImplementedType.NOT_IMPLEMENTED;
-        boolean reflectedChecked = v.type() != w.type()
-                && ((org.python.types.Bool) org.Python.isinstance(w, v.type())).value;
         boolean v_builtin = isBuiltin(v);
-        boolean w_builtin = isBuiltin(w);
+        org.python.Object result = null;
 
-        // Reflective case
-        if (reflectedChecked) {
-            if (w_builtin) {
-                result = w.__contains__(v);
-            } else {
-                result = invokeComparison(w, v, "__contains__");
-            }
-
-            if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
-                return result;
-            }
-        }
-
-        // Normal case
         if (v_builtin) {
             result = v.__contains__(w);
         } else {
@@ -1389,19 +1371,6 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
 
         if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
             return result;
-        }
-
-        // Now check reflection
-        if (!reflectedChecked) {
-            if (w_builtin) {
-                result = w.__contains__(v);
-            } else {
-                result = invokeComparison(w, v, "__contains__");
-            }
-
-            if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
-                return result;
-            }
         }
 
         // Error case
@@ -1415,25 +1384,8 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
     }
 
     public static org.python.Object __not_contains__(org.python.Object v, org.python.Object w) {
-        org.python.Object result = org.python.types.NotImplementedType.NOT_IMPLEMENTED;
-        boolean reflectedChecked = v.type() != w.type()
-                && ((org.python.types.Bool) org.Python.isinstance(w, v.type())).value;
         boolean v_builtin = isBuiltin(v);
-        boolean w_builtin = isBuiltin(w);
-
-        // Reflective case
-        if (reflectedChecked) {
-            if (w_builtin) {
-                result = w.__not_contains__(v);
-            } else {
-                result = invokeComparison(w, v, "__not_contains__");
-            }
-
-            if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
-                return result;
-            }
-        }
-
+        org.python.Object result = null;
         // Normal case
         if (v_builtin) {
             result = v.__not_contains__(w);
@@ -1443,19 +1395,6 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
 
         if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
             return result;
-        }
-
-        // Now check reflection
-        if (!reflectedChecked) {
-            if (w_builtin) {
-                result = w.__not_contains__(v);
-            } else {
-                result = invokeComparison(w, v, "__not_contains__");
-            }
-
-            if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
-                return result;
-            }
         }
 
         // Error case

--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -1043,7 +1043,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
                 obj instanceof org.python.types.Bool || obj instanceof org.python.types.Float ||
                 obj instanceof org.python.types.List || obj instanceof org.python.types.Dict ||
                 obj instanceof org.python.types.Tuple || obj instanceof org.python.types.Set ||
-                obj instanceof org.python.types.Range || obj instanceof org.python.types.Slice || 
+                obj instanceof org.python.types.Range || obj instanceof org.python.types.Slice ||
                 obj instanceof org.python.types.Bytes || obj instanceof org.python.types.Complex ||
                 obj instanceof org.python.types.ByteArray || obj instanceof org.python.types.FrozenSet ||
                 obj instanceof org.python.types.MemoryView;

--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -1287,7 +1287,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
             if (w_builtin) {
                 result = w.__lt__(v);
             } else {
-              result = invokeComparison(w, v, "__lt__");
+                result = invokeComparison(w, v, "__lt__");
             }
 
             if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {

--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -1052,7 +1052,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
             }
 
             if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
-              return result;
+                return result;
             }
         }
 
@@ -1065,6 +1065,19 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
 
         if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
             return result;
+        }
+
+        // Now check reflection
+        if (!reflectedChecked) {
+          if (w instanceof org.python.types.Str) { // TODO all builtin types
+              result = w.__gt__(v);
+          } else {
+              result = invokeComparison(w, v, "__gt__");
+          }
+
+          if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
+              return result;
+          }
         }
 
         // Error case
@@ -1091,7 +1104,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
             }
 
             if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
-              return result;
+                return result;
             }
         }
 
@@ -1100,6 +1113,19 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
             result = v.__le__(w);
         } else {
             result = invokeComparison(v, w, "__le__");
+        }
+
+        // Now check reflection
+        if (!reflectedChecked) {
+          if (w instanceof org.python.types.Str) { // TODO all builtin types
+              result = w.__ge__(v);
+          } else {
+              result = invokeComparison(w, v, "__ge__");
+          }
+
+          if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
+              return result;
+          }
         }
 
         if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
@@ -1130,7 +1156,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
             }
 
             if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
-              return result;
+                return result;
             }
         }
 
@@ -1143,6 +1169,19 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
 
         if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
             return result;
+        }
+
+        // Now check reflection
+        if (!reflectedChecked) {
+          if (w instanceof org.python.types.Str) { // TODO all builtin types
+              result = w.__eq__(v);
+          } else {
+              result = invokeComparison(w, v, "__eq__");
+          }
+
+          if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
+              return result;
+          }
         }
 
         return org.python.types.Bool.getBool(v == w);
@@ -1162,7 +1201,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
             }
 
             if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
-              return result;
+                return result;
             }
         }
 
@@ -1175,6 +1214,19 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
 
         if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
             return result;
+        }
+
+        // Now check reflection
+        if (!reflectedChecked) {
+          if (w instanceof org.python.types.Str) { // TODO all builtin types
+              result = w.__ne__(v);
+          } else {
+              result = invokeComparison(w, v, "__ne__");
+          }
+
+          if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
+              return result;
+          }
         }
 
         return org.python.types.Bool.getBool(v != w);
@@ -1194,7 +1246,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
             }
 
             if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
-              return result;
+                return result;
             }
         }
 
@@ -1207,6 +1259,19 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
 
         if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
             return result;
+        }
+
+        // Now check reflection
+        if (!reflectedChecked) {
+          if (w instanceof org.python.types.Str) { // TODO all builtin types
+              result = w.__lt__(v);
+          } else {
+              result = invokeComparison(w, v, "__lt__");
+          }
+
+          if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
+              return result;
+          }
         }
 
         // Error case
@@ -1233,7 +1298,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
             }
 
             if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
-              return result;
+                return result;
             }
         }
 
@@ -1246,6 +1311,19 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
 
         if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
             return result;
+        }
+
+        // Now check reflection
+        if (!reflectedChecked) {
+          if (w instanceof org.python.types.Str) { // TODO all builtin types
+              result = w.__le__(v);
+          } else {
+              result = invokeComparison(w, v, "__le");
+          }
+
+          if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
+              return result;
+          }
         }
 
         // Error case
@@ -1273,7 +1351,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
             }
 
             if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
-              return result;
+                return result;
             }
         }
 
@@ -1286,6 +1364,19 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
 
         if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
             return result;
+        }
+
+        // Now check reflection
+        if (!reflectedChecked) {
+          if (w instanceof org.python.types.Str) { // TODO all builtin types
+              result = w.__contains__(v);
+          } else {
+              result = invokeComparison(w, v, "__contains__");
+          }
+
+          if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
+              return result;
+          }
         }
 
         // Error case
@@ -1312,7 +1403,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
             }
 
             if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
-              return result;
+                return result;
             }
         }
 
@@ -1325,6 +1416,19 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
 
         if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
             return result;
+        }
+
+        // Now check reflection
+        if (!reflectedChecked) {
+          if (w instanceof org.python.types.Str) { // TODO all builtin types
+              result = w.__not_contains__(v);
+          } else {
+              result = invokeComparison(w, v, "__not_contains__");
+          }
+
+          if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
+              return result;
+          }
         }
 
         // Error case

--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -1120,6 +1120,8 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
                 return org.python.types.Bool.getBool(cmpResult > 0);
             case "__ge__":
                 return org.python.types.Bool.getBool(cmpResult >= 0);
+            case "__ne__":
+                return org.python.types.Bool.getBool(cmpResult != 0);
             default:
                 return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
         }
@@ -1132,6 +1134,13 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
 
         if (x instanceof org.python.types.Str && y instanceof org.python.types.Str) {
             int res = ((org.python.types.Str) x).value.compareTo(((org.python.types.Str) y).value);
+            return resolveComparison(res, methodName);
+        }
+
+        if (x instanceof org.python.types.Int && y instanceof org.python.types.Int) {
+            Long x_long = Long.valueOf(((org.python.types.Int) x).value);
+            Long y_long = Long.valueOf(((org.python.types.Int) y).value);
+            int res = x_long.compareTo(y_long);
             return resolveComparison(res, methodName);
         }
 

--- a/python/common/org/python/types/Super.java
+++ b/python/common/org/python/types/Super.java
@@ -60,7 +60,7 @@ public class Super implements org.python.Object {
      */
     public boolean equals(java.lang.Object other) {
         if (other instanceof org.python.Object) {
-            org.python.Object result = org.python.types.Object.__cmp_bool__(this, (org.python.Object) other, org.python.types.Object.CMP_OP.EQ);
+            org.python.Object result = org.python.types.Object.__eq__(this, (org.python.Object) other);
             return ((org.python.types.Bool) result).value;
         } else {
             throw new org.python.exceptions.RuntimeError("Can't compare a Python object with non-Python object.");

--- a/python/common/org/python/types/Tuple.java
+++ b/python/common/org/python/types/Tuple.java
@@ -119,8 +119,8 @@ public class Tuple extends org.python.types.Object {
             // check how many items are identical on the lists
             int i = 0;
             for (i = 0; i < count; i++) {
-                org.python.types.Bool result = (org.python.types.Bool) org.python.types.Object.__cmp_bool__(
-                        this.value.get(i), otherTuple.value.get(i), org.python.types.Object.CMP_OP.EQ);
+                org.python.types.Bool result = (org.python.types.Bool) org.python.types.Object.__cmp_eq__(
+                        this.value.get(i), otherTuple.value.get(i));
                 if (!result.value) {
                     break;
                 }
@@ -128,8 +128,7 @@ public class Tuple extends org.python.types.Object {
 
             // not all items were identical, result is that of the first non-identical item
             if (i < count) {
-                return org.python.types.Object.__cmp_bool__(this.value.get(i), otherTuple.value.get(i),
-                        org.python.types.Object.CMP_OP.LT);
+                return org.python.types.Object.__lt__(this.value.get(i), otherTuple.value.get(i));
             }
 
             // all items were identical, break tie by size
@@ -153,8 +152,8 @@ public class Tuple extends org.python.types.Object {
             // check how many items are identical on the lists
             int i = 0;
             for (i = 0; i < count; i++) {
-                org.python.types.Bool result = (org.python.types.Bool) org.python.types.Object.__cmp_bool__(
-                        this.value.get(i), otherTuple.value.get(i), org.python.types.Object.CMP_OP.EQ);
+                org.python.types.Bool result = (org.python.types.Bool) org.python.types.Object.__cmp_eq__(
+                        this.value.get(i), otherTuple.value.get(i));
                 if (!result.value) {
                     break;
                 }
@@ -162,8 +161,7 @@ public class Tuple extends org.python.types.Object {
 
             // not all items were identical, result is that of the first non-identical item
             if (i < count) {
-                return org.python.types.Object.__cmp_bool__(this.value.get(i), otherTuple.value.get(i),
-                        org.python.types.Object.CMP_OP.LE);
+                return org.python.types.Object.__le__(this.value.get(i), otherTuple.value.get(i));
             }
 
             // all items were identical, break tie by size
@@ -199,8 +197,8 @@ public class Tuple extends org.python.types.Object {
             // check how many items are identical on the lists
             int i = 0;
             for (i = 0; i < count; i++) {
-                org.python.types.Bool result = (org.python.types.Bool) org.python.types.Object.__cmp_bool__(
-                        this.value.get(i), otherTuple.value.get(i), org.python.types.Object.CMP_OP.EQ);
+                org.python.types.Bool result = (org.python.types.Bool) org.python.types.Object.__cmp_eq__(
+                        this.value.get(i), otherTuple.value.get(i));
                 if (!result.value) {
                     break;
                 }
@@ -208,8 +206,7 @@ public class Tuple extends org.python.types.Object {
 
             // not all items were identical, result is that of the first non-identical item
             if (i < count) {
-                return org.python.types.Object.__cmp_bool__(this.value.get(i), otherTuple.value.get(i),
-                        org.python.types.Object.CMP_OP.GT);
+                return org.python.types.Object.__gt__(this.value.get(i), otherTuple.value.get(i));
             }
 
             // all items were identical, break tie by size
@@ -233,8 +230,8 @@ public class Tuple extends org.python.types.Object {
             // check how many items are identical on the lists
             int i = 0;
             for (i = 0; i < count; i++) {
-                org.python.types.Bool result = (org.python.types.Bool) org.python.types.Object.__cmp_bool__(
-                        this.value.get(i), otherTuple.value.get(i), org.python.types.Object.CMP_OP.EQ);
+                org.python.types.Bool result = (org.python.types.Bool) org.python.types.Object.__cmp_eq__(
+                        this.value.get(i), otherTuple.value.get(i));
                 if (!result.value) {
                     break;
                 }
@@ -242,8 +239,7 @@ public class Tuple extends org.python.types.Object {
 
             // not all items were identical, result is that of the first non-identical item
             if (i < count) {
-                return org.python.types.Object.__cmp_bool__(this.value.get(i), otherTuple.value.get(i),
-                        org.python.types.Object.CMP_OP.GE);
+                return org.python.types.Object.__ge__(this.value.get(i), otherTuple.value.get(i));
             }
 
             // all items were identical, break tie by size

--- a/tests/benchmarks.py
+++ b/tests/benchmarks.py
@@ -138,6 +138,39 @@ def test_code(test_case):
             main(i)
     """), timed=True)
 
+def test_str_comp(test_case):
+    print("Running", "string comparison")
+    test_case.runAsJava(adjust("""
+        s = "mary had a little lamb"
+        t = "humpty dumpty sat on a wall"
+
+        for i in range(1000):
+            for j in range(100):
+                print(s < t)
+                print(s <= t)
+                print(s == t)
+                print(s >= t)
+                print(s > t)
+
+                print(s < t)
+                print(s <= t)
+                print(s == t)
+                print(s >= t)
+                print(s > t)
+
+                print(s < t)
+                print(s <= t)
+                print(s == t)
+                print(s >= t)
+                print(s > t)
+
+                print(s < t)
+                print(s <= t)
+                print(s == t)
+                print(s >= t)
+                print(s > t)
+    """), timed=True)
+
 def main():
     test_case = TranspileTestCase()
     test_case.setUpClass()
@@ -147,6 +180,7 @@ def main():
     test_class_var_load(test_case)
     test_function_var_load(test_case)
     test_code(test_case)
+    test_str_comp(test_case)
 
 if __name__== "__main__":
   main()

--- a/tests/benchmarks.py
+++ b/tests/benchmarks.py
@@ -139,7 +139,7 @@ def test_code(test_case):
     """), timed=True)
 
 def test_cmp(test_case):
-    print("Running", "string comparison")
+    print("Running", "test_cmp")
     test_case.runAsJava(adjust("""
         x = None
         s = "mary had a little lamb"

--- a/tests/benchmarks.py
+++ b/tests/benchmarks.py
@@ -138,37 +138,35 @@ def test_code(test_case):
             main(i)
     """), timed=True)
 
-def test_str_comp(test_case):
+def test_cmp(test_case):
     print("Running", "string comparison")
     test_case.runAsJava(adjust("""
+        x = None
         s = "mary had a little lamb"
         t = "humpty dumpty sat on a wall"
 
         for i in range(1000):
-            for j in range(100):
-                print(s < t)
-                print(s <= t)
-                print(s == t)
-                print(s >= t)
-                print(s > t)
+            for j in range(1000):
+                x = s < t
+                x = s <= t
+                x = s == t
+                x = s != t
+                x = s > t
+                x = s >= t
 
-                print(s < t)
-                print(s <= t)
-                print(s == t)
-                print(s >= t)
-                print(s > t)
+                x = 3 < 5
+                x = 3 <= 5
+                x = 3 == 5
+                x = 3 != 5
+                x = 3 > 5
+                x = 3 >= 5
 
-                print(s < t)
-                print(s <= t)
-                print(s == t)
-                print(s >= t)
-                print(s > t)
-
-                print(s < t)
-                print(s <= t)
-                print(s == t)
-                print(s >= t)
-                print(s > t)
+                x = 3 < True
+                x = 3.0 <= 5
+                x = None == 5
+                x = [3] != 5.0
+                x = [3] > [5]
+                x = [3.0] > [5.0]
     """), timed=True)
 
 def main():
@@ -180,7 +178,7 @@ def main():
     test_class_var_load(test_case)
     test_function_var_load(test_case)
     test_code(test_case)
-    test_str_comp(test_case)
+    test_cmp(test_case)
 
 if __name__== "__main__":
   main()

--- a/voc/python/ast.py
+++ b/voc/python/ast.py
@@ -1884,65 +1884,79 @@ class Visitor(ast.NodeVisitor):
                 )
 
             else:
-                if isinstance(arg, (ast.In, ast.NotIn)):
+                if isinstance(arg, (ast.Eq, ast.Is)):
                     self.context.add_opcodes(
-                        JavaOpcodes.SWAP()
+                        JavaOpcodes.INVOKESTATIC(
+                            'org/python/types/Object',
+                            '__eq__',
+                            args=['Lorg/python/Object;', 'Lorg/python/Object;'],
+                            returns='Lorg/python/Object;'),
                     )
 
-                oper = {
-                        ast.Eq: '__eq__',
-                        ast.Gt: '__gt__',
-                        ast.GtE: '__ge__',
-                        ast.Lt: '__lt__',
-                        ast.LtE: '__le__',
-                        ast.In: '__contains__',
-                        ast.Is: '__eq__',
-                        ast.IsNot: '__ne__',
-                        ast.NotEq: '__ne__',
-                        ast.NotIn: '__not_contains__',
-                }[type(arg)]
-                oper_symbol = {
-                        ast.Eq: '==',
-                        ast.Gt: '>',
-                        ast.GtE: '>=',
-                        ast.Lt: '<',
-                        ast.LtE: '<=',
-                        ast.In: 'in',
-                        ast.Is: 'is',
-                        ast.IsNot: 'is not',
-                        ast.NotEq: '!=',
-                        ast.NotIn: 'not in',
-                }[type(arg)]
-                reflect_oper = {
-                        ast.Eq: '__eq__',
-                        ast.Gt: '__lt__',
-                        ast.GtE: '__le__',
-                        ast.Lt: '__gt__',
-                        ast.LtE: '__ge__',
-                        ast.In: '__contains__',
-                        ast.Is: '__eq__',
-                        ast.IsNot: '__ne__',
-                        ast.NotEq: '__ne__',
-                        ast.NotIn: '__not_contains__',
-                }[type(arg)]
+                if isinstance(arg, (ast.NotEq, ast.IsNot)):
+                    self.context.add_opcodes(
+                        JavaOpcodes.INVOKESTATIC(
+                            'org/python/types/Object',
+                            '__eq__',
+                            args=['Lorg/python/Object;', 'Lorg/python/Object;'],
+                            returns='Lorg/python/Object;'),
+                    )
 
-                self.context.add_opcodes(
-                    JavaOpcodes.LDC_W(oper_symbol),
-                    JavaOpcodes.LDC_W(oper),
-                    JavaOpcodes.LDC_W(reflect_oper),
-                    JavaOpcodes.INVOKESTATIC(
-                        'org/python/types/Object',
-                        '__cmp__',
-                        args=[
-                            'Lorg/python/Object;',
-                            'Lorg/python/Object;',
-                            'Ljava/lang/String;',
-                            'Ljava/lang/String;',
-                            'Ljava/lang/String;',
-                        ],
-                        returns='Lorg/python/Object;',
-                    ),
-                )
+                if isinstance(arg, ast.Lt):
+                    self.context.add_opcodes(
+                        JavaOpcodes.INVOKESTATIC(
+                            'org/python/types/Object',
+                            '__lt__',
+                            args=['Lorg/python/Object;', 'Lorg/python/Object;'],
+                            returns='Lorg/python/Object;'),
+                    )
+
+                if isinstance(arg, ast.LtE):
+                    self.context.add_opcodes(
+                        JavaOpcodes.INVOKESTATIC(
+                            'org/python/types/Object',
+                            '__le__',
+                            args=['Lorg/python/Object;', 'Lorg/python/Object;'],
+                            returns='Lorg/python/Object;'),
+                    )
+
+                if isinstance(arg, ast.Gt):
+                    self.context.add_opcodes(
+                        JavaOpcodes.INVOKESTATIC(
+                            'org/python/types/Object',
+                            '__gt__',
+                            args=['Lorg/python/Object;', 'Lorg/python/Object;'],
+                            returns='Lorg/python/Object;'),
+                    )
+
+                if isinstance(arg, ast.GtE):
+                    self.context.add_opcodes(
+                        JavaOpcodes.INVOKESTATIC(
+                            'org/python/types/Object',
+                            '__ge__',
+                            args=['Lorg/python/Object;', 'Lorg/python/Object;'],
+                            returns='Lorg/python/Object;'),
+                    )
+
+                if isinstance(arg, ast.In):
+                    self.context.add_opcodes(
+                        JavaOpcodes.SWAP(),
+                        JavaOpcodes.INVOKESTATIC(
+                            'org/python/types/Object',
+                            '__contains__',
+                            args=['Lorg/python/Object;', 'Lorg/python/Object;'],
+                            returns='Lorg/python/Object;'),
+                    )
+
+                if isinstance(arg, ast.NotIn):
+                    self.context.add_opcodes(
+                        JavaOpcodes.SWAP(),
+                        JavaOpcodes.INVOKESTATIC(
+                            'org/python/types/Object',
+                            '__not_contains__',
+                            args=['Lorg/python/Object;', 'Lorg/python/Object;'],
+                            returns='Lorg/python/Object;'),
+                    )
 
         self.visit(node.left)
         left = node.left

--- a/voc/python/ast.py
+++ b/voc/python/ast.py
@@ -1897,7 +1897,7 @@ class Visitor(ast.NodeVisitor):
                     self.context.add_opcodes(
                         JavaOpcodes.INVOKESTATIC(
                             'org/python/types/Object',
-                            '__eq__',
+                            '__ne__',
                             args=['Lorg/python/Object;', 'Lorg/python/Object;'],
                             returns='Lorg/python/Object;'),
                     )


### PR DESCRIPTION
Comparison operations (`==`, `<`, `>`, etc.) are expensive because `org/python/types/Method`s are created each time they are used. Sacrificing some generality and coding style, directing each operation to its implementation will save unnecessary objects from being created and functions from being called. 

Results (updated): 

**Pystone** 
*Without optimization* 
```
test_pystone (tests.test_pystone.PystoneTest) ... Pystone(1.2) time for 50000 passes = 37.4149
This machine benchmarks at 1336.37 pystones/second
```
```
test_pystone (tests.test_pystone.PystoneTest) ... Pystone(1.2) time for 50000 passes = 37.1006
This machine benchmarks at 1347.69 pystones/second
```
```
test_pystone (tests.test_pystone.PystoneTest) ... Pystone(1.2) time for 50000 passes = 36.7188
This machine benchmarks at 1361.70 pystones/second
```

*With optimization* 
```
test_pystone (tests.test_pystone.PystoneTest) ... Pystone(1.2) time for 50000 passes = 23.6110
This machine benchmarks at 2157.66 pystones/second
```
```
test_pystone (tests.test_pystone.PystoneTest) ... Pystone(1.2) time for 50000 passes = 22.0497
This machine benchmarks at 2267.61 pystones/second
```
```
test_pystone (tests.test_pystone.PystoneTest) ... Pystone(1.2) time for 50000 passes = 22.6868
This machine benchmarks at 2203.92 pystones/second
```

Over 50% improvement! 


**Benchmarking test**
*Without optimization*
```
Running test_cmp
  Elapsed time:  107.74267825996503  sec
  CPU process time:  0.00042400000000003546  sec
```
```
Running test_cmp
  Elapsed time:  110.58186632907018  sec
  CPU process time:  0.00013099999999999223  sec
```
```
Running test_cmp
  Elapsed time:  108.22996701404918  sec
  CPU process time:  0.0009190000000000031  sec
```

*With optimization* 
```
Running test_cmp
  Elapsed time:  41.10957779898308  sec
  CPU process time:  0.0007880000000000109  sec
```
```
Running test_cmp
  Elapsed time:  39.39081814000383  sec
  CPU process time:  0.00012699999999998823  sec
```
```
Running test_cmp
  Elapsed time:  38.50678546191193  sec
  CPU process time:  0.0004529999999999812  sec
```

Over 60% improvement here! 