### PR TITLE
Mark no-parameter methods static

### DIFF
--- a/tests/structures/test_methods.py
+++ b/tests/structures/test_methods.py
@@ -237,3 +237,31 @@ class MethodTests(TranspileTestCase):
             except AttributeError as err:
                 print(err)
         """, run_in_function=False)
+
+    def test_method_too_few_positional_args(self):
+        self.assertCodeExecution("""
+            class TestObj:
+                def myfunc(self, value):
+                    pass
+
+            obj = TestObj()
+
+            try:
+                obj.myfunc()
+            except TypeError as err:
+                print(err)
+            """)
+
+    def test_method_too_many_positional_args(self):
+        self.assertCodeExecution("""
+            class TestObj:
+                def myfunc(self, value):
+                    pass
+
+            obj = TestObj()
+
+            try:
+                obj.myfunc(1, 2)
+            except TypeError as err:
+                print(err)
+            """)

--- a/tests/structures/test_methods.py
+++ b/tests/structures/test_methods.py
@@ -265,3 +265,18 @@ class MethodTests(TranspileTestCase):
             except TypeError as err:
                 print(err)
             """)
+
+    def test_method_no_self_arg(self):
+        self.assertCodeExecution("""
+            class TestObj:
+                def myfunc():
+                    print(0)
+
+            obj = TestObj()
+            TestObj.myfunc()
+
+            try:
+                obj.myfunc()
+            except TypeError as err:
+                print(err)
+            """)

--- a/voc/python/methods.py
+++ b/voc/python/methods.py
@@ -767,31 +767,35 @@ class Method(Function):
         # object should already exist.
         binding = Accumulator(local_vars if local_vars is not None
                               else self.local_vars)
+        static = False
 
-        binding.add_opcodes(
-            # DEBUG("BINDING FOR " + self.name + self.signature),
-            # DEBUG("BOUND AS " + self.name + self.bound_signature),
-            # JavaOpcodes.ALOAD_0(),
-            # DEBUG_value("BINDING SELF IN"),
+        if len(self.parameters) > 0:
+            binding.add_opcodes(
+                # DEBUG("BINDING FOR " + self.name + self.signature),
+                # DEBUG("BOUND AS " + self.name + self.bound_signature),
+                # JavaOpcodes.ALOAD_0(),
+                # DEBUG_value("BINDING SELF IN"),
 
-            JavaOpcodes.ALOAD_0(),
-            python.Type.to_python(),  # 3
+                JavaOpcodes.ALOAD_0(),
+                python.Type.to_python(),  # 3
 
-            # DEBUG_value("BINDING SELF OUT", dup=True),
-        )
+                # DEBUG_value("BINDING SELF OUT", dup=True),
+            )
 
-        # Then extract each argument, converting to Python types as required.
-        for i, param in enumerate(self.parameters[1:]):
-            if param['annotation'] is None:
-                raise Exception("Parameters can't be void")
-            else:
-                to_python(binding, param['annotation'], param['name'])
+            # Then extract each argument, converting to Python types as required.
+            for i, param in enumerate(self.parameters[1:]):
+                if param['annotation'] is None:
+                    raise Exception("Parameters can't be void")
+                else:
+                    to_python(binding, param['annotation'], param['name'])
+                # binding.add_opcodes(
+                #     DEBUG("INPUT %s TRANSFORMED" % (i)),
+                # )
             # binding.add_opcodes(
-            #     DEBUG("INPUT %s TRANSFORMED" % (i)),
+            #     DEBUG("INPUTS TRANSFORMED"),
             # )
-        # binding.add_opcodes(
-        #     DEBUG("INPUTS TRANSFORMED"),
-        # )
+        else:
+            static = True
 
         # Then call the method, and process the return type.
         binding.add_opcodes(
@@ -809,6 +813,7 @@ class Method(Function):
             JavaMethod(
                 self.java_name,
                 self.bound_signature,
+                static=static,
                 attributes=[
                     JavaCode(
                         max_stack=len(self.parameters) + 5,


### PR DESCRIPTION
Python methods with no parameters are implicitly static. However, in the Java class file, if the method meta-data does not have it explicitly marked as such, DEXing results in the following translation error: "com.android.dx.util.MutabilityException: immutable instance".  This PR explicitly marks no-parameter methods as static.
