### PR TITLE
updating the command for checking python3 version

### DIFF
--- a/docs/background/install.rst
+++ b/docs/background/install.rst
@@ -13,7 +13,7 @@ To check if you have Python installed, run ``python --version`` at the command l
 
 .. code-block:: bash
 
-    $ python --version
+    $ python3 --version
     Python 3.4.4
 
 If you do not have Python 3.4 or newer `install Python <https://www.python.org/downloads/>`_  and check again.

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -31,6 +31,7 @@ So that your directory structure looks like::
 
     tutorial
     ├── env
+    ├── ouroboros
     ├── tutorial0
     └── voc
 


### PR DESCRIPTION
python on most systems will still point to python2, and since python2 and python3 are not interchangeable, for checking the version we should probably type python3 --version and check whether that is installed