### PR TITLE
Do not use hashcode in Dictionary.__setitem__()

### DIFF
--- a/python/common/org/python/types/Dict.java
+++ b/python/common/org/python/types/Dict.java
@@ -295,14 +295,9 @@ public class Dict extends org.python.types.Object {
             args = {"item", "value"}
     )
     public void __setitem__(org.python.Object item, org.python.Object value) {
-        try {
-            // While hashcode is not used, it is not a redundant line.
-            // We are determining if the item is hashable by seeing if an
-            // exception is thrown.
-            org.python.Object hashcode = item.__hash__();
-
+        if (item.isHashable()) {
             this.value.put(item, value);
-        } catch (org.python.exceptions.AttributeError ae) {
+        } else {
             throw new org.python.exceptions.TypeError(
                     String.format("unhashable type: '%s'", org.Python.typeName(item.getClass())));
         }

--- a/tests/benchmarks.py
+++ b/tests/benchmarks.py
@@ -192,6 +192,19 @@ def test_dict_get(test_case):
             dict.get("a")
     """), timed=True)
 
+def test_dict_set(test_case):
+    print("Running", "test_dictionary_set")
+    test_case.runAsJava(adjust("""
+        dict = {}
+        for i in range(1000000):
+            dict["moo"] = 1
+            dict["quack"] = 2
+            dict["woof"] = 3
+            dict["meow"] = 4
+            dict["cockadoodledoo"] = 5
+            dict["hiss"] = 6
+    """), timed=True)
+
 def main():
     test_case = TranspileTestCase()
     test_case.setUpClass()
@@ -204,6 +217,7 @@ def main():
     test_loops(test_case)
     test_cmp(test_case)
     test_dict_get(test_case)
+    test_dict_set(test_case)
 
 if __name__== "__main__":
   main()


### PR DESCRIPTION
This is the same change we made last week in https://github.com/pybee/voc/pull/899, I just totally missed that we have the same problem in `__setitem__`. 

Benchmarking test results: 

*Without optimization* 
```
Running test_dictionary_set
  Elapsed time:  80.42860776100133  sec
  CPU process time:  35.274944  sec
```
```
Running test_dictionary_set
  Elapsed time:  82.14729893500044  sec
  CPU process time:  36.17060300000001  sec
```
```
Running test_dictionary_set
  Elapsed time:  82.20054076200176  sec
  CPU process time:  36.687954000000005  sec
```

*With optimization* 
```
Running test_dictionary_set
  Elapsed time:  21.558084768010303  sec
  CPU process time:  0.00010599999999999499  sec
```
```
Running test_dictionary_set
  Elapsed time:  22.36876635599765  sec
  CPU process time:  0.00010199999999999099  sec
```
```
Running test_dictionary_set
  Elapsed time:  22.17953223499353  sec
  CPU process time:  0.00010499999999999399  sec
```

Almost a 4x speedup here. 

Pystone results: 

*Without optimization*
```
test_pystone (tests.test_pystone.PystoneTest) ... Pystone(1.2) time for 50000 passes = 10.9498
This machine benchmarks at 4566.29 pystones/second
```
```
test_pystone (tests.test_pystone.PystoneTest) ... Pystone(1.2) time for 50000 passes = 11.2300
This machine benchmarks at 4452.37 pystones/second
```
```
test_pystone (tests.test_pystone.PystoneTest) ... Pystone(1.2) time for 50000 passes = 10.9833
This machine benchmarks at 4552.36 pystones/second
```

*With optimization* 
```
test_pystone (tests.test_pystone.PystoneTest) ... Pystone(1.2) time for 50000 passes = 10.8240
This machine benchmarks at 4619.35 pystones/second
```
```
test_pystone (tests.test_pystone.PystoneTest) ... Pystone(1.2) time for 50000 passes = 10.9262
This machine benchmarks at 4576.14 pystones/second
```
```
test_pystone (tests.test_pystone.PystoneTest) ... Pystone(1.2) time for 50000 passes = 10.5671
This machine benchmarks at 4731.65 pystones/second
```

A tiny bump here. 


