### PR TITLE
Do not re-create the same immutable object

### DIFF
--- a/python/common/org/python/Object.java
+++ b/python/common/org/python/Object.java
@@ -34,14 +34,6 @@ public interface Object extends Comparable {
     public java.lang.String typeName();
 
     /**
-     * Return a version of the object that can be used when returning by
-     * value. For most objects, this will be itself; but primitive types
-     * need to return a copy of themselves to ensure that they aren't
-     * modified.
-     */
-    public org.python.Object byValue();
-
-    /**
      * Python interface compatibility
      * Section 3.3.1 - Basic customization
      */

--- a/python/common/org/python/types/Bool.java
+++ b/python/common/org/python/types/Bool.java
@@ -34,7 +34,7 @@ public class Bool extends org.python.types.Object {
     }
 
     public org.python.Object byValue() {
-        return org.python.types.Bool.getBool(this.value);
+        return this;
     }
 
     public int hashCode() {
@@ -173,7 +173,7 @@ public class Bool extends org.python.types.Object {
             __doc__ = "self != 0"
     )
     public org.python.types.Bool __bool__() {
-        return org.python.types.Bool.getBool(this.value);
+        return this;
     }
 
     public boolean __setattr_null(java.lang.String name, org.python.Object value) {
@@ -338,7 +338,7 @@ public class Bool extends org.python.types.Object {
                 }
             } else if (other_val > 1) {
                 if (org.Python.VERSION < 0x03060000) {
-                    return org.python.types.Bool.getBool(this.value);
+                    return this;
                 } else {
                     return org.python.types.Int.getInt(1);
                 }

--- a/python/common/org/python/types/Bool.java
+++ b/python/common/org/python/types/Bool.java
@@ -33,10 +33,6 @@ public class Bool extends org.python.types.Object {
         return this.value;
     }
 
-    public org.python.Object byValue() {
-        return this;
-    }
-
     public int hashCode() {
         return new java.lang.Boolean(this.value).hashCode();
     }

--- a/python/common/org/python/types/Bool.java
+++ b/python/common/org/python/types/Bool.java
@@ -19,16 +19,6 @@ public class Bool extends org.python.types.Object {
         return org.python.types.Bool.FALSE;
     }
 
-    /**
-     * A utility method to update the internal value of this object.
-     *
-     * Used by __i*__ operations to do an in-place operation.
-     * obj must be of type org.python.types.Bool
-     */
-    void setValue(org.python.Object obj) {
-        this.value = ((org.python.types.Bool) obj).value;
-    }
-
     public java.lang.Object toJava() {
         return this.value;
     }

--- a/python/common/org/python/types/ByteArray.java
+++ b/python/common/org/python/types/ByteArray.java
@@ -5,16 +5,6 @@ import java.util.Arrays;
 public class ByteArray extends org.python.types.Object {
     public byte[] value;
 
-    /**
-     * A utility method to update the internal value of this object.
-     *
-     * Used by __i*__ operations to do an in-place operation.
-     * obj must be of type org.python.types.ByteArray
-     */
-    void setValue(org.python.Object obj) {
-        this.value = ((org.python.types.ByteArray) obj).value;
-    }
-
     public int hashCode() {
         return this.value.hashCode();
     }

--- a/python/common/org/python/types/Bytes.java
+++ b/python/common/org/python/types/Bytes.java
@@ -7,16 +7,6 @@ import java.util.List;
 public class Bytes extends org.python.types.Object {
     public byte[] value;
 
-    /**
-     * A utility method to update the internal value of this object.
-     *
-     * Used by __i*__ operations to do an in-place operation.
-     * obj must be of type org.python.types.Bytes
-     */
-    void setValue(org.python.Object obj) {
-        this.value = ((org.python.types.Bytes) obj).value;
-    }
-
     public int hashCode() {
         return this.value.hashCode();
     }

--- a/python/common/org/python/types/Closure.java
+++ b/python/common/org/python/types/Closure.java
@@ -3,15 +3,6 @@ package org.python.types;
 public class Closure extends org.python.types.Object {
     public java.util.List<java.util.Map<java.lang.String, org.python.Object>> locals_list;
 
-    /**
-     * A utility method to update the internal value of this object.
-     *
-     * Used by __i*__ operations to do an in-place operation.
-     * obj must be of type org.python.types.Closure
-     */
-    void setValue(org.python.Object obj) {
-    }
-
     public Closure(java.util.List<java.util.Map<java.lang.String, org.python.Object>> locals_list) {
         super();
         this.locals_list = locals_list;

--- a/python/common/org/python/types/Code.java
+++ b/python/common/org/python/types/Code.java
@@ -46,31 +46,6 @@ public class Code extends org.python.types.Object {
     @org.python.Attribute
     org.python.types.Tuple co_varnames;
 
-    /**
-     * A utility method to update the internal value of this object.
-     *
-     * Used by __i*__ operations to do an in-place operation.
-     * obj must be of type org.python.types.Class
-     */
-    void setValue(org.python.Object obj) {
-        org.python.types.Object object = (org.python.types.Object) obj;
-        this.co_argcount = (org.python.types.Int) object.__getattribute__("co_argcount");
-        this.co_cellvars = (org.python.types.Tuple) object.__getattribute__("co_cellvars");
-        this.co_code = (org.python.types.Bytes) object.__getattribute__("co_code");
-        this.co_consts = (org.python.types.Tuple) object.__getattribute__("co_consts");
-        this.co_filename = (org.python.types.Str) object.__getattribute__("co_filename");
-        this.co_firstlineno = (org.python.types.Int) object.__getattribute__("co_firstlineno");
-        this.co_flags = (org.python.types.Int) object.__getattribute__("co_flags");
-        this.co_freevars = (org.python.types.Tuple) object.__getattribute__("co_freevars");
-        this.co_kwonlyargcount = (org.python.types.Int) object.__getattribute__("co_kwonlyargcount");
-        this.co_lnotab = (org.python.types.Bytes) object.__getattribute__("co_lnotab");
-        this.co_name = (org.python.types.Str) object.__getattribute__("co_name");
-        this.co_names = (org.python.types.Tuple) object.__getattribute__("co_names");
-        this.co_nlocals = (org.python.types.Int) object.__getattribute__("co_nlocals");
-        this.co_stacksize = (org.python.types.Int) object.__getattribute__("co_stacksize");
-        this.co_varnames = (org.python.types.Tuple) object.__getattribute__("co_varnames");
-    }
-
     public Code(
             org.python.types.Int co_argcount,
             org.python.types.Tuple co_cellvars,

--- a/python/common/org/python/types/Complex.java
+++ b/python/common/org/python/types/Complex.java
@@ -18,10 +18,6 @@ public class Complex extends org.python.types.Object {
         return this;
     }
 
-    public org.python.Object byValue() {
-        throw new org.python.exceptions.AttributeError("type object 'complex' has no attribute 'byValue'");
-    }
-
     public int hashCode() {
         return this.hashCode();
     }

--- a/python/common/org/python/types/Complex.java
+++ b/python/common/org/python/types/Complex.java
@@ -375,7 +375,7 @@ public class Complex extends org.python.types.Object {
             if (!((Bool) other).value) {
                 throw new org.python.exceptions.ZeroDivisionError("complex division by zero");
             }
-            return new org.python.types.Complex(this.real, this.imag);
+            return this;
         } else if (other instanceof org.python.types.Float) {
             if (((Float) other).value == 0.0) {
                 throw new org.python.exceptions.ZeroDivisionError("complex division by zero");
@@ -668,7 +668,7 @@ public class Complex extends org.python.types.Object {
             __doc__ = "+self"
     )
     public org.python.Object __pos__() {
-        return new org.python.types.Complex(this.real, this.imag);
+        return this;
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Dict.java
+++ b/python/common/org/python/types/Dict.java
@@ -3,16 +3,6 @@ package org.python.types;
 public class Dict extends org.python.types.Object {
     public java.util.Map<org.python.Object, org.python.Object> value;
 
-    /**
-     * A utility method to update the internal value of this object.
-     * <p>
-     * Used by __i*__ operations to do an in-place operation.
-     * obj must be of type org.python.types.Dict
-     */
-    void setValue(org.python.Object obj) {
-        this.value = ((org.python.types.Dict) obj).value;
-    }
-
     public java.lang.Object toJava() {
         return this.value;
     }

--- a/python/common/org/python/types/DictItems.java
+++ b/python/common/org/python/types/DictItems.java
@@ -7,16 +7,6 @@ public class DictItems extends org.python.types.Object {
         org.python.types.Type.declarePythonType(DictItems.class, "dict_items", null, null);
     }
 
-    /**
-     * A utility method to update the internal value of this object.
-     * <p>
-     * Used by __i*__ operations to do an in-place operation.
-     * obj must be of type org.python.types.DictItems
-     */
-    void setValue(org.python.Object obj) {
-        this.value = ((org.python.types.DictItems) obj).value;
-    }
-
     public java.lang.Object toJava() {
         return this.value;
     }

--- a/python/common/org/python/types/DictKeys.java
+++ b/python/common/org/python/types/DictKeys.java
@@ -5,16 +5,6 @@ public class DictKeys extends org.python.types.FrozenSet {
         org.python.types.Type.declarePythonType(DictKeys.class, "dict_keys", null, null);
     }
 
-    /**
-     * A utility method to update the internal value of this object.
-     *
-     * Used by __i*__ operations to do an in-place operation.
-     * obj must be of type org.python.types.FrozenSet
-     */
-    void setValue(org.python.Object obj) {
-        this.value = ((org.python.types.DictKeys) obj).value;
-    }
-
     @Override
     public org.python.Object __hash__() {
         throw new org.python.exceptions.AttributeError(this, "__hash__");

--- a/python/common/org/python/types/DictValues.java
+++ b/python/common/org/python/types/DictValues.java
@@ -7,16 +7,6 @@ public class DictValues extends org.python.types.Object {
         org.python.types.Type.declarePythonType(DictValues.class, "dict_values", null, null);
     }
 
-    /**
-     * A utility method to update the internal value of this object.
-     * <p>
-     * Used by __i*__ operations to do an in-place operation.
-     * obj must be of type org.python.types.DictValues
-     */
-    void setValue(org.python.Object obj) {
-        this.value = ((org.python.types.DictValues) obj).value;
-    }
-
     public java.lang.Object toJava() {
         return this.value;
     }

--- a/python/common/org/python/types/Float.java
+++ b/python/common/org/python/types/Float.java
@@ -20,10 +20,6 @@ public class Float extends org.python.types.Object {
         return this.value;
     }
 
-    public org.python.Object byValue() {
-        return this;
-    }
-
     public int hashCode() {
         return new java.lang.Double(this.value).hashCode();
     }

--- a/python/common/org/python/types/Float.java
+++ b/python/common/org/python/types/Float.java
@@ -6,16 +6,6 @@ public class Float extends org.python.types.Object {
     private static final long NEGATIVE_ZERO_RAW_BITS = Double.doubleToRawLongBits(-0.0);
     public double value;
 
-    /**
-     * A utility method to update the internal value of this object.
-     *
-     * Used by __i*__ operations to do an in-place operation.
-     * obj must be of type org.python.types.Float
-     */
-    void setValue(org.python.Object obj) {
-        this.value = ((org.python.types.Float) obj).value;
-    }
-
     public java.lang.Object toJava() {
         return this.value;
     }

--- a/python/common/org/python/types/Float.java
+++ b/python/common/org/python/types/Float.java
@@ -21,7 +21,7 @@ public class Float extends org.python.types.Object {
     }
 
     public org.python.Object byValue() {
-        return new org.python.types.Float(this.value);
+        return this;
     }
 
     public int hashCode() {
@@ -264,7 +264,7 @@ public class Float extends org.python.types.Object {
             if (((org.python.types.Bool) other).value) {
                 return new org.python.types.Float(this.value + 1.0);
             }
-            return new org.python.types.Float(this.value);
+            return this;
         } else if (other instanceof org.python.types.Float) {
             double other_val = ((org.python.types.Float) other).value;
             return new org.python.types.Float(this.value + other_val);
@@ -289,7 +289,7 @@ public class Float extends org.python.types.Object {
             if (((org.python.types.Bool) other).value) {
                 return new org.python.types.Float(this.value - 1.0);
             }
-            return new org.python.types.Float(this.value);
+            return this;
         } else if (other instanceof org.python.types.Complex) {
             return new org.python.types.Complex(
                 new org.python.types.Float(this.value - ((org.python.types.Complex) other).real.value),
@@ -363,7 +363,7 @@ public class Float extends org.python.types.Object {
             return new org.python.types.Float(this.value / other_val);
         } else if (other instanceof org.python.types.Bool) {
             if (((org.python.types.Bool) other).value) {
-                return new org.python.types.Float(this.value);
+                return this;
             } else {
                 throw new org.python.exceptions.ZeroDivisionError("float division by zero");
             }
@@ -493,7 +493,7 @@ public class Float extends org.python.types.Object {
             return new org.python.types.Float(java.lang.Math.pow(this.value, other_val));
         } else if (other instanceof org.python.types.Bool) {
             if (((org.python.types.Bool) other).value) {
-                return new org.python.types.Float(this.value);
+                return this;
             } else {
                 return new org.python.types.Float(1);
             }
@@ -596,7 +596,7 @@ public class Float extends org.python.types.Object {
             __doc__ = "+self"
     )
     public org.python.Object __pos__() {
-        return new org.python.types.Float(this.value);
+        return this;
     }
 
     @org.python.Method(
@@ -606,7 +606,7 @@ public class Float extends org.python.types.Object {
         if (this.value < 0.0) {
             return new org.python.types.Float(-this.value);
         } else {
-            return new org.python.types.Float(this.value);
+            return this;
         }
     }
 
@@ -621,7 +621,7 @@ public class Float extends org.python.types.Object {
             __doc__ = "float(self)"
     )
     public org.python.Object __float__() {
-        return new org.python.types.Float(this.value);
+        return this;
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/FrozenSet.java
+++ b/python/common/org/python/types/FrozenSet.java
@@ -3,16 +3,6 @@ package org.python.types;
 public class FrozenSet extends org.python.types.Object {
     public java.util.Set<org.python.Object> value;
 
-    /**
-     * A utility method to update the internal value of this object.
-     *
-     * Used by __i*__ operations to do an in-place operation.
-     * obj must be of type org.python.types.FrozenSet
-     */
-    void setValue(org.python.Object obj) {
-        this.value = ((org.python.types.FrozenSet) obj).value;
-    }
-
     public java.lang.Object toJava() {
         return this.value;
     }

--- a/python/common/org/python/types/Int.java
+++ b/python/common/org/python/types/Int.java
@@ -26,7 +26,7 @@ public class Int extends org.python.types.Object {
     }
 
     public org.python.Object byValue() {
-        return getInt(this.value);
+        return this;
     }
 
     public int hashCode() {
@@ -384,7 +384,7 @@ public class Int extends org.python.types.Object {
             return new org.python.types.Float(Math.floor(this.value / ((org.python.types.Float) other).value));
         } else if (other instanceof org.python.types.Bool) {
             if (((org.python.types.Bool) other).value) {
-                return getInt(this.value);
+                return this;
             } else {
                 throw new org.python.exceptions.ZeroDivisionError("integer division or modulo by zero");
             }
@@ -557,7 +557,7 @@ public class Int extends org.python.types.Object {
             return cmplx_obj.__pow__(other_cmplx_obj, null);
         } else if (other instanceof org.python.types.Bool) {
             if (((org.python.types.Bool) other).value) {
-                return getInt(this.value);
+                return this;
             } else {
                 return getInt(1);
             }
@@ -888,7 +888,7 @@ public class Int extends org.python.types.Object {
             __doc__ = "+self"
     )
     public org.python.Object __pos__() {
-        return getInt(this.value);
+        return this;
     }
 
     @org.python.Method(
@@ -909,7 +909,7 @@ public class Int extends org.python.types.Object {
             __doc__ = "int(self)"
     )
     public org.python.Object __int__() {
-        return getInt(this.value);
+        return this;
     }
 
     @org.python.Method(
@@ -924,7 +924,7 @@ public class Int extends org.python.types.Object {
     )
     public org.python.Object __round__(org.python.Object ndigits) {
         if (ndigits instanceof org.python.types.Int) {
-            return getInt(this.value);
+            return this;
         }
         throw new org.python.exceptions.TypeError("'" + ndigits.typeName() + "' object cannot be interpreted as an integer");
     }

--- a/python/common/org/python/types/Int.java
+++ b/python/common/org/python/types/Int.java
@@ -25,10 +25,6 @@ public class Int extends org.python.types.Object {
         return this.value;
     }
 
-    public org.python.Object byValue() {
-        return this;
-    }
-
     public int hashCode() {
         return new java.lang.Long(this.value).hashCode();
     }

--- a/python/common/org/python/types/Int.java
+++ b/python/common/org/python/types/Int.java
@@ -11,16 +11,6 @@ public class Int extends org.python.types.Object {
      */
     private static final org.python.types.Int[] SMALLINTS = new org.python.types.Int[NSMALLNEGINTS + NSMALLPOSINTS];
 
-    /**
-     * A utility method to update the internal value of this object.
-     *
-     * Used by __i*__ operations to do an in-place operation.
-     * obj must be of type org.python.types.Int
-     */
-    void setValue(org.python.Object obj) {
-        this.value = ((org.python.types.Int) obj).value;
-    }
-
     public java.lang.Object toJava() {
         return this.value;
     }

--- a/python/common/org/python/types/List.java
+++ b/python/common/org/python/types/List.java
@@ -8,16 +8,6 @@ import java.util.Comparator;
 public class List extends org.python.types.Object {
     public java.util.List<org.python.Object> value;
 
-    /**
-     * A utility method to update the internal value of this object.
-     * <p>
-     * Used by __i*__ operations to do an in-place operation.
-     * obj must be of type org.python.types.List
-     */
-    void setValue(org.python.Object obj) {
-        this.value = ((org.python.types.List) obj).value;
-    }
-
     public java.lang.Object toJava() {
         return this.value;
     }

--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -36,10 +36,6 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
         }
     }
 
-    public org.python.Object byValue() {
-        return this;
-    }
-
     /**
      * Return the Python type for this object.
      */

--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -5,17 +5,6 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
     public org.python.types.Type __class__;
     public org.python.types.Type.Origin origin;
 
-    /**
-     * A utility method to update the internal value of this object.
-     *
-     * Used by __i*__ operations to do an in-place operation.
-     * On a base object, it will always fail. Subclasses should override
-     * to provide the relevant assignment info.
-     */
-    void setValue(org.python.Object obj) {
-        throw new org.python.exceptions.RuntimeError("'" + this.typeName() + "' object cannot be updated.");
-    }
-
     public java.lang.Object toJava() {
         return this;
     }
@@ -861,8 +850,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
     )
     public org.python.Object __idivmod__(org.python.Object other) {
         try {
-            this.setValue(this.__divmod__(other));
-            return this;
+            return this.__divmod__(other);
         } catch (org.python.exceptions.TypeError e) {
             throw new org.python.exceptions.TypeError("unsupported operand type(s) for //=: '" + this.typeName() + "' and '" + other.typeName() + "'");
         }
@@ -882,8 +870,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
     )
     public org.python.Object __ilshift__(org.python.Object other) {
         try {
-            this.setValue(this.__lshift__(other));
-            return this;
+            return this.__lshift__(other);
         } catch (org.python.exceptions.TypeError e) {
             throw new org.python.exceptions.TypeError("unsupported operand type(s) for <<=: '" + this.typeName() + "' and '" + other.typeName() + "'");
         }
@@ -895,8 +882,7 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
     )
     public org.python.Object __irshift__(org.python.Object other) {
         try {
-            this.setValue(this.__rshift__(other));
-            return this;
+            return this.__rshift__(other);
         } catch (org.python.exceptions.TypeError e) {
             throw new org.python.exceptions.TypeError("unsupported operand type(s) for >>=: '" + this.typeName() + "' and '" + other.typeName() + "'");
         }

--- a/python/common/org/python/types/Set.java
+++ b/python/common/org/python/types/Set.java
@@ -3,16 +3,6 @@ package org.python.types;
 public class Set extends org.python.types.Object {
     public java.util.Set<org.python.Object> value;
 
-    /**
-     * A utility method to update the internal value of this object.
-     *
-     * Used by __i*__ operations to do an in-place operation.
-     * obj must be of type org.python.types.Set
-     */
-    void setValue(org.python.Object obj) {
-        this.value = ((org.python.types.Set) obj).value;
-    }
-
     public java.lang.Object toJava() {
         return this.value;
     }

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -3,17 +3,6 @@ package org.python.types;
 public class Str extends org.python.types.Object {
     public java.lang.String value;
 
-    /**
-     * A utility method to update the internal value of this object.
-     *
-     * Used by __i*__ operations to do an in-place operation.
-     * obj must be of type org.python.types.Str
-     */
-    void setValue(org.python.Object obj) {
-        this.value = ((org.python.types.Str) obj).value;
-
-    }
-
     public java.lang.Object toJava() {
         return this.value;
     }
@@ -491,8 +480,7 @@ public class Str extends org.python.types.Object {
             args = {"other"}
     )
     public org.python.Object __ipow__(org.python.Object other) {
-        this.setValue(this.__pow__(other, null));
-        return this;
+        return this.__pow__(other, null);
     }
 
     @org.python.Method(
@@ -544,8 +532,7 @@ public class Str extends org.python.types.Object {
             args = {"other"}
     )
     public org.python.Object __imul__(org.python.Object other) {
-        this.setValue(this.__mul__(other));
-        return this;
+        return this.__mul__(other);
     }
 
     @org.python.Method(
@@ -553,8 +540,7 @@ public class Str extends org.python.types.Object {
             args = {"other"}
     )
     public org.python.Object __imod__(org.python.Object other) {
-        this.setValue(this.__mod__(other));
-        return this;
+        return this.__mod__(other);
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -18,10 +18,6 @@ public class Str extends org.python.types.Object {
         return this.value;
     }
 
-    public org.python.Object byValue() {
-        return new org.python.types.Str(this.value);
-    }
-
     public int hashCode() {
         return this.value.hashCode();
     }

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -620,7 +620,7 @@ public class Str extends org.python.types.Object {
                 return new org.python.types.Str(returnString.toString());
             }
         } else if (width instanceof org.python.types.Bool) {
-            return new org.python.types.Str(this.value);
+            return this;
         }
 
         throw new org.python.exceptions.TypeError("Length must be of type Integer or Bool");
@@ -1076,7 +1076,7 @@ public class Str extends org.python.types.Object {
 
         int w = (int) ((org.python.types.Int) width).value;
         if (w < this.value.length()) {
-            return new org.python.types.Str(this.value);
+            return this;
         }
         java.lang.StringBuffer str = new java.lang.StringBuffer(w);
         str.append(this.value);
@@ -1296,7 +1296,7 @@ public class Str extends org.python.types.Object {
             }
             int w = (int) ((org.python.types.Int) width).value;
             if (w < this.value.length()) {
-                return new org.python.types.Str(this.value);
+                return this;
             }
             java.lang.StringBuffer str = new java.lang.StringBuffer(w);
             int balance = w - this.value.length();
@@ -1346,7 +1346,7 @@ public class Str extends org.python.types.Object {
         }
         tuple.add(new org.python.types.Str(""));
         tuple.add(new org.python.types.Str(""));
-        tuple.add(new org.python.types.Str(this.value));
+        tuple.add(this);
         return new org.python.types.Tuple(tuple);
     }
 
@@ -1710,7 +1710,7 @@ public class Str extends org.python.types.Object {
     )
     public org.python.Object swapcase() {
         if (this.value.isEmpty()) {
-            return new org.python.types.Str(this.value);
+            return this;
         }
         java.lang.StringBuffer swapcase = new java.lang.StringBuffer();
         for (int c = 0; c < this.value.length(); c++) {
@@ -1797,7 +1797,7 @@ public class Str extends org.python.types.Object {
         int w = (int) ((org.python.types.Int) width).value;
 
         if (this.value.length() >= w) {
-            return new org.python.types.Str(this.value);
+            return this;
         }
 
         int fill = w - this.value.length();

--- a/python/common/org/python/types/Super.java
+++ b/python/common/org/python/types/Super.java
@@ -4,17 +4,6 @@ public class Super implements org.python.Object {
     public org.python.types.Type klass;
     public org.python.Object instance;
 
-    /**
-     * A utility method to update the internal value of this object.
-     *
-     * Used by __i*__ operations to do an in-place operation.
-     * On a base object, it will always fail. Subclasses should override
-     * to provide the relevant assignment info.
-     */
-    void setValue(org.python.Object obj) {
-        throw new org.python.exceptions.RuntimeError("super object cannot be updated.");
-    }
-
     public java.lang.Object toJava() {
         return this;
     }
@@ -680,8 +669,7 @@ public class Super implements org.python.Object {
     )
     public org.python.Object __iadd__(org.python.Object other) {
         try {
-            this.setValue(this.__add__(other));
-            return this;
+            return this.__add__(other);
         } catch (org.python.exceptions.TypeError e) {
             throw new org.python.exceptions.TypeError("unsupported operand type(s) for +=: 'super()' and '" + other.typeName() + "'");
         }
@@ -705,8 +693,7 @@ public class Super implements org.python.Object {
     )
     public org.python.Object __imul__(org.python.Object other) {
         try {
-            this.setValue(this.__mul__(other));
-            return this;
+            return this.__mul__(other);
         } catch (org.python.exceptions.TypeError e) {
             throw new org.python.exceptions.TypeError("unsupported operand type(s) for *=: 'super()' and '" + other.typeName() + "'");
         }
@@ -718,8 +705,7 @@ public class Super implements org.python.Object {
     )
     public org.python.Object __itruediv__(org.python.Object other) {
         try {
-            this.setValue(this.__truediv__(other));
-            return this;
+            return this.__truediv__(other);
         } catch (org.python.exceptions.TypeError e) {
             throw new org.python.exceptions.TypeError("unsupported operand type(s) for /=: 'super()' and '" + other.typeName() + "'");
         }
@@ -731,8 +717,7 @@ public class Super implements org.python.Object {
     )
     public org.python.Object __ifloordiv__(org.python.Object other) {
         try {
-            this.setValue(this.__floordiv__(other));
-            return this;
+            return this.__floordiv__(other);
         } catch (org.python.exceptions.TypeError e) {
             throw new org.python.exceptions.TypeError("unsupported operand type(s) for //=: 'super()' and '" + other.typeName() + "'");
         }
@@ -744,8 +729,7 @@ public class Super implements org.python.Object {
     )
     public org.python.Object __imod__(org.python.Object other) {
         try {
-            this.setValue(this.__mod__(other));
-            return this;
+            return this.__mod__(other);
         } catch (org.python.exceptions.TypeError e) {
             throw new org.python.exceptions.TypeError("unsupported operand type(s) for %=: 'super()' and '" + other.typeName() + "'");
         }
@@ -757,8 +741,7 @@ public class Super implements org.python.Object {
     )
     public org.python.Object __idivmod__(org.python.Object other) {
         try {
-            this.setValue(this.__pow__(other, null));
-            return this;
+            return this.__divmod__(other);
         } catch (org.python.exceptions.TypeError e) {
             throw new org.python.exceptions.TypeError("unsupported operand type(s) for //=: '" + this.typeName() + "' and '" + other.typeName() + "'");
         }
@@ -770,8 +753,7 @@ public class Super implements org.python.Object {
     )
     public org.python.Object __ipow__(org.python.Object other) {
         try {
-            this.setValue(this.__pow__(other, null));
-            return this;
+            return this.__pow__(other, null);
         } catch (org.python.exceptions.TypeError e) {
             throw new org.python.exceptions.TypeError("unsupported operand type(s) for **=: 'super()' and '" + other.typeName() + "'");
         }
@@ -783,8 +765,7 @@ public class Super implements org.python.Object {
     )
     public org.python.Object __ilshift__(org.python.Object other) {
         try {
-            this.setValue(this.__lshift__(other));
-            return this;
+            return this.__lshift__(other);
         } catch (org.python.exceptions.TypeError e) {
             throw new org.python.exceptions.TypeError("unsupported operand type(s) for <<=: 'super()' and '" + other.typeName() + "'");
         }
@@ -796,8 +777,7 @@ public class Super implements org.python.Object {
     )
     public org.python.Object __irshift__(org.python.Object other) {
         try {
-            this.setValue(this.__rshift__(other));
-            return this;
+            return this.__rshift__(other);
         } catch (org.python.exceptions.TypeError e) {
             throw new org.python.exceptions.TypeError("unsupported operand type(s) for >>=: 'super()' and '" + other.typeName() + "'");
         }
@@ -821,8 +801,7 @@ public class Super implements org.python.Object {
     )
     public org.python.Object __ixor__(org.python.Object other) {
         try {
-            this.setValue(this.__xor__(other));
-            return this;
+            return this.__xor__(other);
         } catch (org.python.exceptions.TypeError e) {
             throw new org.python.exceptions.TypeError("unsupported operand type(s) for ^=: 'super()' and '" + other.typeName() + "'");
         }

--- a/python/common/org/python/types/Super.java
+++ b/python/common/org/python/types/Super.java
@@ -27,10 +27,6 @@ public class Super implements org.python.Object {
         return true;
     }
 
-    public org.python.Object byValue() {
-        return this;
-    }
-
     public org.python.types.Type type() {
         return null;
     }

--- a/python/common/org/python/types/Tuple.java
+++ b/python/common/org/python/types/Tuple.java
@@ -3,16 +3,6 @@ package org.python.types;
 public class Tuple extends org.python.types.Object {
     public java.util.List<org.python.Object> value;
 
-    /**
-     * A utility method to update the internal value of this object.
-     * <p>
-     * Used by __i*__ operations to do an in-place operation.
-     * obj must be of type org.python.types.Tuple
-     */
-    void setValue(org.python.Object obj) {
-        this.value = ((org.python.types.Tuple) obj).value;
-    }
-
     public java.lang.Object toJava() {
         return this.value;
     }

--- a/python/common/org/python/types/Type.java
+++ b/python/common/org/python/types/Type.java
@@ -264,16 +264,6 @@ public class Type extends org.python.types.Object implements org.python.Callable
         }
     }
 
-    /**
-     * A utility method to update the internal value of this object.
-     *
-     * Used by __i*__ operations to do an in-place operation.
-     * obj must be of type org.python.types.Type
-     */
-    void setValue(org.python.Object obj) {
-        this.klass = ((org.python.types.Type) obj).klass;
-    }
-
     public Type(Origin origin, java.lang.Class klass) {
         super(origin, null);
 

--- a/voc/python/ast.py
+++ b/voc/python/ast.py
@@ -1695,9 +1695,6 @@ class Visitor(ast.NodeVisitor):
 
         yield_point = len(self.context.yield_points) + 1
         self.context.add_opcodes(
-            # Convert to a new value for return purposes
-            JavaOpcodes.INVOKEINTERFACE('org/python/Object', 'byValue', args=[], returns='Lorg/python/Object;'),
-
             # Save the current stack and yield index
             ALOAD_name('<generator>'),
             ALOAD_name('#locals'),
@@ -1769,10 +1766,6 @@ class Visitor(ast.NodeVisitor):
             # obtained from iterator onto stack, hence no need to visit node.value here
             if node.value:
                 self.visit(node.value)
-                self.context.add_opcodes(
-                    # Convert to a new value for return purposes
-                    JavaOpcodes.INVOKEINTERFACE('org/python/Object', 'byValue', args=[], returns='Lorg/python/Object;')
-                )
             else:
                 # push NoneType object to stack to support single yield statement (without operand)
                 # as the statment `yield` is equivalent to `yield None`
@@ -1783,12 +1776,7 @@ class Visitor(ast.NodeVisitor):
                         'Lorg/python/Object;'
                     )
                 )
-        else:
-            # value is already pushed on stack, hence only need to convert to org.python.Object
-            self.context.add_opcodes(
-                JavaOpcodes.INVOKEINTERFACE('org/python/Object', 'byValue', args=[], returns='Lorg/python/Object;')
-            )
-
+                
         yield_point = len(self.context.yield_points) + 1
 
         # Save the current stack and yield index


### PR DESCRIPTION
This is a cleanup of methods in various immutable object classes that call `new` on themselves. That seems unnecessary since they are immutable. 

Changes: 

1. Removed `org.python.Object.byValue()`, which was being used in yield statements (removed those too). 
2. Removed `setValue()`, which was being used internally in `Super.java` and `Str.java` (inconsistently). Removed those usages too. 
3. Replaced statements in immutable datatypes (`Str`, `Int`, etc) like `return new org.python.types.X(this.value)` with `return this` to prevent creating the same object multiple times. 