### PR TITLE
Fix error messages for calling __setitem__ on an immutable type

### DIFF
--- a/python/common/org/python/types/Bool.java
+++ b/python/common/org/python/types/Bool.java
@@ -95,6 +95,16 @@ public class Bool extends org.python.types.Object {
     }
 
     @org.python.Method(
+            __doc__ = "",
+            args = {"index", "value"}
+    )
+    public void __setitem__(org.python.Object index, org.python.Object value) {
+        throw new org.python.exceptions.TypeError(
+                "'bool' object does not support item assignment"
+        );
+    }
+
+    @org.python.Method(
             __doc__ = "Return self<value.",
             args = {"other"}
     )

--- a/python/common/org/python/types/FrozenSet.java
+++ b/python/common/org/python/types/FrozenSet.java
@@ -166,6 +166,16 @@ public class FrozenSet extends org.python.types.Object {
     }
 
     @org.python.Method(
+            __doc__ = "",
+            args = {"index", "value"}
+    )
+    public void __setitem__(org.python.Object index, org.python.Object value) {
+        throw new org.python.exceptions.TypeError(
+                "'frozenset' object does not support item assignment"
+        );
+    }
+
+    @org.python.Method(
             __doc__ = "Return self<value.",
             args = {"other"}
     )

--- a/python/common/org/python/types/Int.java
+++ b/python/common/org/python/types/Int.java
@@ -156,6 +156,16 @@ public class Int extends org.python.types.Object {
     }
 
     @org.python.Method(
+            __doc__ = "",
+            args = {"index", "value"}
+    )
+    public void __setitem__(org.python.Object index, org.python.Object value) {
+        throw new org.python.exceptions.TypeError(
+                "'int' object does not support item assignment"
+        );
+    }
+
+    @org.python.Method(
             __doc__ = "Return self<value.",
             args = {"other"}
     )

--- a/python/common/org/python/types/Range.java
+++ b/python/common/org/python/types/Range.java
@@ -123,6 +123,16 @@ public class Range extends org.python.types.Object {
     }
 
     @org.python.Method(
+            __doc__ = "",
+            args = {"index", "value"}
+    )
+    public void __setitem__(org.python.Object index, org.python.Object value) {
+        throw new org.python.exceptions.TypeError(
+                "'range' object does not support item assignment"
+        );
+    }
+
+    @org.python.Method(
             __doc__ = "Implement __len__(self)."
     )
     public org.python.Object __len__() {

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -377,6 +377,16 @@ public class Str extends org.python.types.Object {
     }
 
     @org.python.Method(
+            __doc__ = "",
+            args = {"index", "value"}
+    )
+    public void __setitem__(org.python.Object index, org.python.Object value) {
+        throw new org.python.exceptions.TypeError(
+                "'str' object does not support item assignment"
+        );
+    }
+
+    @org.python.Method(
             __doc__ = "Implement iter(self)."
     )
     public org.python.Object __iter__() {

--- a/tests/datatypes/test_bool.py
+++ b/tests/datatypes/test_bool.py
@@ -21,6 +21,15 @@ class BoolTests(TranspileTestCase):
                 print(err)
             """)
 
+    def test_setitem(self):
+        self.assertCodeExecution("""
+            x = True
+            try:
+                x[0] = 1
+            except TypeError as err:
+                print(err)
+        """)
+
 
 class UnaryBoolOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'bool'

--- a/tests/datatypes/test_float.py
+++ b/tests/datatypes/test_float.py
@@ -26,6 +26,15 @@ class FloatTests(TranspileTestCase):
                 print(err)
             """)
 
+    def test_setitem(self):
+        self.assertCodeExecution("""
+            x = 3.14159
+            try:
+                x[0] = 2
+            except TypeError as err:
+                print(err)
+        """)
+
     def test_repr(self):
         self.assertCodeExecution("""
             x = 350000000000000000.0

--- a/tests/datatypes/test_frozenset.py
+++ b/tests/datatypes/test_frozenset.py
@@ -145,6 +145,15 @@ class FrozensetTests(TranspileTestCase):
 
             """)
 
+    def test_setitem(self):
+        self.assertCodeExecution("""
+            x = frozenset("hello world")
+            try:
+                x[0] = "goodbye"
+            except TypeError as err:
+                print(err)
+        """)
+
     def test_isdisjoint(self):
         self.assertCodeExecution("""
             x = frozenset("hello world")

--- a/tests/datatypes/test_int.py
+++ b/tests/datatypes/test_int.py
@@ -28,6 +28,15 @@ class IntTests(TranspileTestCase):
                 print(err)
             """)
 
+    def test_setitem(self):
+        self.assertCodeExecution("""
+            x = 37
+            try:
+                x[0] = 1
+            except TypeError as err:
+                print(err)
+        """)
+
     def test_invalid_literal(self):
         self.assertCodeExecution("""
             try:

--- a/tests/datatypes/test_range.py
+++ b/tests/datatypes/test_range.py
@@ -80,6 +80,15 @@ class RangeTests(TranspileTestCase):
             print(r)
         """)
 
+    def test_setitem(self):
+        self.assertCodeExecution("""
+            r = range(10)
+            try:
+                r[0] = "abc"
+            except TypeError as e:
+                print(e)
+        """)
+
 
 class UnaryRangeOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'range'

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -238,6 +238,16 @@ class StrTests(TranspileTestCase):
                 print(err)
             """)
 
+    def test_setitem(self):
+        # Strings are immutable and do not allow item assignment
+        self.assertCodeExecution("""
+            x = "BeeWare"
+            try:
+                x[0] = "A"
+            except TypeError as err:
+                print(err)
+        """)
+
     def test_slice(self):
         # Full slice
         self.assertCodeExecution("""

--- a/tests/datatypes/test_tuple.py
+++ b/tests/datatypes/test_tuple.py
@@ -43,6 +43,15 @@ class TupleTests(TranspileTestCase):
             print(x)
             """)
 
+    def test_setitem(self):
+        self.assertCodeExecution("""
+            x = (1, 2, 3, 4, 5)
+            try:
+                x[0] = "a"
+            except TypeError as err:
+                print(err)
+        """)
+
     def test_getitem(self):
         # Simple positive index
         self.assertCodeExecution("""


### PR DESCRIPTION
For example, 
```
x = "abc"
x[0] = "d"
``` 
should result in a `TypeError: 'str' object does not support item assignment`. Currently it incorrectly throws an `AttributeError`. The proper behavior is already implemented in `org/python/types/Tuple.java` and `org/python/types/Float.java` (in the form of an overrided `__setitem__` method that throws the right `TypeError`), hence why there are only tests and no code for those files. 