### PR TITLE
Making sets work with complex elements

### DIFF
--- a/python/common/org/python/types/Complex.java
+++ b/python/common/org/python/types/Complex.java
@@ -19,7 +19,10 @@ public class Complex extends org.python.types.Object {
     }
 
     public int hashCode() {
-        return this.hashCode();
+        java.util.ArrayList<org.python.types.Float> pair = new java.util.ArrayList<org.python.types.Float>();
+        pair.add(real);
+        pair.add(imag);
+        return pair.hashCode();
     }
 
     public Complex(org.python.types.Float real_val, org.python.types.Float imag_val) {

--- a/tests/datatypes/test_set.py
+++ b/tests/datatypes/test_set.py
@@ -4,7 +4,6 @@ from .. utils import TranspileTestCase, UnaryOperationTestCase, BinaryOperationT
 
 
 class SetTests(TranspileTestCase):
-    @expectedFailure
     def test_complex_element(self):
         self.assertCodeExecution("""
             x = {1j, 2j}


### PR DESCRIPTION
### Changes
Changed the definition of the function `Complex.hashCode()` to just create an *ArrayList*, add the real and imaginary parts to it, and then get the value returned by calling the hashing function on the ArrayList.

### Fixing tests
One unexpected success in testing in **test_complex_element** (Trying #36). 
```
test_complex_element (tests.datatypes.test_set.SetTests) ... unexpected success
```