### PR TITLE
Fixed Incompatible Stack Height caused by expression statement

### DIFF
--- a/tests/structures/test_for.py
+++ b/tests/structures/test_for.py
@@ -37,6 +37,12 @@ class ForLoopTests(TranspileTestCase):
                 print(i, total)
             """)
 
+        # Test expression statement
+        self.assertCodeExecution("""
+            for i in range(10):
+                "abc" == "def"
+            """)
+
     def test_for_over_iterable(self):
         self.assertCodeExecution("""
             total = 0

--- a/tests/structures/test_for.py
+++ b/tests/structures/test_for.py
@@ -40,6 +40,7 @@ class ForLoopTests(TranspileTestCase):
         # Test expression statement
         self.assertCodeExecution("""
             for i in range(10):
+                [1, 2, 3]
                 "abc" == "def"
             """)
 

--- a/tests/structures/test_if_elif_else.py
+++ b/tests/structures/test_if_elif_else.py
@@ -22,7 +22,7 @@ class IfElifElseTests(TranspileTestCase):
             x = 1
             if x < 5:
                 [1, 2, 3]
-                x == 1
+                "abc" == "def"
             """)
 
     def test_if_else(self):

--- a/tests/structures/test_if_elif_else.py
+++ b/tests/structures/test_if_elif_else.py
@@ -17,6 +17,14 @@ class IfElifElseTests(TranspileTestCase):
                 print('Small x')
             """)
 
+        # Test expression statement
+        self.assertCodeExecution("""
+            x = 1
+            if x < 5:
+                [1, 2, 3]
+                x == 1
+            """)
+
     def test_if_else(self):
         self.assertCodeExecution("""
             x = 1

--- a/tests/structures/test_try_catch.py
+++ b/tests/structures/test_try_catch.py
@@ -23,6 +23,16 @@ class TryExceptTests(TranspileTestCase):
             print('Done.')
             """)
 
+        # Test expression statement
+        self.assertCodeExecution("""
+            try:
+                [1, 2, 3]
+                "abc" == "def"
+            except:
+                print("Got an error")
+            print('Done.')
+            """)
+
     def test_try_except_unnamed(self):
         # No exception
         self.assertCodeExecution("""

--- a/tests/structures/test_while.py
+++ b/tests/structures/test_while.py
@@ -13,6 +13,15 @@ class WhileLoopTests(TranspileTestCase):
                 print(i, total)
             """)
 
+        # Test expression statement
+        self.assertCodeExecution("""
+            x = True
+            while x:
+                [1, 2, 3]
+                "abc" == "def"
+                x = False
+            """)
+
     def test_break(self):
         self.assertCodeExecution("""
             i = 0

--- a/voc/python/ast.py
+++ b/voc/python/ast.py
@@ -249,9 +249,9 @@ class Visitor(ast.NodeVisitor):
     def visit_Expr(self, node):
         self.generic_visit(node)
 
-        # If the expression is a call, we need to ignore
-        # any return value from the function.
-        if isinstance(node.value, (ast.Call, ast.Attribute, ast.Str)):
+        # If the expression is not yield/yield from expression,
+        # we need to ignore expression value by popping it off from stack.
+        if not isinstance(node.value, (ast.Yield, ast.YieldFrom)):
             self.context.add_opcodes(
                 JavaOpcodes.POP()
             )


### PR DESCRIPTION
Fix for #876

Upon closer inspection, evaluated Expression value is only required by `yield` and `yieldFrom` node hence it can be safely popped off for other node types.