### PR TITLE
Implements time.monotonic()

### DIFF
--- a/python/common/org/python/stdlib/time/Namespace.java
+++ b/python/common/org/python/stdlib/time/Namespace.java
@@ -1,0 +1,40 @@
+package org.python.stdlib.time;
+
+/**
+ * Data structure for the return value of time.get_clock_info
+ */
+public class Namespace extends org.python.types.Object {
+    @org.python.Attribute
+    public org.python.types.Bool adjustable;
+    @org.python.Attribute
+    public org.python.types.Str implementation;
+    @org.python.Attribute
+    public org.python.types.Bool monotonic;
+    @org.python.Attribute
+    public org.python.types.Float resolution;
+
+    public Namespace(boolean adjustable, String implementation, boolean monotonic, double resolution) {
+        this.adjustable = org.python.types.Bool.getBool(adjustable);
+        this.implementation = new org.python.types.Str(implementation);
+        this.monotonic = org.python.types.Bool.getBool(monotonic);
+        this.resolution = new org.python.types.Float(resolution);
+    }
+
+    @org.python.Method(
+            __doc__ = "Return repr(self)."
+    )
+    public org.python.types.Str __repr__() {
+        java.lang.StringBuilder buffer = new java.lang.StringBuilder("namespace(");
+        buffer.append("adjustable=");
+        buffer.append(this.adjustable.__repr__());
+        buffer.append(", implementation=");
+        buffer.append(this.implementation.__repr__());
+        buffer.append(", monotonic=");
+        buffer.append(this.monotonic.__repr__());
+        buffer.append(", resolution=");
+        buffer.append(this.resolution.__repr__());
+        buffer.append(")");
+
+        return new org.python.types.Str(buffer.toString());
+    }
+}

--- a/python/common/python/time.java
+++ b/python/common/python/time.java
@@ -137,7 +137,10 @@ public class time extends org.python.types.Module {
             // TODO: complete this when more clock types are implemented
             throw new org.python.exceptions.ValueError("unknown clock");
         } catch (java.lang.ClassCastException e) {
-            throw new org.python.exceptions.TypeError("get_clock_info() argument 1 must be str, not int");
+            if (org.Python.VERSION < 0x03050000) {
+                throw new org.python.exceptions.TypeError("must be str, not " + name.typeName());
+            }
+            throw new org.python.exceptions.TypeError("get_clock_info() argument 1 must be str, not " + name.typeName());
         }
 
     }

--- a/tests/stdlib/test_time.py
+++ b/tests/stdlib/test_time.py
@@ -146,11 +146,34 @@ class TimeModuleTests(TranspileTestCase):
 
     #######################################################
     # get_clock_info
+    def test_get_clock_info_monotonic(self):
+        self.assertCodeExecution("""
+            import time
+
+            mono_info = time.get_clock_info('monotonic')
+            print(mono_info.adjustable)
+            # monotonic clock is implemented using System.nanoTime() in Java
+            # print(mono_info.implementation)
+            print(mono_info.monotonic)
+            # java implementation has much higher resolution due to
+            # JVM's high-resolution time source
+            # print(mono_info.resolution)
+
+            try:
+                time.get_clock_info(123)
+            except TypeError as e:
+                print(e)
+            """)
+
     @expectedFailure
     def test_get_clock_info(self):
         self.assertCodeExecution("""
             import time
-            print(time.get_clock_info())
+
+            print(time.get_clock_info('clock'))
+            print(time.get_clock_info('perf_counter'))
+            print(time.get_clock_info('process_time'))
+            print(time.get_clock_info('time'))
             """)
 
     #######################################################
@@ -182,11 +205,21 @@ class TimeModuleTests(TranspileTestCase):
 
     #######################################################
     # monotonic
-    @expectedFailure
     def test_monotonic(self):
+        # test to make sure that time elapsed between two consecutive
+        # monotonic clockticks is within the range of
+        # [monotonic resolution - ε, monotonic resolution + ε], where ε = 0.001
         self.assertCodeExecution("""
             import time
-            print(time.monotonic())
+
+            now = time.monotonic()
+            prev = now
+            while now == prev:
+                now = time.monotonic()
+
+            diff = now-prev
+            delta = abs(diff- time.get_clock_info('monotonic').resolution)
+            print(delta < 0.001)
             """)
 
     #######################################################


### PR DESCRIPTION
This PR added java implementation of `time.monotonic()` based on `java.lang.System.nanoTime()`. 

Note: 
- `java.lang.System.nanoTime()` has much higher resolution than CPython's monotonic clock implementation (0.001 seconds compared to 0.015625 seconds on my Windows 10 machine). I'm guessing it has something to do with JVM's own high-resolution time source.
- `time.monotonic()` and `time.get_clock_info('monotonic')` are the only two functions from `time` module that `asyncio` module depends on.