### PR TITLE
Dictionary __getitem__ optimization

### DIFF
--- a/python/common/org/python/Object.java
+++ b/python/common/org/python/Object.java
@@ -66,7 +66,7 @@ public interface Object extends Comparable {
     public org.python.Object __ge__(org.python.Object other);
 
     public org.python.Object __hash__();
-
+    public boolean isHashable();
     public org.python.Object __bool__();
 
     /**

--- a/python/common/org/python/types/Dict.java
+++ b/python/common/org/python/types/Dict.java
@@ -26,6 +26,11 @@ public class Dict extends org.python.types.Object {
         throw new org.python.exceptions.AttributeError(this, "__hash__");
     }
 
+    @Override
+    public boolean isHashable() {
+        return false;
+    }
+
     public Dict() {
         super();
         this.value = new java.util.HashMap<org.python.Object, org.python.Object>();
@@ -256,19 +261,14 @@ public class Dict extends org.python.types.Object {
     }
 
     private org.python.Object _getitem(org.python.Object item) {
-        try {
-            // While hashcode is not used, it is not a redundant line.
-            // We are determining if the item is hashable by seeing if an
-            // exception is thrown.
-            org.python.Object hashcode = item.__hash__();
-
+        if (item.isHashable()) {
             org.python.Object value = this.value.get(item);
 
             if (value == null) {
                 throw new org.python.exceptions.KeyError(item);
             }
             return value;
-        } catch (org.python.exceptions.AttributeError ae) {
+        } else {
             throw new org.python.exceptions.TypeError(
                 String.format("unhashable type: '%s'", org.Python.typeName(item.getClass())));
         }

--- a/python/common/org/python/types/DictItems.java
+++ b/python/common/org/python/types/DictItems.java
@@ -30,6 +30,11 @@ public class DictItems extends org.python.types.Object {
         throw new org.python.exceptions.AttributeError(this, "__hash__");
     }
 
+    @Override
+    public boolean isHashable() {
+        return false;
+    }
+
     public DictItems(org.python.types.Dict dict) {
         this.value = dict.value.entrySet();
     }

--- a/python/common/org/python/types/DictKeys.java
+++ b/python/common/org/python/types/DictKeys.java
@@ -20,6 +20,11 @@ public class DictKeys extends org.python.types.FrozenSet {
         throw new org.python.exceptions.AttributeError(this, "__hash__");
     }
 
+    @Override
+    public boolean isHashable() {
+        return false;
+    }
+
     public DictKeys(org.python.types.Dict dict) {
         this.value = dict.value.keySet();
     }

--- a/python/common/org/python/types/DictValues.java
+++ b/python/common/org/python/types/DictValues.java
@@ -30,6 +30,11 @@ public class DictValues extends org.python.types.Object {
         throw new org.python.exceptions.AttributeError(this, "__hash__");
     }
 
+    @Override
+    public boolean isHashable() {
+        return false;
+    }
+
     DictValues(org.python.types.Dict dict) {
         this.value = dict.value.values();
     }

--- a/python/common/org/python/types/List.java
+++ b/python/common/org/python/types/List.java
@@ -31,6 +31,11 @@ public class List extends org.python.types.Object {
         throw new org.python.exceptions.AttributeError(this, "__hash__");
     }
 
+    @Override
+    public boolean isHashable() {
+        return false;
+    }
+
     public List() {
         super();
         this.value = new java.util.ArrayList<org.python.Object>();

--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -258,6 +258,10 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         return org.python.types.Int.getInt(this.hashCode());
     }
 
+    public boolean isHashable() {
+        return true;
+    }
+
     @org.python.Method(
             __doc__ = ""
     )

--- a/python/common/org/python/types/Set.java
+++ b/python/common/org/python/types/Set.java
@@ -26,6 +26,11 @@ public class Set extends org.python.types.Object {
         throw new org.python.exceptions.AttributeError(this, "__hash__");
     }
 
+    @Override
+    public boolean isHashable() {
+        return false;
+    }
+
     public Set() {
         super();
         this.value = new java.util.HashSet<org.python.Object>();

--- a/python/common/org/python/types/Slice.java
+++ b/python/common/org/python/types/Slice.java
@@ -325,4 +325,9 @@ public class Slice extends org.python.types.Object {
         throw new org.python.exceptions.AttributeError(this, "__hash__");
     }
 
+    @Override
+    public boolean isHashable() {
+        return false;
+    }
+
 }

--- a/python/common/org/python/types/Super.java
+++ b/python/common/org/python/types/Super.java
@@ -204,6 +204,10 @@ public class Super implements org.python.Object {
         return org.python.types.Int.getInt(this.hashCode());
     }
 
+    public boolean isHashable() {
+        return true;
+    }
+
     @org.python.Method(
             __doc__ = ""
     )

--- a/tests/benchmarks.py
+++ b/tests/benchmarks.py
@@ -179,6 +179,19 @@ def test_loops(test_case):
                         pass
     """), timed=True)
 
+def test_dict_get(test_case):
+    print("Running", "test_dictionary_get")
+    test_case.runAsJava(adjust("""
+        dict = {1 : 2, "a" : "b"}
+        for i in range(1000000):
+            dict.get(i)
+            dict.get(1)
+            dict.get("a")
+            dict.get(i)
+            dict.get(1)
+            dict.get("a")
+    """), timed=True)
+
 def main():
     test_case = TranspileTestCase()
     test_case.setUpClass()
@@ -190,6 +203,7 @@ def main():
     test_code(test_case)
     test_loops(test_case)
     test_cmp(test_case)
+    test_dict_get(test_case)
 
 if __name__== "__main__":
   main()

--- a/tests/datatypes/test_dict.py
+++ b/tests/datatypes/test_dict.py
@@ -203,30 +203,45 @@ class DictTests(TranspileTestCase):
             print(x.get(1))
             print(x.get(2))
             print(x.get(3,4))
+
+            class MyClass:
+                pass
+
+            obj = MyClass()
+            print(x.get(obj))
             """)
 
         # check for unhashable type errors
         self.assertCodeExecution("""
             x = {1: 2}
-            try:
-                print(x.get([]))
-            except TypeError as err:
-                print(err)
-            try:
-                print(x.get([], 1))
-            except TypeError as err:
-                print(err)
-            """)
 
-        # check for unhashable type errors
-        self.assertCodeExecution("""
-            x = {1: 2}
             try:
                 print(x.get([]))
             except TypeError as err:
                 print(err)
+
             try:
                 print(x.get([], 1))
+            except TypeError as err:
+                print(err)
+
+            try:
+                print(x.get(list([1])))
+            except TypeError as err:
+                print(err)
+
+            try:
+                print(x.get(set([1, 2, 3])))
+            except TypeError as err:
+                print(err)
+
+            try:
+                print(x.get(iter([1, 2, 3])))
+            except TypeError as err:
+                print(err)
+
+            try:
+                print(x.get(slice(3)))
             except TypeError as err:
                 print(err)
             """)


### PR DESCRIPTION
Currently, `Dict.get(x)` calls `__hash__()` to determine whether or not `x` is hashable (though the value itself is not used). Instead of using `__hash__()` to test an object's hashability, we could use a separate method that avoids the creation of the hashcode objects (which, since they are hashcodes, are large integers that don't get cached and have to be created each time `__hash__()` is called).  

Performance results: 


On Pystone: 

*Without optimization* (current master)
```
test_pystone (tests.test_pystone.PystoneTest) ... Pystone(1.2) time for 50000 passes = 18.2472
This machine benchmarks at 2740.15 pystones/second
```
```
test_pystone (tests.test_pystone.PystoneTest) ... Pystone(1.2) time for 50000 passes = 18.7644
This machine benchmarks at 2664.63 pystones/second
```
```
test_pystone (tests.test_pystone.PystoneTest) ... Pystone(1.2) time for 50000 passes = 18.2185
This machine benchmarks at 2744.46 pystones/second
```

*With optimization* 
```
test_pystone (tests.test_pystone.PystoneTest) ... Pystone(1.2) time for 50000 passes = 10.9498
This machine benchmarks at 4566.29 pystones/second
```
```
test_pystone (tests.test_pystone.PystoneTest) ... Pystone(1.2) time for 50000 passes = 11.2300
This machine benchmarks at 4452.37 pystones/second
```
```
test_pystone (tests.test_pystone.PystoneTest) ... Pystone(1.2) time for 50000 passes = 10.9833
This machine benchmarks at 4552.36 pystones/second
```

That's almost a 70% improvement! Apparently there is quite a lot of dictionary accessing in pystone. 

On [benchmarking test](https://github.com/pybee/voc/pull/899/files#diff-76c95e069000c65f3a49f9984e93fde6):

*Without optimization* 
```
Running test_dictionary_get
  Elapsed time:  55.72767485608347  sec
  CPU process time:  0.00013799999999997148  sec
```
```
Running test_dictionary_get
  Elapsed time:  55.894008523086086  sec
  CPU process time:  0.00011600000000000499  sec
```
```
Running test_dictionary_get
  Elapsed time:  56.72291784896515  sec
  CPU process time:  0.0011000000000000454  sec
```

*With optimization*  
```
Running test_dictionary_get
  Elapsed time:  47.00173879181966  sec
  CPU process time:  0.00012499999999998623  sec
```
```
Running test_dictionary_get
  Elapsed time:  47.65469679213129  sec
  CPU process time:  0.00012100000000003774  sec
```
```
Running test_dictionary_get
  Elapsed time:  48.37633503694087  sec
  CPU process time:  0.00014999999999998348  sec
```

About ~15% improvement. 