### PR TITLE
Reuse StopIteration exceptions (loop optimization) 

### DIFF
--- a/docs/reference/differences.rst
+++ b/docs/reference/differences.rst
@@ -1,0 +1,15 @@
+Differences between VOC and CPython
+===================================
+
+StopIteration
+-------------
+
+A ``StopIteration`` is a signal raised by an iterator to tell whomever is
+iterating that there are no more items to be produced. This is used in ``for``
+loops, generator functions, etc. The ``org.python.exception.StopIteration``
+exception differs from the CPython ``StopIteration`` exception in that it is a
+singleton. This was introduced in `PR #811<https://github.com/pybee/voc/pull/881>`_
+as part of a performance effort as it yields a non-trivial performance improvement
+for nested ``for`` loops. However, it also means that an equality comparison
+between two ``StopIteration`` exceptions will always be ``True``, which is not
+the case in CPython.

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -11,3 +11,4 @@ This is the technical reference for public APIs provided by VOC.
 
    Python signatures for Java-defined methods <signatures>
    The VOC type system <typesystem>
+   Differences between VOC and CPython <differences> 

--- a/python/common/org/python/exceptions/StopIteration.java
+++ b/python/common/org/python/exceptions/StopIteration.java
@@ -3,6 +3,12 @@ package org.python.exceptions;
 public class StopIteration extends org.python.exceptions.Exception {
     org.python.Object value;
 
+    /*
+        StopIteration is a singleton instance for performance reasons, introduced in
+        PR #881 (https://github.com/pybee/voc/pull/881/). This results in a non-trivial
+        performance improvement for nested loops. However, this also means that the equality
+        comparison between StopIteration instances will always be true.
+    */
     public static final org.python.exceptions.StopIteration STOPITERATION = new org.python.exceptions.StopIteration();
 
     private StopIteration() {

--- a/python/common/org/python/exceptions/StopIteration.java
+++ b/python/common/org/python/exceptions/StopIteration.java
@@ -3,12 +3,12 @@ package org.python.exceptions;
 public class StopIteration extends org.python.exceptions.Exception {
     org.python.Object value;
 
-    /*
-        StopIteration is a singleton instance for performance reasons, introduced in
-        PR #881 (https://github.com/pybee/voc/pull/881/). This results in a non-trivial
-        performance improvement for nested loops. However, this also means that the equality
-        comparison between StopIteration instances will always be true.
-    */
+    /**
+     * StopIteration is a singleton instance for performance reasons, introduced in
+     * PR #881 (https://github.com/pybee/voc/pull/881/). This results in a non-trivial
+     * performance improvement for nested loops. However, this also means that the equality
+     * comparison between StopIteration instances will always be true.
+     */
     public static final org.python.exceptions.StopIteration STOPITERATION = new org.python.exceptions.StopIteration();
 
     private StopIteration() {

--- a/python/common/org/python/exceptions/StopIteration.java
+++ b/python/common/org/python/exceptions/StopIteration.java
@@ -3,7 +3,9 @@ package org.python.exceptions;
 public class StopIteration extends org.python.exceptions.Exception {
     org.python.Object value;
 
-    public StopIteration() {
+    public static final org.python.exceptions.StopIteration STOPITERATION = new org.python.exceptions.StopIteration();
+
+    private StopIteration() {
         super("");
     }
 

--- a/python/common/org/python/types/Iterator.java
+++ b/python/common/org/python/types/Iterator.java
@@ -38,7 +38,7 @@ class Iterator extends org.python.types.Object implements org.python.Object {
         try {
             return this.iterator.next();
         } catch (java.util.NoSuchElementException e) {
-            throw new org.python.exceptions.StopIteration();
+            throw org.python.exceptions.StopIteration.STOPITERATION;
         }
     }
 

--- a/python/common/org/python/types/Iterator.java
+++ b/python/common/org/python/types/Iterator.java
@@ -38,6 +38,7 @@ class Iterator extends org.python.types.Object implements org.python.Object {
         try {
             return this.iterator.next();
         } catch (java.util.NoSuchElementException e) {
+            // StopIteration is a singleton by design, see org/python/exceptions/StopIteration 
             throw org.python.exceptions.StopIteration.STOPITERATION;
         }
     }

--- a/python/common/org/python/types/Iterator.java
+++ b/python/common/org/python/types/Iterator.java
@@ -38,7 +38,7 @@ class Iterator extends org.python.types.Object implements org.python.Object {
         try {
             return this.iterator.next();
         } catch (java.util.NoSuchElementException e) {
-            // StopIteration is a singleton by design, see org/python/exceptions/StopIteration 
+            // StopIteration is a singleton by design, see org/python/exceptions/StopIteration
             throw org.python.exceptions.StopIteration.STOPITERATION;
         }
     }

--- a/python/common/org/python/types/Range.java
+++ b/python/common/org/python/types/Range.java
@@ -262,8 +262,10 @@ public class Range extends org.python.types.Object {
         )
         public org.python.Object __next__() {
             if (this.step > 0 && this.index >= this.stop) {
+                // StopIteration is a singleton by design, see org/python/exceptions/StopIteration 
                 throw org.python.exceptions.StopIteration.STOPITERATION;
             } else if (this.step < 0 && this.index <= this.stop) {
+                // StopIteration is a singleton by design, see org/python/exceptions/StopIteration
                 throw org.python.exceptions.StopIteration.STOPITERATION;
             }
 

--- a/python/common/org/python/types/Range.java
+++ b/python/common/org/python/types/Range.java
@@ -262,7 +262,7 @@ public class Range extends org.python.types.Object {
         )
         public org.python.Object __next__() {
             if (this.step > 0 && this.index >= this.stop) {
-                // StopIteration is a singleton by design, see org/python/exceptions/StopIteration 
+                // StopIteration is a singleton by design, see org/python/exceptions/StopIteration
                 throw org.python.exceptions.StopIteration.STOPITERATION;
             } else if (this.step < 0 && this.index <= this.stop) {
                 // StopIteration is a singleton by design, see org/python/exceptions/StopIteration

--- a/python/common/org/python/types/Range.java
+++ b/python/common/org/python/types/Range.java
@@ -262,9 +262,9 @@ public class Range extends org.python.types.Object {
         )
         public org.python.Object __next__() {
             if (this.step > 0 && this.index >= this.stop) {
-                throw new org.python.exceptions.StopIteration();
+                throw org.python.exceptions.StopIteration.STOPITERATION;
             } else if (this.step < 0 && this.index <= this.stop) {
-                throw new org.python.exceptions.StopIteration();
+                throw org.python.exceptions.StopIteration.STOPITERATION;
             }
 
             org.python.Object result = org.python.types.Int.getInt(this.index);

--- a/python/common/org/python/types/ReverseIterator.java
+++ b/python/common/org/python/types/ReverseIterator.java
@@ -39,7 +39,7 @@ class ReverseIterator extends org.python.types.Object implements org.python.Obje
         try {
             return this.iterator.previous();
         } catch (java.util.NoSuchElementException e) {
-            throw new org.python.exceptions.StopIteration();
+            throw org.python.exceptions.StopIteration.STOPITERATION;
         }
     }
 

--- a/python/common/org/python/types/ReverseIterator.java
+++ b/python/common/org/python/types/ReverseIterator.java
@@ -39,7 +39,7 @@ class ReverseIterator extends org.python.types.Object implements org.python.Obje
         try {
             return this.iterator.previous();
         } catch (java.util.NoSuchElementException e) {
-            // StopIteration is a singleton by design, see org/python/exceptions/StopIteration 
+            // StopIteration is a singleton by design, see org/python/exceptions/StopIteration
             throw org.python.exceptions.StopIteration.STOPITERATION;
         }
     }

--- a/python/common/org/python/types/ReverseIterator.java
+++ b/python/common/org/python/types/ReverseIterator.java
@@ -39,6 +39,7 @@ class ReverseIterator extends org.python.types.Object implements org.python.Obje
         try {
             return this.iterator.previous();
         } catch (java.util.NoSuchElementException e) {
+            // StopIteration is a singleton by design, see org/python/exceptions/StopIteration 
             throw org.python.exceptions.StopIteration.STOPITERATION;
         }
     }

--- a/python/common/org/python/types/Reversed.java
+++ b/python/common/org/python/types/Reversed.java
@@ -22,7 +22,7 @@ public class Reversed extends Object implements org.python.Object {
     )
     public org.python.Object __next__() {
         if (this.index < 0) {
-            throw new org.python.exceptions.StopIteration();
+            throw org.python.exceptions.StopIteration.STOPITERATION;
         }
         org.python.Object item = this.sequence.__getitem__(org.python.types.Int.getInt(this.index));
         this.index--;

--- a/python/common/org/python/types/Reversed.java
+++ b/python/common/org/python/types/Reversed.java
@@ -22,6 +22,7 @@ public class Reversed extends Object implements org.python.Object {
     )
     public org.python.Object __next__() {
         if (this.index < 0) {
+            // StopIteration is a singleton by design, see org/python/exceptions/StopIteration 
             throw org.python.exceptions.StopIteration.STOPITERATION;
         }
         org.python.Object item = this.sequence.__getitem__(org.python.types.Int.getInt(this.index));

--- a/python/common/org/python/types/Reversed.java
+++ b/python/common/org/python/types/Reversed.java
@@ -22,7 +22,7 @@ public class Reversed extends Object implements org.python.Object {
     )
     public org.python.Object __next__() {
         if (this.index < 0) {
-            // StopIteration is a singleton by design, see org/python/exceptions/StopIteration 
+            // StopIteration is a singleton by design, see org/python/exceptions/StopIteration
             throw org.python.exceptions.StopIteration.STOPITERATION;
         }
         org.python.Object item = this.sequence.__getitem__(org.python.types.Int.getInt(this.index));

--- a/tests/benchmarks.py
+++ b/tests/benchmarks.py
@@ -177,6 +177,7 @@ def test_loops(test_case):
                 for z in range(100):
                     for a in range(100):
                         pass
+    """), timed=True)
 
 def main():
     test_case = TranspileTestCase()

--- a/tests/benchmarks.py
+++ b/tests/benchmarks.py
@@ -168,14 +168,14 @@ def test_cmp(test_case):
                 x = [3] > [5]
                 x = [3.0] > [5.0]
     """), timed=True)
-    
+
 def test_loops(test_case):
     print("Running", "test_loops")
     test_case.runAsJava(adjust("""
-        for a in range(100):
-            for b in range(100):
-                for c in range(100):
-                    for d in range(100):
+        for x in range(100):
+            for y in range(100):
+                for z in range(100):
+                    for a in range(100):
                         pass
 
 def main():

--- a/tests/benchmarks.py
+++ b/tests/benchmarks.py
@@ -138,6 +138,16 @@ def test_code(test_case):
             main(i)
     """), timed=True)
 
+def test_loops(test_case):
+    print("Running", "test_loops")
+    test_case.runAsJava(adjust("""
+        for a in range(100):
+            for b in range(100):
+                for c in range(100):
+                    for d in range(100):
+                        pass
+    """), timed=True)
+
 def main():
     test_case = TranspileTestCase()
     test_case.setUpClass()
@@ -147,6 +157,7 @@ def main():
     test_class_var_load(test_case)
     test_function_var_load(test_case)
     test_code(test_case)
+    test_loops(test_case)
 
 if __name__== "__main__":
   main()

--- a/tests/structures/test_exception.py
+++ b/tests/structures/test_exception.py
@@ -112,3 +112,20 @@ class ExceptionTests(TranspileTestCase):
 
                     """
             })
+
+    @expectedFailure
+    def test_stopiteration_equality(self):
+        # This is kwown and StopIteration is a singleton by design.
+        # See org/python/exceptions/StopIteration
+        self.assertCodeExecution("""
+            x = iter([])
+            y = iter([])
+
+            try:
+                next(x)
+            except StopIteration as e1:
+                try:
+                    next(y)
+                except StopIteration as e2:
+                    print(e1 == e2)
+        """)

--- a/voc/python/methods.py
+++ b/voc/python/methods.py
@@ -276,7 +276,7 @@ class Function(Block):
         pass
 
     def store_module(self):
-        # Stores the current module as a local variable 
+        # Stores the current module as a local variable
         if ('#module') not in self.local_vars:
             self.add_opcodes(
                 JavaOpcodes.GETSTATIC('python/sys', 'modules', 'Lorg/python/types/Dict;'),
@@ -1093,8 +1093,9 @@ class GeneratorFunction(Function):
     def visitor_teardown(self):
         if len(self.opcodes) == 0 or not isinstance(self.opcodes[-1], JavaOpcodes.ATHROW):
             self.add_opcodes(
-                java.New('org/python/exceptions/StopIteration'),
-                java.Init('org/python/exceptions/StopIteration'),
+                JavaOpcodes.GETSTATIC('org/python/exceptions/StopIteration', 'STOPITERATION', 'Lorg/python/exceptions/StopIteration;'),
+                #java.New('org/python/exceptions/StopIteration'),
+                #java.Init('org/python/exceptions/StopIteration'),
                 JavaOpcodes.ATHROW(),
             )
 
@@ -1282,8 +1283,9 @@ class GeneratorMethod(Method):
     def visitor_teardown(self):
         if len(self.opcodes) == 0 or not isinstance(self.opcodes[-1], JavaOpcodes.ATHROW):
             self.add_opcodes(
-                java.New('org/python/exceptions/StopIteration'),
-                java.Init('org/python/exceptions/StopIteration'),
+                JavaOpcodes.GETSTATIC('org/python/exceptions/StopIteration', 'STOPITERATION', 'Lorg/python/exceptions/StopIteration;'),
+                #java.New('org/python/exceptions/StopIteration'),
+                #java.Init('org/python/exceptions/StopIteration'),
                 JavaOpcodes.ATHROW(),
             )
 

--- a/voc/python/methods.py
+++ b/voc/python/methods.py
@@ -1093,9 +1093,8 @@ class GeneratorFunction(Function):
     def visitor_teardown(self):
         if len(self.opcodes) == 0 or not isinstance(self.opcodes[-1], JavaOpcodes.ATHROW):
             self.add_opcodes(
+                # StopIteration is a singleton by design, see org/python/exceptions/StopIteration 
                 JavaOpcodes.GETSTATIC('org/python/exceptions/StopIteration', 'STOPITERATION', 'Lorg/python/exceptions/StopIteration;'),
-                #java.New('org/python/exceptions/StopIteration'),
-                #java.Init('org/python/exceptions/StopIteration'),
                 JavaOpcodes.ATHROW(),
             )
 
@@ -1283,9 +1282,8 @@ class GeneratorMethod(Method):
     def visitor_teardown(self):
         if len(self.opcodes) == 0 or not isinstance(self.opcodes[-1], JavaOpcodes.ATHROW):
             self.add_opcodes(
+                # StopIteration is a singleton by design, see org/python/exceptions/StopIteration
                 JavaOpcodes.GETSTATIC('org/python/exceptions/StopIteration', 'STOPITERATION', 'Lorg/python/exceptions/StopIteration;'),
-                #java.New('org/python/exceptions/StopIteration'),
-                #java.Init('org/python/exceptions/StopIteration'),
                 JavaOpcodes.ATHROW(),
             )
 


### PR DESCRIPTION
Nested loops are expensive in part because of `StopIteration` exceptions that have to be created. Since most of these exceptions are created and thrown away, it might be a good idea to recycle them.

Results on benchmarking test: 

*Without optimization* 
```
Running test_loops
  Elapsed time:  33.62263886607252  sec
  CPU process time:  0.000150000000000039  sec
```
```
Running test_loops
  Elapsed time:  34.80267596896738  sec
  CPU process time:  0.00011499999999997623  sec
```
```
Running test_loops
  Elapsed time:  33.84538966906257  sec
  CPU process time:  0.00011900000000003574  sec
```

*With optimization* 
```
Running test_loops
  Elapsed time:  24.959855893044733  sec
  CPU process time:  9.500000000001174e-05  sec
```
```
Running test_loops
  Elapsed time:  25.487824370036833  sec
  CPU process time:  0.00013099999999999223  sec
```
```
Running test_loops
  Elapsed time:  25.309327021008357  sec
  CPU process time:  0.0011470000000000091  sec
```

~25% improvement! 