### PR TITLE
Implements types.SimpleNamespace

### DIFF
--- a/python/common/org/python/types/SimpleNamespace.java
+++ b/python/common/org/python/types/SimpleNamespace.java
@@ -1,0 +1,52 @@
+package org.python.types;
+
+public class SimpleNamespace extends org.python.types.Object {
+    @org.python.Method(
+            __doc__ = "A simple attribute-based namespace.\n" +
+                "\n" +
+                "SimpleNamespace(**kwargs)"
+    )
+    public SimpleNamespace(org.python.Object[] args, java.util.Map<java.lang.String, org.python.Object> kwargs) {
+        if (args.length > 0) {
+            throw new org.python.exceptions.TypeError("no positional arguments expected");
+        }
+
+        for (java.util.Map.Entry<java.lang.String, org.python.Object> entry : kwargs.entrySet()) {
+            this.__setattr__(entry.getKey(), entry.getValue());
+        }
+    }
+
+    @org.python.Method(
+            __doc__ = "Return repr(self)."
+    )
+    public org.python.types.Str __repr__() {
+        java.lang.StringBuilder buffer = new java.lang.StringBuilder("namespace(");
+        java.lang.Object[] sorted_keys = this.__dict__.keySet().toArray();
+        java.util.Arrays.sort(sorted_keys);
+        boolean first = true;
+        for (java.lang.Object key : sorted_keys) {
+            if (!first) {
+                buffer.append(", ");
+            }
+            first = false;
+            buffer.append(key);
+            buffer.append("=");
+            buffer.append(this.__dict__.get((java.lang.String) key).__repr__());
+        }
+        buffer.append(")");
+
+        return new org.python.types.Str(buffer.toString());
+    }
+
+    @org.python.Method(
+            __doc__ = "Return self==value.",
+            args = {"other"}
+    )
+    public org.python.Object __eq__(org.python.Object other) {
+        if (this.__dict__.equals(((org.python.types.Object) other).__dict__)) {
+            return org.python.types.Bool.TRUE;
+        } else {
+            return org.python.types.NotImplementedType.NOT_IMPLEMENTED;
+        }
+    }
+}

--- a/python/common/python/types.java
+++ b/python/common/python/types.java
@@ -18,7 +18,7 @@ public class types extends org.python.types.Module {
         // MemberDescriptorType = org.python.types.Type.pythonType(org.python.types.MemberDescriptor.class);
         MethodType = org.python.types.Type.pythonType(org.python.types.Method.class);
         ModuleType = org.python.types.Type.pythonType(org.python.types.Module.class);
-        // SimpleNamespace = org.python.types.Type.pythonType(org.python.types.SimpleNames.class);
+        SimpleNamespace = org.python.types.Type.pythonType(org.python.types.SimpleNamespace.class);
         // TracebackType = org.python.types.Type.pythonType(org.python.types.Traceback.class);
     }
 
@@ -58,8 +58,8 @@ public class types extends org.python.types.Module {
     @org.python.Attribute
     public static org.python.Object ModuleType;
 
-    // @org.python.Attribute
-    // public static org.python.Object SimpleNamespace;
+    @org.python.Attribute
+    public static org.python.Object SimpleNamespace;
 
     // @org.python.Attribute
     // public static org.python.Object TracebackType;

--- a/tests/structures/test_SimpleNamespace.py
+++ b/tests/structures/test_SimpleNamespace.py
@@ -1,0 +1,29 @@
+from ..utils import TranspileTestCase
+
+
+class SimpleNamespaceTests(TranspileTestCase):
+    def test_creation(self):
+        self.assertCodeExecution("""
+            import types
+
+            s = types.SimpleNamespace(a=1, b=2)
+            print(s)
+
+            try:
+                s = types.SimpleNamespace(1, b=2)
+                print("should not print this")
+            except TypeError as e:
+                print(e)
+            """)
+
+    def test_eq(self):
+        self.assertCodeExecution("""
+            import types
+
+            s1 = types.SimpleNamespace(a=1, b=2)
+            s2 = types.SimpleNamespace(b=2, a=1)
+            print(s1 == s2)
+
+            s3 = types.SimpleNamespace(b=2, a=1, c=3)
+            print(s1 == s3)
+            """)

--- a/tests/structures/test_SimpleNamespace.py
+++ b/tests/structures/test_SimpleNamespace.py
@@ -8,6 +8,8 @@ class SimpleNamespaceTests(TranspileTestCase):
 
             s = types.SimpleNamespace(a=1, b=2)
             print(s)
+            print(s.a)
+            print(s.b)
 
             try:
                 s = types.SimpleNamespace(1, b=2)


### PR DESCRIPTION
I realized the namespace object returned from `time.get_clock_info()` was actually an instance of `types.SimpleNamespace`. So I created this separate PR to implement it. 

Once this is merged, I shall refactored the namaspace implementation in #915 