### PR TITLE
Contains/Not Contains throws wrong errors 

### DIFF
--- a/python/common/org/python/Object.java
+++ b/python/common/org/python/Object.java
@@ -170,7 +170,6 @@ public interface Object extends Comparable {
     public org.python.Object __invert__();
 
     public org.python.Object __not__();
-    public org.python.Object __not_contains__(org.python.Object item);
 
     public org.python.Object __complex__(org.python.Object real, org.python.Object imag);
     public org.python.Object __int__();

--- a/python/common/org/python/types/Dict.java
+++ b/python/common/org/python/types/Dict.java
@@ -329,20 +329,6 @@ public class Dict extends org.python.types.Object {
     }
 
     @org.python.Method(
-            __doc__ = "",
-            args = {"item"}
-    )
-    public org.python.Object __not_contains__(org.python.Object item) {
-        // allow unhashable type error to be percolated up.
-        try {
-            __getitem__(item);
-            return org.python.types.Bool.FALSE;
-        } catch (org.python.exceptions.KeyError e) {
-            return org.python.types.Bool.TRUE;
-        }
-    }
-
-    @org.python.Method(
             __doc__ = "D.clear() -> None.  Remove all items from D."
     )
     public org.python.Object clear() {

--- a/python/common/org/python/types/DictItems.java
+++ b/python/common/org/python/types/DictItems.java
@@ -181,7 +181,7 @@ public class DictItems extends org.python.types.Object {
         org.python.types.Set set = new org.python.types.Set(this.toTupleSet());
         return set.__contains__(item);
     }
-    
+
     @org.python.Method(
             __doc__ = "Return self<value.",
             args = {"other"}

--- a/python/common/org/python/types/DictItems.java
+++ b/python/common/org/python/types/DictItems.java
@@ -181,16 +181,7 @@ public class DictItems extends org.python.types.Object {
         org.python.types.Set set = new org.python.types.Set(this.toTupleSet());
         return set.__contains__(item);
     }
-
-    @org.python.Method(
-            __doc__ = "",
-            args = {"item"}
-    )
-    public org.python.Object __not_contains__(org.python.Object other) {
-        org.python.types.Set set = new org.python.types.Set(this.toTupleSet());
-        return set.__not_contains__(other);
-    }
-
+    
     @org.python.Method(
             __doc__ = "Return self<value.",
             args = {"other"}

--- a/python/common/org/python/types/DictValues.java
+++ b/python/common/org/python/types/DictValues.java
@@ -170,12 +170,4 @@ public class DictValues extends org.python.types.Object {
     public org.python.Object __contains__(org.python.Object item) {
         return org.python.types.Bool.getBool(this.value.contains(item));
     }
-
-    @org.python.Method(
-            __doc__ = "",
-            args = {"item"}
-    )
-    public org.python.Object __not_contains__(org.python.Object item) {
-        return org.python.types.Bool.getBool(!this.value.contains(item));
-    }
 }

--- a/python/common/org/python/types/FrozenSet.java
+++ b/python/common/org/python/types/FrozenSet.java
@@ -151,14 +151,6 @@ public class FrozenSet extends org.python.types.Object {
     }
 
     @org.python.Method(
-            __doc__ = "",
-            args = {"item"}
-    )
-    public org.python.Object __not_contains__(org.python.Object other) {
-        return org.python.types.Bool.getBool(!this.value.contains(other));
-    }
-
-    @org.python.Method(
             __doc__ = "Return a shallow copy of a FrozenSet."
     )
     public org.python.Object copy() {

--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -1371,24 +1371,14 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
             try {
                 result = v.__contains__(w);
             } catch (org.python.exceptions.AttributeError e) {
-                if (org.Python.VERSION < 0x03060000) {
-                    throw new org.python.exceptions.TypeError(String.format(
-                        "unorderable types: %s() %s %s()", v.typeName(), "in", w.typeName()));
-                } else {
-                    throw new org.python.exceptions.TypeError(String.format("argument of type '%s' is not iterable", v.typeName()));
-                }
+                throw new org.python.exceptions.TypeError(String.format("argument of type '%s' is not iterable", v.typeName()));
             }
             return result;
         } else {
             try {
                 result = invokeComparison(v, w, "__contains__");
             } catch (org.python.exceptions.AttributeError e) {
-                if (org.Python.VERSION < 0x03060000) {
-                    throw new org.python.exceptions.TypeError(String.format(
-                        "unorderable types: %s() %s %s()", v.typeName(), "in", w.typeName()));
-                } else {
-                    throw new org.python.exceptions.TypeError(String.format("argument of type '%s' is not iterable", v.typeName()));
-                }
+                throw new org.python.exceptions.TypeError(String.format("argument of type '%s' is not iterable", v.typeName()));
             }
             return result;
         }

--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -1385,27 +1385,8 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
     }
 
     public static org.python.Object __not_contains__(org.python.Object v, org.python.Object w) {
-        boolean v_builtin = isBuiltin(v);
-        org.python.Object result = null;
-        // Normal case
-        if (v_builtin) {
-            result = v.__not_contains__(w);
-        } else {
-            result = invokeComparison(v, w, "__not_contains__");
-        }
-
-        if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
-            return result;
-        }
-
-        // Error case
-        if (org.Python.VERSION < 0x03060000) {
-            throw new org.python.exceptions.TypeError(String.format(
-                "unorderable types: %s() %s %s()", v.typeName(), "not in", w.typeName()));
-        } else {
-            throw new org.python.exceptions.TypeError(String.format(
-                "'%s' not supported between instances of '%s' and '%s'", "not in", v.typeName(), w.typeName()));
-        }
+        org.python.Object containsObj = org.python.types.Object.__contains__(v, w);
+        return org.python.types.Bool.getBool(!((org.python.types.Bool) containsObj).value);
     }
 
     private static org.python.Object invokeComparison(org.python.Object x, org.python.Object y, String methodName) {

--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -557,7 +557,11 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
             args = {"item"}
     )
     public org.python.Object __not_contains__(org.python.Object item) {
-        throw new org.python.exceptions.AttributeError(this, "__not_contains__");
+        try {
+            return org.python.types.Bool.getBool(!((org.python.types.Bool) this.__contains__(item)).value);
+        } catch (org.python.exceptions.AttributeError e) {
+            throw new org.python.exceptions.AttributeError(this, "__not_contains__");
+        }
     }
 
     /**

--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -1368,22 +1368,29 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         org.python.Object result = null;
 
         if (v_builtin) {
-            result = v.__contains__(w);
-        } else {
-            result = invokeComparison(v, w, "__contains__");
-        }
-
-        if (result != org.python.types.NotImplementedType.NOT_IMPLEMENTED) {
+            try {
+                result = v.__contains__(w);
+            } catch (org.python.exceptions.AttributeError e) {
+                if (org.Python.VERSION < 0x03060000) {
+                    throw new org.python.exceptions.TypeError(String.format(
+                        "unorderable types: %s() %s %s()", v.typeName(), "in", w.typeName()));
+                } else {
+                    throw new org.python.exceptions.TypeError(String.format("argument of type '%s' is not iterable", v.typeName()));
+                }
+            }
             return result;
-        }
-
-        // Error case
-        if (org.Python.VERSION < 0x03060000) {
-            throw new org.python.exceptions.TypeError(String.format(
-                "unorderable types: %s() %s %s()", v.typeName(), "in", w.typeName()));
         } else {
-            throw new org.python.exceptions.TypeError(String.format(
-                "'%s' not supported between instances of '%s' and '%s'", "in", v.typeName(), w.typeName()));
+            try {
+                result = invokeComparison(v, w, "__contains__");
+            } catch (org.python.exceptions.AttributeError e) {
+                if (org.Python.VERSION < 0x03060000) {
+                    throw new org.python.exceptions.TypeError(String.format(
+                        "unorderable types: %s() %s %s()", v.typeName(), "in", w.typeName()));
+                } else {
+                    throw new org.python.exceptions.TypeError(String.format("argument of type '%s' is not iterable", v.typeName()));
+                }
+            }
+            return result;
         }
     }
 

--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -552,18 +552,6 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         throw new org.python.exceptions.AttributeError(this, "__contains__");
     }
 
-    @org.python.Method(
-            __doc__ = "",
-            args = {"item"}
-    )
-    public org.python.Object __not_contains__(org.python.Object item) {
-        try {
-            return org.python.types.Bool.getBool(!((org.python.types.Bool) this.__contains__(item)).value);
-        } catch (org.python.exceptions.AttributeError e) {
-            throw new org.python.exceptions.AttributeError(this, "__not_contains__");
-        }
-    }
-
     /**
      * Section 3.3.7 - Emulating numeric types
      */

--- a/python/common/org/python/types/Set.java
+++ b/python/common/org/python/types/Set.java
@@ -262,14 +262,6 @@ public class Set extends org.python.types.Object {
     }
 
     @org.python.Method(
-            __doc__ = "",
-            args = {"item"}
-    )
-    public org.python.Object __not_contains__(org.python.Object other) {
-        return org.python.types.Bool.getBool(!this.value.contains(other));
-    }
-
-    @org.python.Method(
             __doc__ = ""
     )
     public org.python.Object __mul__(org.python.Object other) {

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -400,7 +400,7 @@ public class Str extends org.python.types.Object {
             if (this.value.length() == 0 && item_str.value.length() == 0) {
                 substr_exists = 1;
             } else if (this.value == item_str.value) {
-                substr_exists = 1; 
+                substr_exists = 1;
             } else {
                 for (int i = 0; i < this.value.length() - item_str.value.length(); i++) {
                     boolean mismatch = false;

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -391,7 +391,7 @@ public class Str extends org.python.types.Object {
             __doc__ = "Return key in self.",
             args = {"item"}
     )
-    public org.python.types.Int __contains__(org.python.Object item) {
+    public org.python.Object __contains__(org.python.Object item) {
         if (item instanceof org.python.types.Str) {
 
             int substr_exists = 0;
@@ -399,6 +399,8 @@ public class Str extends org.python.types.Object {
 
             if (this.value.length() == 0 && item_str.value.length() == 0) {
                 substr_exists = 1;
+            } else if (this.value == item_str.value) {
+                substr_exists = 1; 
             } else {
                 for (int i = 0; i < this.value.length() - item_str.value.length(); i++) {
                     boolean mismatch = false;
@@ -413,7 +415,7 @@ public class Str extends org.python.types.Object {
                     }
                 }
             }
-            return org.python.types.Int.getInt(substr_exists);
+            return org.python.types.Bool.getBool(substr_exists);
         }
         if (org.Python.VERSION < 0x03060000) {
             throw new org.python.exceptions.TypeError("Can't convert '" + item.typeName() + "' object to str implicitly");

--- a/python/common/org/python/types/Super.java
+++ b/python/common/org/python/types/Super.java
@@ -463,14 +463,6 @@ public class Super implements org.python.Object {
         throw new org.python.exceptions.AttributeError(this, "__contains__");
     }
 
-    @org.python.Method(
-            __doc__ = "",
-            args = {"item"}
-    )
-    public org.python.Object __not_contains__(org.python.Object item) {
-        throw new org.python.exceptions.AttributeError(this, "__not_contains__");
-    }
-
     /**
      * Section 3.3.7 - Emulating numeric types
      */

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -884,6 +884,11 @@ class StrTests(TranspileTestCase):
             print('a' in 'abc')
             print('a' in '')
             print('' in 'a')
+
+            print('abc' not in 'abc')
+            print('a' not in 'abc')
+            print('a' not in '')
+            print('' in 'a')
         """)
 
 

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -878,6 +878,14 @@ class StrTests(TranspileTestCase):
                 print(err)
         """)
 
+    def test_contains(self):
+        self.assertCodeExecution("""
+            print('abc' in 'abc')
+            print('a' in 'abc')
+            print('a' in '')
+            print('' in 'a')
+        """)
+
 
 class UnaryStrOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'str'

--- a/tests/structures/test_comparisons.py
+++ b/tests/structures/test_comparisons.py
@@ -587,7 +587,6 @@ class ComparisonTests(TranspileTestCase):
     @expectedFailure
     def test_bad_in(self):
         self.assertCodeExecution("""
-            print('abc' in 'abc')
             print(0 in 0)
             print(0 not in 0)
             print('abc' not in 'abc')

--- a/tests/structures/test_comparisons.py
+++ b/tests/structures/test_comparisons.py
@@ -584,9 +584,30 @@ class ComparisonTests(TranspileTestCase):
             print(x == (50 + 50) > 2000)
             """)
 
+    def test_bad_contains(self):
+        self.assertCodeExecution("""
+            try:
+                print(0 in 0)
+            except TypeError as e:
+                print(e)
+
+            try:
+                print(0 in True)
+            except TypeError as e:
+                print(e)
+
+            class MyClass():
+                value = "I am not iterable!"
+            x = MyClass()
+
+            try:
+                print(0 in x)
+            except TypeError as e:
+                print(e)
+        """)
+
     @expectedFailure
     def test_bad_in(self):
         self.assertCodeExecution("""
-            print(0 in 0)
             print(0 not in 0)
         """)

--- a/tests/structures/test_comparisons.py
+++ b/tests/structures/test_comparisons.py
@@ -589,5 +589,4 @@ class ComparisonTests(TranspileTestCase):
         self.assertCodeExecution("""
             print(0 in 0)
             print(0 not in 0)
-            print('abc' not in 'abc')
         """)

--- a/tests/structures/test_comparisons.py
+++ b/tests/structures/test_comparisons.py
@@ -606,8 +606,24 @@ class ComparisonTests(TranspileTestCase):
                 print(e)
         """)
 
-    @expectedFailure
-    def test_bad_in(self):
+    def test_bad_not_contains(self):
         self.assertCodeExecution("""
-            print(0 not in 0)
+            try:
+                print(0 not in 0)
+            except TypeError as e:
+                print(e)
+
+            try:
+                print(0 not in True)
+            except TypeError as e:
+                print(e)
+
+            class MyClass():
+                value = "I am not iterable!"
+            x = MyClass()
+
+            try:
+                print(0 not in x)
+            except TypeError as e:
+                print(e)
         """)

--- a/tests/structures/test_comparisons.py
+++ b/tests/structures/test_comparisons.py
@@ -583,3 +583,12 @@ class ComparisonTests(TranspileTestCase):
             print(x == (50 + 50) < 2000)
             print(x == (50 + 50) > 2000)
             """)
+
+    @expectedFailure
+    def test_bad_in(self):
+        self.assertCodeExecution("""
+            print('abc' in 'abc')
+            print(0 in 0)
+            print(0 not in 0)
+            print('abc' not in 'abc')
+        """)


### PR DESCRIPTION
1. `in`/`__contains__` throws the wrong error on non-iterable types (like int) -- should be `TypeError` not `AttributeError` 
2. `not in`/`__not_contains__` should probably use `__contains__` instead of looking for `__not_contains__` attribute 
2. org.python.types.Str.__contains__ should return a `org.python.types.Bool` 

This PR makes the following changes: 
1. Addresses the problems above 
2. Removes the `__not_contains__` attribute from org/python/Objects. I verified that each `__not_contains__` attribute that was defined was just an inverse of its `__contains__` attribute. Since *the operator not in is defined to have the inverse true value of in* (from https://docs.python.org/3/reference/expressions.html#membership-test-operations), there is no need to define separate `__not_contains__` attributes, they should all direct to `__contains__`. See org/python/types/Object.java#__not_contains__.
