### PR TITLE
Do not create org/python/types/Functions until needed

### DIFF
--- a/python/common/org/Python.java
+++ b/python/common/org/Python.java
@@ -226,7 +226,6 @@ public class Python {
                     kwargs_name = cls_annotation.kwargs();
                 }
 
-
                 attrs.put(
                         method_name,
                         new org.python.types.Function(

--- a/python/common/org/Python.java
+++ b/python/common/org/Python.java
@@ -173,11 +173,12 @@ public class Python {
 
                 if (cls_annotation.name().equals("")) {
                     nameToCheck = method.getName();
+
                 } else {
                     nameToCheck = cls_annotation.name();
                 }
 
-                if (name == nameToCheck) {
+                if (name.equals(nameToCheck)) {
                     java.lang.String varargs_name;
                     java.lang.String kwargs_name;
 

--- a/python/common/org/Python.java
+++ b/python/common/org/Python.java
@@ -179,7 +179,6 @@ public class Python {
                 } else {
                     method_name = cls_annotation.name();
                 }
-                
                 methods.put(method_name, method);
             }
         }

--- a/python/common/org/Python.java
+++ b/python/common/org/Python.java
@@ -165,6 +165,27 @@ public class Python {
         }
     }
 
+    public static java.util.Map<java.lang.String, java.lang.reflect.Method> loadModule(java.lang.Class cls) {
+        java.util.Map<java.lang.String, java.lang.reflect.Method> methods = new java.util.HashMap<java.lang.String, java.lang.reflect.Method>();
+        org.python.Module mod_annotation = (org.python.Module) cls.getAnnotation(org.python.Module.class);
+
+        for (java.lang.reflect.Method method : cls.getMethods()) {
+            org.python.Method cls_annotation = method.getAnnotation(org.python.Method.class);
+            if (cls_annotation != null) {
+                java.lang.String method_name;
+
+                if (cls_annotation.name().equals("")) {
+                    method_name = method.getName();
+                } else {
+                    method_name = cls_annotation.name();
+                }
+                
+                methods.put(method_name, method);
+            }
+        }
+        return methods;
+    }
+
     public static void initializeModule(java.lang.Class cls, java.util.Map<java.lang.String, org.python.Object> attrs) {
         // Get the class annotation and add any properties.
         org.python.Module mod_annotation = (org.python.Module) cls.getAnnotation(org.python.Module.class);
@@ -205,6 +226,7 @@ public class Python {
                 } else {
                     kwargs_name = cls_annotation.kwargs();
                 }
+
 
                 attrs.put(
                         method_name,

--- a/python/common/org/Python.java
+++ b/python/common/org/Python.java
@@ -165,6 +165,8 @@ public class Python {
         }
     }
 
+    // This function gets a method defined on the class by name and creates an org.python.types.Function wrapper for it
+    // If no method is found, returns null
     public static org.python.types.Function getPythonFunction(java.lang.String name, java.lang.Class cls) {
         for (java.lang.reflect.Method method : cls.getMethods()) {
             org.python.Method cls_annotation = method.getAnnotation(org.python.Method.class);
@@ -179,29 +181,7 @@ public class Python {
                 }
 
                 if (name.equals(nameToCheck)) {
-                    java.lang.String varargs_name;
-                    java.lang.String kwargs_name;
-
-                    if (cls_annotation.varargs().equals("")) {
-                        varargs_name = null;
-                    } else {
-                        varargs_name = cls_annotation.varargs();
-                    }
-
-                    if (cls_annotation.kwargs().equals("")) {
-                        kwargs_name = null;
-                    } else {
-                        kwargs_name = cls_annotation.kwargs();
-                    }
-
-                    return new org.python.types.Function(
-                            method,
-                            cls_annotation.args(),
-                            cls_annotation.default_args(),
-                            varargs_name,
-                            cls_annotation.kwonlyargs(),
-                            kwargs_name
-                    );
+                    return org.Python.createFunction(cls_annotation, method);
                 }
             }
         }
@@ -209,6 +189,10 @@ public class Python {
         return null;
     }
 
+    // This function performs the following initialization work:
+    //     1. Puts the __doc__ property on the given dictionary (a __dict__)
+    //     2. Puts the names of all Python methods defined on the class into the dictionary,
+    //        but does not create a function wrapper for the method, i.e. (method_name, null)
     public static void loadModule(java.lang.Class cls, java.util.Map<java.lang.String, org.python.Object> attrs) {
         // Get the class annotation and add any properties.
         org.python.Module mod_annotation = (org.python.Module) cls.getAnnotation(org.python.Module.class);
@@ -238,6 +222,9 @@ public class Python {
         }
     }
 
+    // This function performs the following initialization work:
+    //     1. Puts the __doc__ property on the given dictionary (a __dict__)
+    //     2. Puts all Python methods defined on the class into the dictionary i.e. (method_name, function)
     public static void initializeModule(java.lang.Class cls, java.util.Map<java.lang.String, org.python.Object> attrs) {
         // Get the class annotation and add any properties.
         org.python.Module mod_annotation = (org.python.Module) cls.getAnnotation(org.python.Module.class);
@@ -257,8 +244,6 @@ public class Python {
             org.python.Method cls_annotation = method.getAnnotation(org.python.Method.class);
             if (cls_annotation != null) {
                 java.lang.String method_name;
-                java.lang.String varargs_name;
-                java.lang.String kwargs_name;
 
                 // Check for any explicitly set names
                 if (cls_annotation.name().equals("")) {
@@ -267,31 +252,34 @@ public class Python {
                     method_name = cls_annotation.name();
                 }
 
-                if (cls_annotation.varargs().equals("")) {
-                    varargs_name = null;
-                } else {
-                    varargs_name = cls_annotation.varargs();
-                }
-
-                if (cls_annotation.kwargs().equals("")) {
-                    kwargs_name = null;
-                } else {
-                    kwargs_name = cls_annotation.kwargs();
-                }
-
-                attrs.put(
-                        method_name,
-                        new org.python.types.Function(
-                                method,
-                                cls_annotation.args(),
-                                cls_annotation.default_args(),
-                                varargs_name,
-                                cls_annotation.kwonlyargs(),
-                                kwargs_name
-                        )
-                );
+                attrs.put(method_name, org.Python.createFunction(cls_annotation, method));
             }
         }
+    }
+
+    private static org.python.types.Function createFunction(org.python.Method cls_annotation, java.lang.reflect.Method method) {
+        java.lang.String varargs_name;
+        java.lang.String kwargs_name;
+
+        if (cls_annotation.varargs().equals("")) {
+            varargs_name = null;
+        } else {
+            varargs_name = cls_annotation.varargs();
+        }
+
+        if (cls_annotation.kwargs().equals("")) {
+            kwargs_name = null;
+        } else {
+            kwargs_name = cls_annotation.kwargs();
+        }
+
+        return new org.python.types.Function(
+                method,
+                cls_annotation.args(),
+                cls_annotation.default_args(),
+                varargs_name,
+                cls_annotation.kwonlyargs(),
+                kwargs_name);
     }
 
     public static java.lang.String typeName(java.lang.Class cls) {

--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -343,12 +343,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         // org.Python.debug(String.format("GETATTRIBUTE %s = ", name), value);
         // Post-process the value retrieved.
 
-        org.python.Object val = value.__get__(this, this.__class__);
-        if (val instanceof org.python.types.Method) {
-              // Methods can't change at runtime
-              this.__dict__.put(name, val);
-        }
-        return val;
+        return value.__get__(this, this.__class__);
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -343,7 +343,12 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         // org.Python.debug(String.format("GETATTRIBUTE %s = ", name), value);
         // Post-process the value retrieved.
 
-        return value.__get__(this, this.__class__);
+        org.python.Object val = value.__get__(this, this.__class__);
+        if (val instanceof org.python.types.Method) {
+              // Methods can't change at runtime
+              this.__dict__.put(name, val);
+        }
+        return val;
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Type.java
+++ b/python/common/org/python/types/Type.java
@@ -14,7 +14,7 @@ public class Type extends org.python.types.Object implements org.python.Callable
     public java.lang.reflect.Constructor constructor;
     public java.lang.Class klass;
 
-    // A map of methods defined on this object. If this class is in org/python/types
+    // A map of methods defined on this class. If this class is in org/python/types
     // or org/python/stdlib, this will be populated when declarePythonType is invoked.
     private java.util.Map<java.lang.String, java.lang.reflect.Method> python_methods;
 

--- a/python/common/org/python/types/Type.java
+++ b/python/common/org/python/types/Type.java
@@ -15,7 +15,7 @@ public class Type extends org.python.types.Object implements org.python.Callable
     public java.lang.Class klass;
 
     // A map of methods defined on this object. If this class is in org/python/types
-    // or org/python/stdlib, this will be populated when declarePythonType is invoked. 
+    // or org/python/stdlib, this will be populated when declarePythonType is invoked.
     private java.util.Map<java.lang.String, java.lang.reflect.Method> python_methods;
 
     private static org.python.Object[] emptyArgs;

--- a/tests/benchmarks.py
+++ b/tests/benchmarks.py
@@ -192,18 +192,65 @@ def test_dict_get(test_case):
             dict.get("a")
     """), timed=True)
 
+def test_init(test_case):
+    print("Running" , "test_init")
+    test_case.runAsJava(adjust("""
+        for i in range(10000):
+            class A:
+                pass
+
+            class B:
+                pass
+
+            class C:
+                pass
+
+            class D:
+                pass
+
+            class E:
+                pass
+
+            class F:
+                pass
+
+            class G:
+                pass
+
+            class H:
+                pass
+
+            a = "a"
+            b = 1
+            c = [1]
+            d = {10 : "ten"}
+            e = list([1])
+            f = True
+            g = 3.0
+            h = abs
+            i = (1, 2)
+            j = 0j
+            k = b"abc"
+            l = set(c)
+            m = slice(1, 2)
+            n = None
+            o = iter([1])
+            p = range(1)
+    """), timed=True)
+
 def main():
     test_case = TranspileTestCase()
     test_case.setUpClass()
-    test_small_integers(test_case)
-    test_booleans(test_case)
-    test_global_var_load(test_case)
-    test_class_var_load(test_case)
-    test_function_var_load(test_case)
-    test_code(test_case)
-    test_loops(test_case)
-    test_cmp(test_case)
-    test_dict_get(test_case)
+    #test_small_integers(test_case)
+    #test_booleans(test_case)
+    #test_global_var_load(test_case)
+    #test_class_var_load(test_case)
+    #test_function_var_load(test_case)
+    #test_code(test_case)
+    #test_loops(test_case)
+    #test_cmp(test_case)
+    #test_dict_get(test_case)
+    test_init(test_case)
 
 if __name__== "__main__":
   main()

--- a/tests/benchmarks.py
+++ b/tests/benchmarks.py
@@ -231,28 +231,6 @@ def test_class_init(test_case):
         g = 3.0
     """), timed=True)
 
-def test_method(test_case):
-    print("Running, test_method")
-    test_case.runAsJava(adjust("""
-        class MyClass:
-
-            def A(self):
-                print("A!")
-
-            def B(self):
-                print("B!")
-
-            def C(self):
-                print("C!")
-
-        obj = MyClass()
-
-        for i in range(1000000):
-            obj.A()
-            obj.B()
-            obj.C()
-    """), timed=True)
-
 def main():
     test_case = TranspileTestCase()
     test_case.setUpClass()
@@ -266,7 +244,6 @@ def main():
     test_cmp(test_case)
     test_dict_get(test_case)
     test_class_init(test_case)
-    test_method(test_case)
 
 if __name__== "__main__":
   main()

--- a/tests/benchmarks.py
+++ b/tests/benchmarks.py
@@ -231,6 +231,28 @@ def test_class_init(test_case):
         g = 3.0
     """), timed=True)
 
+def test_method(test_case):
+    print("Running, test_method")
+    test_case.runAsJava(adjust("""
+        class MyClass:
+
+            def A(self):
+                print("A!")
+
+            def B(self):
+                print("B!")
+
+            def C(self):
+                print("C!")
+
+        obj = MyClass()
+
+        for i in range(1000000):
+            obj.A()
+            obj.B()
+            obj.C()
+    """), timed=True)
+
 def main():
     test_case = TranspileTestCase()
     test_case.setUpClass()
@@ -244,6 +266,7 @@ def main():
     test_cmp(test_case)
     test_dict_get(test_case)
     test_class_init(test_case)
+    test_method(test_case)
 
 if __name__== "__main__":
   main()

--- a/tests/benchmarks.py
+++ b/tests/benchmarks.py
@@ -192,65 +192,58 @@ def test_dict_get(test_case):
             dict.get("a")
     """), timed=True)
 
-def test_init(test_case):
-    print("Running" , "test_init")
+def test_class_init(test_case):
+    print("Running" , "test_class_init")
     test_case.runAsJava(adjust("""
-        for i in range(10000):
-            class A:
-                pass
+        class A: pass
+        class B: pass
+        class C: pass
+        class D: pass
+        class E: pass
+        class F: pass
+        class G: pass
+        class H: pass
+        class I: pass
+        class J: pass
+        class K: pass
+        class L: pass
+        class M: pass
+        class N: pass
+        class O: pass
+        class P: pass
+        class Q: pass
+        class R: pass
+        class S: pass
+        class T: pass
+        class U: pass
+        class V: pass
+        class W: pass
+        class X: pass
+        class Y: pass
+        class Z: pass
 
-            class B:
-                pass
-
-            class C:
-                pass
-
-            class D:
-                pass
-
-            class E:
-                pass
-
-            class F:
-                pass
-
-            class G:
-                pass
-
-            class H:
-                pass
-
-            a = "a"
-            b = 1
-            c = [1]
-            d = {10 : "ten"}
-            e = list([1])
-            f = True
-            g = 3.0
-            h = abs
-            i = (1, 2)
-            j = 0j
-            k = b"abc"
-            l = set(c)
-            m = slice(1, 2)
-            n = None
-            o = iter([1])
-            p = range(1)
+        a = "a"
+        b = 1
+        c = [1]
+        d = {1 : 1}
+        e = list([1])
+        f = True
+        g = 3.0
     """), timed=True)
 
 def main():
     test_case = TranspileTestCase()
     test_case.setUpClass()
-    #test_small_integers(test_case)
-    #test_booleans(test_case)
-    #test_global_var_load(test_case)
-    #test_class_var_load(test_case)
-    #test_function_var_load(test_case)
-    #test_code(test_case)
-    #test_loops(test_case)
-    #test_cmp(test_case)
-    #test_dict_get(test_case)
-    test_init(test_case)
+    test_small_integers(test_case)
+    test_booleans(test_case)
+    test_global_var_load(test_case)
+    test_class_var_load(test_case)
+    test_function_var_load(test_case)
+    test_code(test_case)
+    test_loops(test_case)
+    test_cmp(test_case)
+    test_dict_get(test_case)
+    test_class_init(test_case)
 
 if __name__== "__main__":
   main()


### PR DESCRIPTION
Each `org/python/types` object does a certain amount of initialisation work which currently includes loading (creating) all the functions that are defined on python objects (`+`, `==`, etc). This PR proposes to not create those functions until they are specifically asked for. The resulting performance gain is a modest boost for start-up time and is linear in the number of classes that are referenced/created. 

Results on [benchmarking test](https://github.com/pybee/voc/pull/902/files#diff-76c95e069000c65f3a49f9984e93fde6): 

*Without optimization* 
```
Running test_init
  Elapsed time:  0.5658640359979472  sec
  CPU process time:  0.00010599999999993948  sec
```
```
Running test_init
  Elapsed time:  0.6104675190035778  sec
  CPU process time:  9.599999999998499e-05  sec
```
```
Running test_class_init
  Elapsed time:  0.5521897639991948  sec
  CPU process time:  0.00011099999999997223  sec
```

*With optimization* 
```
Running test_class_init
  Elapsed time:  0.32723955099936575  sec
  CPU process time:  7.900000000005125e-05  sec
```
```
Running test_class_init
  Elapsed time:  0.38820800599933136  sec
  CPU process time:  0.00010399999999999299  sec
```
```
Running test_class_init
  Elapsed time:  0.3487427390027733  sec
  CPU process time:  0.00010099999999990672  sec
```

About a 30% improvement, but again, this is a one-time benefit. 